### PR TITLE
[test] Add option to access `next` instance even after the process throws

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -161,6 +161,15 @@ const nextDev = async (
   portSource: PortSource,
   directory?: string
 ) => {
+  const isTurbopack = Boolean(
+    options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST
+  )
+  if (isTurbopack) {
+    process.env.TURBOPACK = '1'
+  }
+
+  isTurboSession = isTurbopack
+
   dir = getProjectDir(process.env.NEXT_PRIVATE_DEV_DIR || directory)
 
   // Check if pages dir exists and warn if not
@@ -237,15 +246,6 @@ const nextDev = async (
     isDev: true,
     hostname: host,
   }
-
-  const isTurbopack = Boolean(
-    options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST
-  )
-  if (isTurbopack) {
-    process.env.TURBOPACK = '1'
-  }
-
-  isTurboSession = isTurbopack
 
   const distDir = path.join(dir, config.distDir ?? '.next')
   setGlobal('phase', PHASE_DEVELOPMENT_SERVER)

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -214,6 +214,14 @@ export async function createNext(
     })
   } catch (err) {
     require('console').error('Failed to create next instance', err)
+
+    if (opts.expectToThrow) {
+      require('console').warn(
+        'Test option "expectToThrow" is enabled, returning the existing next instance.'
+      )
+      return nextInstance!
+    }
+
     try {
       await nextInstance?.destroy()
     } catch (_) {}

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -46,6 +46,12 @@ export interface NextInstanceOpts {
   serverReadyPattern?: RegExp
   patchFileDelay?: number
   startServerTimeout?: number
+  /**
+   * Enable when you expect an error to be thrown during the process (e.g. Build Error).
+   * The `next` instance will not be destroyed and will be available to be accessed. This
+   * is useful when you want to access the CLI output.
+   */
+  expectToThrow?: boolean
 }
 
 /**
@@ -88,6 +94,7 @@ export class NextInstance {
   public dirSuffix: string = ''
   public startServerTimeout: number = 10_000 // 10 seconds
   public serverReadyPattern: RegExp = / ✓ Ready in /
+  public expectToThrow: boolean = false
   patchFileDelay: number = 0
 
   constructor(opts: NextInstanceOpts) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82163](https://github.com/vercel/next.js/pull/82163)**