### PR TITLE
[next-dev] Set `TURBOPACK` env before loading config

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -161,6 +161,15 @@ const nextDev = async (
   portSource: PortSource,
   directory?: string
 ) => {
+  const isTurbopack = Boolean(
+    options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST
+  )
+  if (isTurbopack) {
+    process.env.TURBOPACK = '1'
+  }
+
+  isTurboSession = isTurbopack
+
   dir = getProjectDir(process.env.NEXT_PRIVATE_DEV_DIR || directory)
 
   // Check if pages dir exists and warn if not
@@ -237,15 +246,6 @@ const nextDev = async (
     isDev: true,
     hostname: host,
   }
-
-  const isTurbopack = Boolean(
-    options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST
-  )
-  if (isTurbopack) {
-    process.env.TURBOPACK = '1'
-  }
-
-  isTurboSession = isTurbopack
 
   const distDir = path.join(dir, config.distDir ?? '.next')
   setGlobal('phase', PHASE_DEVELOPMENT_SERVER)


### PR DESCRIPTION
### Why?

In `next dev`, `process.env.TURBOPACK` was set after `loadConfig`, which caused the `process.env.TURBOPACK` conditions within the initial `loadConfig` calls to be skipped unexpectedly.

---
🔄 **This is a mirror of [upstream PR #82162](https://github.com/vercel/next.js/pull/82162)**