### PR TITLE
refactor: lowercase app router header values

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -1,19 +1,19 @@
-export const RSC_HEADER = 'RSC' as const
-export const ACTION_HEADER = 'Next-Action' as const
+export const RSC_HEADER = 'rsc' as const
+export const ACTION_HEADER = 'next-action' as const
 // TODO: Instead of sending the full router state, we only need to send the
 // segment path. Saves bytes. Then we could also use this field for segment
 // prefetches, which also need to specify a particular segment.
-export const NEXT_ROUTER_STATE_TREE_HEADER = 'Next-Router-State-Tree' as const
-export const NEXT_ROUTER_PREFETCH_HEADER = 'Next-Router-Prefetch' as const
+export const NEXT_ROUTER_STATE_TREE_HEADER = 'next-router-state-tree' as const
+export const NEXT_ROUTER_PREFETCH_HEADER = 'next-router-prefetch' as const
 // This contains the path to the segment being prefetched.
-// TODO: If we change Next-Router-State-Tree to be a segment path, we can use
-// that instead. Then Next-Router-Prefetch and Next-Router-Segment-Prefetch can
+// TODO: If we change next-router-state-tree to be a segment path, we can use
+// that instead. Then next-router-prefetch and next-router-segment-prefetch can
 // be merged into a single enum.
 export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER =
-  'Next-Router-Segment-Prefetch' as const
-export const NEXT_HMR_REFRESH_HEADER = 'Next-HMR-Refresh' as const
+  'next-router-segment-prefetch' as const
+export const NEXT_HMR_REFRESH_HEADER = 'next-hmr-refresh' as const
 export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
-export const NEXT_URL = 'Next-Url' as const
+export const NEXT_URL = 'next-url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 
 export const FLIGHT_HEADERS = [

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -282,28 +282,23 @@ function parseRequestHeaders(
 
   // dev warmup requests are treated as prefetch RSC requests
   const isPrefetchRequest =
-    isDevWarmupRequest ||
-    headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] !== undefined
+    isDevWarmupRequest || headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined
 
-  const isHmrRefresh =
-    headers[NEXT_HMR_REFRESH_HEADER.toLowerCase()] !== undefined
+  const isHmrRefresh = headers[NEXT_HMR_REFRESH_HEADER] !== undefined
 
   // dev warmup requests are treated as prefetch RSC requests
-  const isRSCRequest =
-    isDevWarmupRequest || headers[RSC_HEADER.toLowerCase()] !== undefined
+  const isRSCRequest = isDevWarmupRequest || headers[RSC_HEADER] !== undefined
 
   const shouldProvideFlightRouterState =
     isRSCRequest && (!isPrefetchRequest || !options.isRoutePPREnabled)
 
   const flightRouterState = shouldProvideFlightRouterState
-    ? parseAndValidateFlightRouterState(
-        headers[NEXT_ROUTER_STATE_TREE_HEADER.toLowerCase()]
-      )
+    ? parseAndValidateFlightRouterState(headers[NEXT_ROUTER_STATE_TREE_HEADER])
     : undefined
 
   // Checks if this is a prefetch of the Route Tree by the Segment Cache
   const isRouteTreePrefetchRequest =
-    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()] === '/_tree'
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === '/_tree'
 
   const csp =
     headers['content-security-policy'] ||
@@ -399,7 +394,7 @@ function NonIndex({
 /**
  * This is used by server actions & client-side navigations to generate RSC data from a client-side request.
  * This function is only called on "dynamic" requests (ie, there wasn't already a static response).
- * It uses request headers (namely `Next-Router-State-Tree`) to determine where to start rendering.
+ * It uses request headers (namely `next-router-state-tree`) to determine where to start rendering.
  */
 async function generateDynamicRSCPayload(
   ctx: AppRenderContext,

--- a/packages/next/src/server/app-render/strip-flight-headers.ts
+++ b/packages/next/src/server/app-render/strip-flight-headers.ts
@@ -9,6 +9,6 @@ import { FLIGHT_HEADERS } from '../../client/components/app-router-headers'
  */
 export function stripFlightHeaders(headers: IncomingHttpHeaders) {
   for (const header of FLIGHT_HEADERS) {
-    delete headers[header.toLowerCase()]
+    delete headers[header]
   }
 }

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -28,7 +28,7 @@ import type { ImplicitTags } from '../lib/implicit-tags'
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
   for (const header of FLIGHT_HEADERS) {
-    cleaned.delete(header.toLowerCase())
+    cleaned.delete(header)
   }
 
   return HeadersAdapter.seal(cleaned)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -614,10 +614,9 @@ export default abstract class Server<
       parsedUrl.pathname = originalPathname
 
       // Mark the request as a router prefetch request.
-      req.headers[RSC_HEADER.toLowerCase()] = '1'
-      req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] = '1'
-      req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()] =
-        segmentPath
+      req.headers[RSC_HEADER] = '1'
+      req.headers[NEXT_ROUTER_PREFETCH_HEADER] = '1'
+      req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] = segmentPath
 
       addRequestMeta(req, 'isRSCRequest', true)
       addRequestMeta(req, 'isPrefetchRSCRequest', true)
@@ -629,8 +628,8 @@ export default abstract class Server<
       )
 
       // Mark the request as a router prefetch request.
-      req.headers[RSC_HEADER.toLowerCase()] = '1'
-      req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] = '1'
+      req.headers[RSC_HEADER] = '1'
+      req.headers[NEXT_ROUTER_PREFETCH_HEADER] = '1'
       addRequestMeta(req, 'isRSCRequest', true)
       addRequestMeta(req, 'isPrefetchRSCRequest', true)
     } else if (this.normalizers.rsc?.match(parsedUrl.pathname)) {
@@ -640,7 +639,7 @@ export default abstract class Server<
       )
 
       // Mark the request as a RSC request.
-      req.headers[RSC_HEADER.toLowerCase()] = '1'
+      req.headers[RSC_HEADER] = '1'
       addRequestMeta(req, 'isRSCRequest', true)
     } else if (req.headers['x-now-route-matches']) {
       // If we didn't match, return with the flight headers stripped. If in
@@ -651,14 +650,14 @@ export default abstract class Server<
       stripFlightHeaders(req.headers)
 
       return false
-    } else if (req.headers[RSC_HEADER.toLowerCase()] === '1') {
+    } else if (req.headers[RSC_HEADER] === '1') {
       addRequestMeta(req, 'isRSCRequest', true)
 
-      if (req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] === '1') {
+      if (req.headers[NEXT_ROUTER_PREFETCH_HEADER] === '1') {
         addRequestMeta(req, 'isPrefetchRSCRequest', true)
 
         const segmentPrefetchRSCRequest =
-          req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()]
+          req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]
         if (typeof segmentPrefetchRSCRequest === 'string') {
           addRequestMeta(
             req,
@@ -1333,7 +1332,7 @@ export default abstract class Server<
                   params
                 )
 
-                req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()] =
+                req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] =
                   segmentPrefetchRSCRequest
                 addRequestMeta(
                   req,
@@ -2017,18 +2016,18 @@ export default abstract class Server<
       const headers = req.headers
 
       const isPrefetchRSCRequest =
-        headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] ||
+        headers[NEXT_ROUTER_PREFETCH_HEADER] ||
         getRequestMeta(req, 'isPrefetchRSCRequest')
 
       const segmentPrefetchRSCRequest =
-        headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()] ||
+        headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] ||
         getRequestMeta(req, 'segmentPrefetchRSCRequest')
 
       const expectedHash = computeCacheBustingSearchParam(
         isPrefetchRSCRequest ? '1' : '0',
         segmentPrefetchRSCRequest,
-        headers[NEXT_ROUTER_STATE_TREE_HEADER.toLowerCase()],
-        headers[NEXT_URL.toLowerCase()]
+        headers[NEXT_ROUTER_STATE_TREE_HEADER],
+        headers[NEXT_URL]
       )
       const actualHash =
         getRequestMeta(req, 'cacheBustingSearchParam') ??

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -743,8 +743,7 @@ export function getResolveRoutes(
             // is currently on, which wouldn't be extractable from the matched route params.
             // This attempts to extract the dynamic params from the provided router state.
             if (isInterceptionRouteRewrite(route as Rewrite)) {
-              const stateHeader =
-                req.headers[NEXT_ROUTER_STATE_TREE_HEADER.toLowerCase()]
+              const stateHeader = req.headers[NEXT_ROUTER_STATE_TREE_HEADER]
 
               if (stateHeader) {
                 rewriteParams = {
@@ -776,7 +775,7 @@ export function getResolveRoutes(
           }
 
           // Set the rewrite headers only if this is a RSC request.
-          if (req.headers[RSC_HEADER.toLowerCase()] === '1') {
+          if (req.headers[RSC_HEADER] === '1') {
             // We set the rewritten path and query headers on the response now
             // that we know that the it's not an external rewrite.
             if (parsedUrl.pathname !== parsedDestination.pathname) {

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -16,10 +16,10 @@ export function getServerActionRequestMetadata(
   let contentType: string | null
 
   if (req.headers instanceof Headers) {
-    actionId = req.headers.get(ACTION_HEADER.toLowerCase()) ?? null
+    actionId = req.headers.get(ACTION_HEADER) ?? null
     contentType = req.headers.get('content-type')
   } else {
-    actionId = (req.headers[ACTION_HEADER.toLowerCase()] as string) ?? null
+    actionId = (req.headers[ACTION_HEADER] as string) ?? null
     contentType = req.headers['content-type'] ?? null
   }
 

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -268,8 +268,7 @@ export function getServerUtils({
           // is currently on, which wouldn't be extractable from the matched route params.
           // This attempts to extract the dynamic params from the provided router state.
           if (isInterceptionRouteRewrite(rewrite as Rewrite)) {
-            const stateHeader =
-              req.headers[NEXT_ROUTER_STATE_TREE_HEADER.toLowerCase()]
+            const stateHeader = req.headers[NEXT_ROUTER_STATE_TREE_HEADER]
 
             if (stateHeader) {
               params = {

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -154,11 +154,10 @@ export async function adapter(
   // Headers should only be stripped for middleware
   if (!isEdgeRendering) {
     for (const header of FLIGHT_HEADERS) {
-      const key = header.toLowerCase()
-      const value = requestHeaders.get(key)
+      const value = requestHeaders.get(header)
       if (value !== null) {
-        flightHeaders.set(key, value)
-        requestHeaders.delete(key)
+        flightHeaders.set(header, value)
+        requestHeaders.delete(header)
       }
     }
   }

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -78,9 +78,9 @@ describe('app dir - basepath', () => {
           page.on('request', (request) => {
             return request.allHeaders().then((headers) => {
               if (
-                headers['RSC'.toLowerCase()] === '1' &&
-                // Prefetches also include `RSC`
-                headers['Next-Router-Prefetch'.toLowerCase()] !== '1'
+                headers['rsc'] === '1' &&
+                // Prefetches also include `rsc`
+                headers['next-router-prefetch'] !== '1'
               ) {
                 rscRequests.push(request.url())
               }

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -262,10 +262,10 @@ describe('app dir - prefetching', () => {
     )
     const response = await next.fetch(`/prefetch-auto/justputit?_rsc=dcqtr`, {
       headers: {
-        RSC: '1',
-        'Next-Router-Prefetch': '1',
-        'Next-Router-State-Tree': stateTree,
-        'Next-Url': '/prefetch-auto/justputit',
+        rsc: '1',
+        'next-router-prefetch': '1',
+        'next-router-state-tree': stateTree,
+        'next-url': '/prefetch-auto/justputit',
       },
     })
 
@@ -297,18 +297,18 @@ describe('app dir - prefetching', () => {
     )
 
     const headers = {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
-      'Next-Router-State-Tree': stateTree,
-      'Next-Url': '/prefetch-auto/vercel',
+      rsc: '1',
+      'next-router-prefetch': '1',
+      'next-router-state-tree': stateTree,
+      'next-url': '/prefetch-auto/vercel',
     }
 
     const url = new URL('/prefetch-auto/justputit', 'http://localhost')
     const cacheBustingParam = computeCacheBustingSearchParam(
-      headers['Next-Router-Prefetch'] ? '1' : '0',
+      headers['next-router-prefetch'] ? '1' : '0',
       undefined,
-      headers['Next-Router-State-Tree'],
-      headers['Next-Url']
+      headers['next-router-state-tree'],
+      headers['next-url']
     )
     if (cacheBustingParam) {
       url.searchParams.set('_rsc', cacheBustingParam)

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -975,7 +975,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/index.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -999,7 +999,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": null,
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1027,7 +1027,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/articles/works.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1052,7 +1052,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/seb.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1077,7 +1077,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/seb/second-post.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1101,7 +1101,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/styfle.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1126,7 +1126,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/styfle/first-post.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1150,7 +1150,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/styfle/second-post.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1174,7 +1174,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/tim.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1199,7 +1199,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/blog/tim/first-post.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1223,7 +1223,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/default-config-fetch.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1247,7 +1247,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/force-cache.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1272,7 +1272,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/force-static-fetch-no-store.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1296,7 +1296,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/force-static/first.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1320,7 +1320,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/force-static/second.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1344,7 +1344,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/gen-params-catch-all-unique/foo/bar.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1368,7 +1368,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/gen-params-catch-all-unique/foo/foo.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1392,7 +1392,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/gen-params-dynamic-revalidate/one.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1417,7 +1417,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/hooks/use-pathname/slug.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1441,7 +1441,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/hooks/use-search-params/force-static.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1465,7 +1465,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/hooks/use-search-params/with-suspense.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1489,7 +1489,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/isr-error-handling.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1514,7 +1514,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/no-config-fetch.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1538,7 +1538,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/no-store/static.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1562,7 +1562,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-lang/en/RAND.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1586,7 +1586,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-lang/en/first.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1610,7 +1610,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-lang/en/second.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1634,7 +1634,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-lang/fr/RAND.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1658,7 +1658,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-lang/fr/first.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1682,7 +1682,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-lang/fr/second.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1706,7 +1706,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-slug/en/RAND.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1730,7 +1730,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-slug/en/first.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1754,7 +1754,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-slug/en/second.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1778,7 +1778,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-slug/fr/RAND.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1802,7 +1802,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-slug/fr/first.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1826,7 +1826,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-gen-params-no-additional-slug/fr/second.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1850,7 +1850,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-params-false/en/static.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1874,7 +1874,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/partial-params-false/fr/static.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1898,7 +1898,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/prerendered-not-found/first.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1922,7 +1922,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/prerendered-not-found/second.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1946,7 +1946,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/prerendered-not-found/segment-revalidate.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -1971,7 +1971,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": null,
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2000,7 +2000,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": null,
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2029,7 +2029,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": null,
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2057,7 +2057,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/ssg-draft-mode.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2081,7 +2081,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/ssg-draft-mode/test.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2105,7 +2105,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/ssg-draft-mode/test-2.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2129,7 +2129,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/strip-w3c-trace-context-headers.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2154,7 +2154,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/unstable-cache/fetch/no-cache.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2178,7 +2178,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/unstable-cache/fetch/no-store.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2202,7 +2202,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-config-revalidate/revalidate-3.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2227,7 +2227,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate-stable/revalidate-3.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2252,7 +2252,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate/authorization.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2277,7 +2277,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate/cookie.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2302,7 +2302,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate/encoding.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2327,7 +2327,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate/headers-instance.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2352,7 +2352,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate/revalidate-3.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2377,7 +2377,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRoute": "/variable-revalidate/revalidate-360-isr.rsc",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2407,7 +2407,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/articles\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2432,7 +2432,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/blog\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2457,7 +2457,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2482,7 +2482,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/dynamic\\-error\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2507,7 +2507,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/force\\-static\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2532,7 +2532,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/gen\\-params\\-catch\\-all\\-unique\\/(.+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2557,7 +2557,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2582,7 +2582,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/hooks\\/use\\-pathname\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2607,7 +2607,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-lang\\/([^\\/]+?)\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2632,7 +2632,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-slug\\/([^\\/]+?)\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2657,7 +2657,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/partial\\-params\\-false\\/([^\\/]+?)\\/static\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2682,7 +2682,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/prerendered\\-not\\-found\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2707,7 +2707,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/ssg\\-draft\\-mode(?:\\/(.+?))?\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {
@@ -2732,7 +2732,7 @@ describe('app-dir static/dynamic handling', () => {
            "dataRouteRegex": "^\\/static\\-to\\-dynamic\\-error\\-forced\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
              {
-               "key": "Next-Action",
+               "key": "next-action",
                "type": "header",
              },
              {

--- a/test/e2e/app-dir/app-validation/validation.test.ts
+++ b/test/e2e/app-dir/app-validation/validation.test.ts
@@ -16,13 +16,13 @@ describe('app dir - validation', () => {
     const stateTree2 = JSON.stringify(['', {}])
 
     const headers1 = {
-      RSC: '1',
-      'Next-Router-State-Tree': stateTree1,
+      rsc: '1',
+      'next-router-state-tree': stateTree1,
     }
 
     const headers2 = {
-      RSC: '1',
-      'Next-Router-State-Tree': stateTree2,
+      rsc: '1',
+      'next-router-state-tree': stateTree2,
     }
 
     const url1 = new URL('/', 'http://localhost')

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -334,7 +334,7 @@ describe('app dir - basic', () => {
     const res = await next.fetch('/dashboard')
     expect(res.headers.get('x-edge-runtime')).toBe('1')
     expect(res.headers.get('vary')).toBe(
-      'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch'
+      'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch'
     )
   })
 
@@ -346,8 +346,8 @@ describe('app dir - basic', () => {
     })
     expect(res.headers.get('vary')).toBe(
       isNextDeploy
-        ? 'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch'
-        : 'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding'
+        ? 'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch'
+        : 'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding'
     )
   })
 

--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -41,8 +41,8 @@ export async function middleware(request) {
       ? 'rewrite'
       : 'redirect'
 
-    const internal = ['RSC', 'Next-Router-State-Tree']
-    if (internal.some((name) => request.headers.has(name.toLowerCase()))) {
+    const internal = ['rsc', 'next-router-state-tree']
+    if (internal.some((name) => request.headers.has(name))) {
       return NextResponse[method](new URL('/internal/failure', request.url))
     }
 

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -52,10 +52,10 @@ const addCacheBustingSearchParam = (
   headers: Record<string, string | string[] | undefined>
 ) => {
   const cacheKey = computeCacheBustingSearchParam(
-    headers['Next-Router-Prefetch'] ? '1' : '0',
-    headers['Next-Router-Segment-Prefetch'],
-    headers['Next-Router-State-Tree'],
-    headers['Next-URL']
+    headers['next-router-prefetch'] ? '1' : '0',
+    headers['next-router-segment-prefetch'],
+    headers['next-router-state-tree'],
+    headers['next-url']
   )
 
   if (cacheKey === null) {
@@ -535,8 +535,8 @@ describe('ppr-full', () => {
         it('should have correct headers', async () => {
           await retry(async () => {
             const headers = {
-              RSC: '1',
-              'Next-Router-Prefetch': '1',
+              rsc: '1',
+              'next-router-prefetch': '1',
             }
             const urlWithCacheBusting = addCacheBustingSearchParam(
               pathname,
@@ -573,8 +573,8 @@ describe('ppr-full', () => {
         it('should not contain dynamic content', async () => {
           const unexpected = `${Date.now()}:${Math.random()}`
           const headers = {
-            RSC: '1',
-            'Next-Router-Prefetch': '1',
+            rsc: '1',
+            'next-router-prefetch': '1',
             'X-Test-Input': unexpected,
           }
           const urlWithCacheBusting = addCacheBustingSearchParam(
@@ -596,7 +596,7 @@ describe('ppr-full', () => {
     describe('Dynamic RSC Response', () => {
       describe.each(pages)('for $pathname', ({ pathname, dynamic }) => {
         it('should have correct headers', async () => {
-          const headers = { RSC: '1' }
+          const headers = { rsc: '1' }
           const urlWithCacheBusting = addCacheBustingSearchParam(
             pathname,
             headers
@@ -621,7 +621,7 @@ describe('ppr-full', () => {
           it('should contain dynamic content', async () => {
             const expected = `${Date.now()}:${Math.random()}`
             const headers = {
-              RSC: '1',
+              rsc: '1',
               'X-Test-Input': expected,
             }
             const urlWithCacheBusting = addCacheBustingSearchParam(
@@ -641,7 +641,7 @@ describe('ppr-full', () => {
           it('should not contain dynamic content', async () => {
             const unexpected = `${Date.now()}:${Math.random()}`
             const headers = {
-              RSC: '1',
+              rsc: '1',
               'X-Test-Input': unexpected,
             }
             const urlWithCacheBusting = addCacheBustingSearchParam(

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -25,7 +25,7 @@ const cases: {
     name: 'static RSC',
     pathname: '/',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -36,8 +36,8 @@ const cases: {
     name: 'static Prefetch RSC',
     pathname: '/',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -56,7 +56,7 @@ const cases: {
     name: 'prerendered RSC',
     pathname: '/hello/world',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -67,8 +67,8 @@ const cases: {
     name: 'prerendered Prefetch RSC',
     pathname: '/hello/world',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -87,7 +87,7 @@ const cases: {
     name: 'middleware rewrite RSC',
     pathname: '/hello/wyatt',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/hello/admin',
@@ -98,8 +98,8 @@ const cases: {
     name: 'middleware rewrite Prefetch RSC',
     pathname: '/hello/wyatt',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     // only: true,
     expected: {
@@ -119,7 +119,7 @@ const cases: {
     name: 'middleware rewrite dynamic RSC',
     pathname: '/hello/bob',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/hello/bobby',
@@ -130,8 +130,8 @@ const cases: {
     name: 'middleware rewrite dynamic Prefetch RSC',
     pathname: '/hello/bob',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/hello/bobby',
@@ -150,7 +150,7 @@ const cases: {
     name: 'dynamic RSC',
     pathname: '/hello/mary',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -161,8 +161,8 @@ const cases: {
     name: 'dynamic Prefetch RSC',
     pathname: '/hello/mary',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -181,7 +181,7 @@ const cases: {
     name: 'dynamic RSC with query',
     pathname: '/hello/mary?key=value',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -192,8 +192,8 @@ const cases: {
     name: 'dynamic Prefetch RSC with query',
     pathname: '/hello/mary?key=value',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -212,7 +212,7 @@ const cases: {
     name: 'next.config.js rewrites RSC',
     pathname: '/hello/sam',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/hello/samantha',
@@ -223,8 +223,8 @@ const cases: {
     name: 'next.config.js rewrites Prefetch RSC',
     pathname: '/hello/sam',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/hello/samantha',
@@ -243,7 +243,7 @@ const cases: {
     name: 'next.config.js rewrites static RSC',
     pathname: '/hello/other',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/other',
@@ -254,8 +254,8 @@ const cases: {
     name: 'next.config.js rewrites static Prefetch RSC',
     pathname: '/hello/other',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/other',
@@ -282,7 +282,7 @@ const cases: {
     name: 'middleware rewrite query RSC',
     pathname: '/hello/john',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -293,8 +293,8 @@ const cases: {
     name: 'middleware rewrite query Prefetch RSC',
     pathname: '/hello/john',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': null,
@@ -316,7 +316,7 @@ const cases: {
   //   name: 'middleware rewrite external RSC',
   //   pathname: '/hello/vercel',
   //   headers: {
-  //     RSC: '1',
+  //     rsc: '1',
   //   },
   //   expected: {
   //     // Vercel matches `/` to `/home`
@@ -328,8 +328,8 @@ const cases: {
   //   name: 'middleware rewrite external Prefetch RSC',
   //   pathname: '/hello/vercel',
   //   headers: {
-  //     RSC: '1',
-  //     'Next-Router-Prefetch': '1',
+  //     rsc: '1',
+  //     'next-router-prefetch': '1',
   //   },
   //   expected: {
   //     // Vercel matches `/` to `/home`
@@ -349,7 +349,7 @@ const cases: {
     name: 'next.config.js rewrites with query RSC',
     pathname: '/hello/fred',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/other',
@@ -360,8 +360,8 @@ const cases: {
     name: 'next.config.js rewrites with query Prefetch RSC',
     pathname: '/hello/fred',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/other',
@@ -380,7 +380,7 @@ const cases: {
     name: 'next.config.js rewrites with path-matched query RSC',
     pathname: '/rewrites-to-query/andrew',
     headers: {
-      RSC: '1',
+      rsc: '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/other',
@@ -391,8 +391,8 @@ const cases: {
     name: 'next.config.js rewrites with path-matched query Prefetch RSC',
     pathname: '/rewrites-to-query/andrew',
     headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
+      rsc: '1',
+      'next-router-prefetch': '1',
     },
     expected: {
       'x-nextjs-rewritten-path': '/other',
@@ -416,11 +416,11 @@ describe('rewrite-headers', () => {
         const url = new URL(pathname, 'http://localhost')
 
         // Add cache busting param for RSC requests
-        if (headers.RSC === '1') {
+        if (headers.rsc === '1') {
           const cacheBustingParam = computeCacheBustingSearchParam(
-            headers['Next-Router-Prefetch'] ? '1' : '0',
+            headers['next-router-prefetch'] ? '1' : '0',
             undefined,
-            headers['Next-Router-State-Tree'],
+            headers['next-router-state-tree'],
             undefined
           )
           if (cacheBustingParam) {

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -169,9 +169,9 @@ describe('app dir - rsc basics', () => {
           requestsCount++
           const headers = request.headers()
           if (
-            headers['RSC'.toLowerCase()] === '1' &&
-            // Prefetches also include `RSC`
-            headers['Next-Router-Prefetch'.toLowerCase()] !== '1'
+            headers['rsc'] === '1' &&
+            // Prefetches also include `rsc`
+            headers['next-router-prefetch'] !== '1'
           ) {
             flightRequests.push(request.url())
           }

--- a/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+++ b/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
@@ -26,7 +26,7 @@ describe('rsc-redirect', () => {
       {
         redirect: 'manual',
         headers: {
-          RSC: '1',
+          rsc: '1',
         },
       }
     )

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -83,9 +83,9 @@ describe('segment cache (CDN cache busting)', () => {
         async () => {
           const res = await fetch('/target-page', {
             headers: {
-              RSC: '1',
-              'Next-Router-Prefetch': '1',
-              'Next-Router-Segment-Prefetch': '/_tree',
+              rsc: '1',
+              'next-router-prefetch': '1',
+              'next-router-segment-prefetch': '/_tree',
             },
           })
           return {

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
@@ -25,9 +25,9 @@ describe('conflicting routes', () => {
     fetchUrl.search = searchParams.toString()
     return await next.fetch(fetchUrl.pathname + fetchUrl.search, {
       headers: {
-        RSC: '1',
-        'Next-Router-Prefetch': '1',
-        'Next-Router-Segment-Prefetch': segmentPath,
+        rsc: '1',
+        'next-router-prefetch': '1',
+        'next-router-segment-prefetch': segmentPath,
       },
     })
   }

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -37,8 +37,8 @@ describe('segment cache (incremental opt in)', () => {
             const url = request.url()
             const prefetchInfo = {
               href: new URL(url).pathname,
-              segment: headers['Next-Router-Segment-Prefetch'.toLowerCase()],
-              base: headers['Next-Router-State-Tree'.toLowerCase()] ?? null,
+              segment: headers['next-router-segment-prefetch'],
+              base: headers['next-router-state-tree'] ?? null,
             }
             const key = JSON.stringify(prefetchInfo)
             if (prefetches.has(key)) {

--- a/test/e2e/next-form/default/next-form-prefetch.test.ts
+++ b/test/e2e/next-form/default/next-form-prefetch.test.ts
@@ -28,8 +28,8 @@ _describe('app dir - form prefetching', () => {
       requestFilter: async (request) => {
         // only capture RSC requests that *aren't* prefetches
         const headers = await request.allHeaders()
-        const isRSC = headers[RSC_HEADER.toLowerCase()] === '1'
-        const isPrefetch = !!headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()]
+        const isRSC = headers[RSC_HEADER] === '1'
+        const isPrefetch = !!headers[NEXT_ROUTER_PREFETCH_HEADER]
         return isRSC && !isPrefetch
       },
       log: true,
@@ -74,7 +74,7 @@ _describe('app dir - form prefetching', () => {
       requestFilter: async (request) => {
         // capture all RSC requests, prefetch or not
         const headers = await request.allHeaders()
-        const isRSC = headers[RSC_HEADER.toLowerCase()] === '1'
+        const isRSC = headers[RSC_HEADER] === '1'
         return isRSC
       },
       log: true,

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -108,7 +108,7 @@ describe('Switchable runtime', () => {
           beforePageLoad(page) {
             page.on('request', (request) => {
               return request.allHeaders().then((headers) => {
-                if (headers['RSC'.toLowerCase()] === '1') {
+                if (headers['rsc'] === '1') {
                   flightRequest = request.url()
                 }
               })
@@ -640,7 +640,7 @@ describe('Switchable runtime', () => {
           beforePageLoad(page) {
             page.on('request', (request) => {
               request.allHeaders().then((headers) => {
-                if (headers['RSC'.toLowerCase()] === '1') {
+                if (headers['rsc'] === '1') {
                   flightRequest = request.url()
                 }
               })

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -21,9 +21,9 @@ describe('Vary Header Tests', () => {
     expect(res.headers.get('cache-control')).toBe('s-maxage=3600')
 
     // Next.js internal headers are appended
-    expect(varyHeader).toContain('RSC')
-    expect(varyHeader).toContain('Next-Router-State-Tree')
-    expect(varyHeader).toContain('Next-Router-Prefetch')
+    expect(varyHeader).toContain('rsc')
+    expect(varyHeader).toContain('next-router-state-tree')
+    expect(varyHeader).toContain('next-router-prefetch')
   })
 
   it('should preserve middleware vary header in combination with route handlers', async () => {
@@ -39,8 +39,8 @@ describe('Vary Header Tests', () => {
     expect(varyHeader).toContain('User-Agent')
 
     // Next.js internal headers are still present
-    expect(varyHeader).toContain('RSC')
-    expect(varyHeader).toContain('Next-Router-State-Tree')
-    expect(varyHeader).toContain('Next-Router-Prefetch')
+    expect(varyHeader).toContain('rsc')
+    expect(varyHeader).toContain('next-router-state-tree')
+    expect(varyHeader).toContain('next-router-prefetch')
   })
 })

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2559,14 +2559,14 @@ const runTests = (isDev = false) => {
           },
         ],
         rsc: {
-          header: 'RSC',
+          header: 'rsc',
           contentTypeHeader: 'text/x-component',
           didPostponeHeader: 'x-nextjs-postponed',
           varyHeader:
-            'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch',
-          prefetchHeader: 'Next-Router-Prefetch',
+            'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch',
+          prefetchHeader: 'next-router-prefetch',
           prefetchSegmentDirSuffix: '.segments',
-          prefetchSegmentHeader: 'Next-Router-Segment-Prefetch',
+          prefetchSegmentHeader: 'next-router-segment-prefetch',
           prefetchSegmentSuffix: '.segment.rsc',
           prefetchSuffix: '.prefetch.rsc',
           suffix: '.rsc',

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1518,14 +1518,14 @@ function runTests({ dev }) {
           queryHeader: 'x-nextjs-rewritten-query',
         },
         rsc: {
-          header: 'RSC',
+          header: 'rsc',
           contentTypeHeader: 'text/x-component',
           didPostponeHeader: 'x-nextjs-postponed',
           varyHeader:
-            'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch',
-          prefetchHeader: 'Next-Router-Prefetch',
+            'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch',
+          prefetchHeader: 'next-router-prefetch',
           prefetchSegmentDirSuffix: '.segments',
-          prefetchSegmentHeader: 'Next-Router-Segment-Prefetch',
+          prefetchSegmentHeader: 'next-router-segment-prefetch',
           prefetchSegmentSuffix: '.segment.rsc',
           prefetchSuffix: '.prefetch.rsc',
           suffix: '.rsc',

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -92,7 +92,7 @@ describe('minimal-mode-response-cache', () => {
 
   it('app router revalidate should work with previous response cache dynamic', async () => {
     const headers = {
-      vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+      vary: 'rsc, next-router-state-tree, next-router-prefetch',
       'x-now-route-matches': '1=compare&rsc=1',
       'x-matched-path': '/app-blog/compare.rsc',
       'x-vercel-id': '1',
@@ -122,7 +122,7 @@ describe('minimal-mode-response-cache', () => {
 
   it('app router revalidate should work with previous response cache', async () => {
     const headers = {
-      vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+      vary: 'rsc, next-router-state-tree, next-router-prefetch',
       'x-now-route-matches': '1=app-another&rsc=1',
       'x-matched-path': '/app-another.rsc',
       'x-vercel-id': '1',


### PR DESCRIPTION
we define most of the app router headers with capital letters, like this:
```ts
export const NEXT_ROUTER_PREFETCH_HEADER = 'Next-Router-Prefetch' as const
```
which means we have to keep lowercasing the header everywhere when checking for its presence, because node and other intermediate layers normalize all headers to lowercase:
```ts
if (req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()]) { ... }
```
this seems pretty pointless -- we can just define the headers in lowercase form, and skip all those `toLowerCase()` calls.

(all the above sentences have been normalized to lowercase to match the spirit of this pr)

---
🔄 **This is a mirror of [upstream PR #82169](https://github.com/vercel/next.js/pull/82169)**