### PR TITLE
Strip internals from `NextRequest` types

### DIFF
--- a/packages/next/src/server/web/spec-extension/request.ts
+++ b/packages/next/src/server/web/spec-extension/request.ts
@@ -12,6 +12,7 @@ export const INTERNALS = Symbol('internal request')
  * Read more: [Next.js Docs: `NextRequest`](https://nextjs.org/docs/app/api-reference/functions/next-request)
  */
 export class NextRequest extends Request {
+  /** @internal */
   [INTERNALS]: {
     cookies: RequestCookies
     url: string


### PR DESCRIPTION
`next/server#NextRequest` used to be shipped with an internal field that was only accessible with a unique symbol. This means that `NextRequest` from two different Next.js versions are not assignable in TypeScript even though all other fields match.

This is problematic for monorepos where dependencies have a peer on Next.js but also install their own version for development. 

```
app
| (direct) next@15.1
| (direct) package@workspace
package
| (dev-direct) next@15.0
| (peer) next@15.x
```

If `package` has a method that accepts a `NextRequest`, you would now have to pass a `NextRequest` from `15.0` even though `package` claims it's compatible with 15.x. TypeScript should check that compatibility claim structurally. But we effectively made `NextRequest` nominally type-checked which isn't supported by TypeScript. The branding hacks you'll find in the wild are hacks for a reason. They work in small scopes but not when applied to the NPM ecosystem.

---
🔄 **This is a mirror of [upstream PR #82172](https://github.com/vercel/next.js/pull/82172)**