### PR TITLE
[WAIT TO MERGE] docs: mention turbopack config codemod

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -7,6 +7,10 @@ description: Configure Next.js with Turbopack-specific options
 
 The `turbopack` option lets you customize [Turbopack](/docs/app/api-reference/turbopack) to transform different files and change how modules are resolved.
 
+> **Good to know**: The `turbopack` option was previously named `experimental.turbo` in Next.js versions 13.0.0 to 15.2.x. The `experimental.turbo` option will be removed in Next.js 16.
+>
+> If you are using an older version of Next.js, run `npx @next/codemod@latest next-experimental-turbo-to-turbopack .` to automatically migrate your configuration.
+
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 

--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -129,7 +129,7 @@ export async function runTransform(
   if (verbose) {
     args.push('--verbose=2')
   }
-  args.push('--no-babel')
+  args.push('--parser=tsx')
 
   args.push('--ignore-pattern=**/node_modules/**')
   args.push('--ignore-pattern=**/.next/**')

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -116,4 +116,9 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'app-dir-runtime-config-experimental-edge',
     version: '15.0.0-canary.179',
   },
+  {
+    title: 'Updates `next.config.js` to use the new `turbopack` configuration',
+    value: 'next-experimental-turbo-to-turbopack',
+    version: '10.0.0',
+  },
 ]

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/commonjs-var.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/commonjs-var.input.js
@@ -1,0 +1,22 @@
+// CommonJS configuration with variable declaration first
+const config = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+      memoryLimit: 4096,
+      minify: true,
+      treeShaking: false,
+      sourceMaps: true
+    },
+    serverActions: true,
+    typedRoutes: false
+  },
+  images: {
+    formats: ['image/avif', 'image/webp']
+  }
+};
+
+module.exports = config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/commonjs-var.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/commonjs-var.output.js
@@ -1,0 +1,24 @@
+// CommonJS configuration with variable declaration first
+const config = {
+  experimental: {
+    serverActions: true,
+    typedRoutes: false,
+    turbopackMemoryLimit: 4096,
+    turbopackMinify: true,
+    turbopackTreeShaking: false,
+    turbopackSourceMaps: true
+  },
+
+  images: {
+    formats: ['image/avif', 'image/webp']
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+      mocha: { browser: 'mocha/browser-entry.js' },
+    }
+  }
+};
+
+module.exports = config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/esm.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/esm.input.js
@@ -1,0 +1,19 @@
+export default {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+      memoryLimit: 4096,
+      minify: true,
+      treeShaking: false,
+      sourceMaps: true
+    },
+    serverActions: true,
+    typedRoutes: false,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/esm.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/esm.output.js
@@ -1,0 +1,21 @@
+export default {
+  experimental: {
+    serverActions: true,
+    typedRoutes: false,
+    turbopackMemoryLimit: 4096,
+    turbopackMinify: true,
+    turbopackTreeShaking: false,
+    turbopackSourceMaps: true
+  },
+
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+      mocha: { browser: 'mocha/browser-entry.js' },
+    }
+  }
+};

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/mixed-config.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/mixed-config.input.js
@@ -1,0 +1,23 @@
+module.exports = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+      memoryLimit: 4096,
+      minify: true,
+      treeShaking: false,
+      sourceMaps: true
+    },
+    serverActions: true,
+    typedRoutes: false,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+}
+
+module.exports.turbopack.resolveAlias.chai = {
+  browser: 'chai/chai.js',
+};

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/mixed-config.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/mixed-config.output.js
@@ -1,0 +1,25 @@
+module.exports = {
+  experimental: {
+    serverActions: true,
+    typedRoutes: false,
+    turbopackMemoryLimit: 4096,
+    turbopackMinify: true,
+    turbopackTreeShaking: false,
+    turbopackSourceMaps: true
+  },
+
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+      mocha: { browser: 'mocha/browser-entry.js' },
+    }
+  }
+}
+
+module.exports.turbopack.resolveAlias.chai = {
+  browser: 'chai/chai.js',
+};

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/modified-var.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/modified-var.input.js
@@ -1,0 +1,22 @@
+// CommonJS configuration with variable declaration and modification
+const config = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+      },
+      memoryLimit: 4096,
+    },
+    typedRoutes: true,
+  },
+};
+
+// Add additional configuration before export
+config.images = {
+  formats: ['image/avif', 'image/webp']
+};
+
+// Add more to turbo config
+config.experimental.turbo.sourceMaps = true;
+
+module.exports = config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/modified-var.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/modified-var.output.js
@@ -1,0 +1,23 @@
+// CommonJS configuration with variable declaration and modification
+const config = {
+  experimental: {
+    typedRoutes: true,
+    turbopackMemoryLimit: 4096,
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+    }
+  }
+};
+
+// Add additional configuration before export
+config.images = {
+  formats: ['image/avif', 'image/webp']
+};
+
+// Add more to turbo config
+config.experimental.turbopackSourceMaps = true;
+
+module.exports = config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/no-change.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/no-change.input.js
@@ -1,0 +1,1 @@
+export const x = 3;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/no-change.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/no-change.output.js
@@ -1,0 +1,1 @@
+export const x = 3;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/property-assignment.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/property-assignment.input.js
@@ -1,0 +1,23 @@
+// CommonJS with object property assignment
+const config = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+      }
+    },
+    typedRoutes: true,
+  },
+};
+
+// Add properties to the turbo object
+config.experimental.turbo.resolveAlias.foo = 'bar';
+config.experimental.turbo.minify = true;
+config.experimental.turbo.memoryLimit = 4096;
+
+// Add regular property
+config.images = {
+  formats: ['image/avif', 'image/webp'],
+};
+
+module.exports = config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/property-assignment.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/property-assignment.output.js
@@ -1,0 +1,24 @@
+// CommonJS with object property assignment
+const config = {
+  experimental: {
+    typedRoutes: true
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+    }
+  }
+};
+
+// Add properties to the turbo object
+config.turbopack.resolveAlias.foo = 'bar';
+config.experimental.turbopackMinify = true;
+config.experimental.turbopackMemoryLimit = 4096;
+
+// Add regular property
+config.images = {
+  formats: ['image/avif', 'image/webp'],
+};
+
+module.exports = config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-as-const.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-as-const.input.ts
@@ -1,0 +1,22 @@
+import type { NextConfig } from 'next';
+
+const config = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+      memoryLimit: 4096,
+      minify: true,
+      treeShaking: false,
+      sourceMaps: true,
+    },
+    typedRoutes: true,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+} as const;
+
+export default config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-as-const.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-as-const.output.ts
@@ -1,0 +1,24 @@
+import type { NextConfig } from 'next';
+
+const config = {
+  experimental: {
+    typedRoutes: true,
+    turbopackMemoryLimit: 4096,
+    turbopackMinify: true,
+    turbopackTreeShaking: false,
+    turbopackSourceMaps: true
+  },
+
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+      mocha: { browser: 'mocha/browser-entry.js' },
+    }
+  }
+} as const;
+
+export default config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies-wrapped.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies-wrapped.input.ts
@@ -1,0 +1,22 @@
+import type { NextConfig } from "next";
+
+const nextConfig = {
+  experimental: {
+    mdxRs: true,
+    turbo: {
+      rules: {
+        "*.react.svg": {
+          loaders: ["@svgr/webpack"],
+          as: "*.js",
+        },
+      },
+    },
+  },
+  // Other config properties
+  webpack(config) {
+    return config;
+  },
+} satisfies NextConfig;
+
+const withMDX = require("@next/mdx")();
+export default withMDX(nextConfig);

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies-wrapped.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies-wrapped.output.ts
@@ -1,0 +1,24 @@
+import type { NextConfig } from "next";
+
+const nextConfig = {
+  experimental: {
+    mdxRs: true
+  },
+
+  // Other config properties
+  webpack(config) {
+    return config;
+  },
+
+  turbopack: {
+    rules: {
+      "*.react.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+      },
+    }
+  }
+} satisfies NextConfig;
+
+const withMDX = require("@next/mdx")();
+export default withMDX(nextConfig);

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies.input.ts
@@ -1,0 +1,21 @@
+import type { NextConfig } from "next";
+
+const nextConfig = {
+  experimental: {
+    mdxRs: true,
+    turbo: {
+      rules: {
+        "*.react.svg": {
+          loaders: ["@svgr/webpack"],
+          as: "*.js",
+        },
+      },
+    },
+  },
+  // Other config properties
+  webpack(config) {
+    return config;
+  },
+} satisfies NextConfig;
+
+export default nextConfig;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript-satisfies.output.ts
@@ -1,0 +1,23 @@
+import type { NextConfig } from "next";
+
+const nextConfig = {
+  experimental: {
+    mdxRs: true
+  },
+
+  // Other config properties
+  webpack(config) {
+    return config;
+  },
+
+  turbopack: {
+    rules: {
+      "*.react.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+      },
+    }
+  }
+} satisfies NextConfig;
+
+export default nextConfig;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript.input.ts
@@ -1,0 +1,23 @@
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+      memoryLimit: 4096,
+      minify: true,
+      treeShaking: false,
+      sourceMaps: true,
+    },
+    // Removed serverActions due to TypeScript compatibility
+    typedRoutes: true,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+};
+
+export default config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/typescript.output.ts
@@ -1,0 +1,26 @@
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    // Removed serverActions due to TypeScript compatibility
+    typedRoutes: true,
+
+    turbopackMemoryLimit: 4096,
+    turbopackMinify: true,
+    turbopackTreeShaking: false,
+    turbopackSourceMaps: true
+  },
+
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+      mocha: { browser: 'mocha/browser-entry.js' },
+    }
+  }
+};
+
+export default config;

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/wrapped-function.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/wrapped-function.input.js
@@ -1,0 +1,23 @@
+// Next.js config with wrapper function
+const nextConfig = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+      memoryLimit: 4096,
+      minify: true,
+      treeShaking: false,
+      sourceMaps: true
+    },
+    typedRoutes: true,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+};
+
+// Wrapper function
+const withMDX = require("@next/mdx")();
+module.exports = withMDX(nextConfig);

--- a/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/wrapped-function.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-experimental-turbo-to-turbopack/wrapped-function.output.js
@@ -1,0 +1,25 @@
+// Next.js config with wrapper function
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+    turbopackMemoryLimit: 4096,
+    turbopackMinify: true,
+    turbopackTreeShaking: false,
+    turbopackSourceMaps: true
+  },
+
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  turbopack: {
+    resolveAlias: {
+      underscore: 'lodash',
+      mocha: { browser: 'mocha/browser-entry.js' },
+    }
+  }
+};
+
+// Wrapper function
+const withMDX = require("@next/mdx")();
+module.exports = withMDX(nextConfig);

--- a/packages/next-codemod/transforms/__tests__/next-experimental-turbo-to-turbopack.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-experimental-turbo-to-turbopack.test.js
@@ -1,0 +1,17 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+
+const fixtureDir = 'next-experimental-turbo-to-turbopack'
+
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/commonjs-var`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/esm`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/mixed-config`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/modified-var`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/wrapped-function`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/no-change`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/property-assignment`, { parser: 'js' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/typescript-as-const`, { parser: 'ts' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/typescript`, { parser: 'ts' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/typescript-satisfies`, { parser: 'ts' })
+defineTest(__dirname, fixtureDir, null, `${fixtureDir}/typescript-satisfies-wrapped`, { parser: 'ts' })

--- a/packages/next-codemod/transforms/lib/utils.ts
+++ b/packages/next-codemod/transforms/lib/utils.ts
@@ -1,0 +1,12 @@
+import type { FileInfo } from 'jscodeshift'
+import path from 'node:path'
+
+export function isNextConfigFile(file: FileInfo): boolean {
+  const parsed = path.parse(file.path || '/')
+  return (
+    parsed.base === 'next.config.js' ||
+    parsed.base === 'next.config.ts' ||
+    parsed.base === 'next.config.mjs' ||
+    parsed.base === 'next.config.cjs'
+  )
+}

--- a/packages/next-codemod/transforms/next-experimental-turbo-to-turbopack.ts
+++ b/packages/next-codemod/transforms/next-experimental-turbo-to-turbopack.ts
@@ -1,0 +1,314 @@
+/*
+ * This codemod transforms the experimental turbo configuration in Next.js config to
+ * the new top-level `turbopack` configuration.
+ *
+ * It moves most properties from experimental.turbo to the top-level turbopack
+ * property, with special handling for certain properties like memoryLimit, minify,
+ * treeShaking, and sourceMaps which become experimental.turbopack* properties instead.
+ */
+
+import type {
+  API as JSCodeShiftAPI,
+  Options as JSCodeShiftOptions,
+  FileInfo,
+  ObjectExpression,
+  Property,
+  ObjectProperty,
+  SpreadElement,
+  SpreadProperty,
+  ObjectMethod,
+} from 'jscodeshift'
+import { createParserFromPath } from '../lib/parser'
+import { isNextConfigFile } from './lib/utils'
+
+// Properties that need to be moved to experimental.turbopack*
+const RENAMED_EXPERIMENTAL_PROPERTIES = {
+  memoryLimit: 'turbopackMemoryLimit',
+  minify: 'turbopackMinify',
+  treeShaking: 'turbopackTreeShaking',
+  sourceMaps: 'turbopackSourceMaps',
+}
+
+export default function transformer(
+  file: FileInfo,
+  _api: JSCodeShiftAPI,
+  options: JSCodeShiftOptions
+): string {
+  const j = createParserFromPath(file.path)
+  const root = j(file.source)
+  let hasChanges = false
+
+  if (
+    !isNextConfigFile(file) &&
+    process.env.NODE_ENV !== 'test' // fixtures have unique basenames in test
+  ) {
+    return file.source
+  }
+
+  // Process a config object once we find it
+  function processConfigObject(configObj: ObjectExpression): boolean {
+    // Check for `experimental` property in the config
+    const experimentalProp = configObj.properties.find(
+      (prop) =>
+        isStaticProperty(prop) &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'experimental'
+    )
+
+    if (!experimentalProp || !isStaticProperty(experimentalProp)) {
+      return false
+    }
+
+    const experimentalObj = experimentalProp.value
+    if (experimentalObj.type !== 'ObjectExpression') {
+      return false
+    }
+
+    // Check for `experimental.turbo` property in the config
+    const turboProp = experimentalObj.properties.find(
+      (prop) =>
+        isStaticProperty(prop) &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'turbo'
+    )
+
+    if (!turboProp || !isStaticProperty(turboProp)) {
+      return false
+    }
+
+    const turboObj = turboProp.value
+    if (turboObj.type !== 'ObjectExpression') {
+      return false
+    }
+
+    const regularProps = []
+    const specialProps = []
+
+    turboObj.properties.forEach((prop) => {
+      if (
+        isStaticProperty(prop) &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        RENAMED_EXPERIMENTAL_PROPERTIES[prop.key.name]
+      ) {
+        // Create a new property with the renamed key
+        specialProps.push(
+          j.objectProperty(
+            j.identifier(RENAMED_EXPERIMENTAL_PROPERTIES[prop.key.name]),
+            prop.value
+          )
+        )
+      } else {
+        // Keep the property for turbopack
+        regularProps.push(prop)
+      }
+    })
+
+    const existingProps = experimentalObj.properties.filter(
+      (prop) =>
+        !(
+          isStaticProperty(prop) &&
+          prop.key &&
+          prop.key.type === 'Identifier' &&
+          prop.key.name === 'turbo'
+        )
+    )
+
+    experimentalObj.properties = [...existingProps, ...specialProps]
+
+    // If experimental has no properties, remove it
+    if (experimentalObj.properties.length === 0) {
+      configObj.properties = configObj.properties.filter(
+        (prop) =>
+          !(
+            isStaticProperty(prop) &&
+            prop.key &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === 'experimental'
+          )
+      )
+    }
+
+    // Add turbopack property at top level if there are regular props
+    if (regularProps.length > 0) {
+      // Create the turbopack property
+      const turbopackProp = j.objectProperty(
+        j.identifier('turbopack'),
+        j.objectExpression(regularProps)
+      )
+
+      configObj.properties.push(turbopackProp)
+    }
+
+    return true
+  }
+
+  root.find(j.ObjectExpression).forEach((path) => {
+    if (processConfigObject(path.value)) {
+      hasChanges = true
+    }
+  })
+
+  // Transform config.experimental.turbo.X = value to config.turbopack.X = value
+  // or config.experimental.turbopackX = value for special properties
+  root
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'MemberExpression',
+          object: {
+            type: 'MemberExpression',
+            property: { type: 'Identifier', name: 'experimental' },
+          },
+          property: { type: 'Identifier', name: 'turbo' },
+        },
+      },
+    })
+    .forEach((path) => {
+      if (path.node.left.type !== 'MemberExpression') return
+
+      // Get the variable name (e.g., config in config.experimental.turbo.sourceMaps)
+      let varName = null
+      let currentPath = path.node.left.object
+      while (currentPath?.type === 'MemberExpression') {
+        currentPath = currentPath.object
+      }
+      if (currentPath?.type === 'Identifier') {
+        varName = currentPath.name
+      }
+
+      if (!varName) return
+
+      // Get the property name being assigned (e.g., sourceMaps)
+      let propName: string | undefined = undefined
+      if (
+        path.node.left.property &&
+        path.node.left.property.type === 'Identifier'
+      ) {
+        propName = path.node.left.property.name
+      } else {
+        return
+      }
+
+      // For special properties like memoryLimit, minify, etc.
+      if (propName && RENAMED_EXPERIMENTAL_PROPERTIES[propName]) {
+        const newAssignment = j.assignmentExpression(
+          '=',
+          j.memberExpression(
+            j.memberExpression(
+              j.identifier(varName),
+              j.identifier('experimental')
+            ),
+            j.identifier(RENAMED_EXPERIMENTAL_PROPERTIES[propName])
+          ),
+          path.node.right
+        )
+
+        j(path).replaceWith(newAssignment)
+        hasChanges = true
+      } else if (propName) {
+        // Create new assignment: config.turbopack.propName = value
+        const newAssignment = j.assignmentExpression(
+          '=',
+          j.memberExpression(
+            j.memberExpression(
+              j.identifier(varName),
+              j.identifier('turbopack')
+            ),
+            j.identifier(propName)
+          ),
+          path.node.right
+        )
+
+        j(path).replaceWith(newAssignment)
+        hasChanges = true
+      }
+    })
+
+  // For nested property assignments like config.experimental.turbo.resolveAlias.foo = 'bar';
+  root.find(j.AssignmentExpression).forEach((path) => {
+    if (path.node.left.type !== 'MemberExpression') return
+
+    // Build a path to check if this is like `experimental.turbo.resolveAlias.foo`
+    let obj = path.node.left.object
+    let props = []
+
+    // Collect the property chain
+    while (obj && obj.type === 'MemberExpression') {
+      if (obj.property && obj.property.type === 'Identifier') {
+        props.unshift(obj.property.name)
+      }
+      obj = obj.object
+    }
+
+    // Get the root variable name (e.g., 'config')
+    let varName = null
+    if (obj && obj.type === 'Identifier') {
+      varName = obj.name
+    }
+
+    if (!varName) return
+
+    // Check if this matches the pattern: config.experimental.turbo.resolveAlias.foo
+    if (
+      props.length >= 3 &&
+      props[0] === 'experimental' &&
+      props[1] === 'turbo'
+    ) {
+      // Get the final property name, only if it's an Identifier
+      let finalProp: string | undefined = undefined
+      if (
+        path.node.left.property &&
+        path.node.left.property.type === 'Identifier'
+      ) {
+        finalProp = path.node.left.property.name
+      } else {
+        // If not an Identifier, skip this assignment
+        return
+      }
+
+      // The properties after 'turbo'
+      const middleProps = props.slice(2) // e.g. ['resolveAlias']
+
+      // Start building the new left side: config.turbopack
+      let newLeft = j.memberExpression(
+        j.identifier(varName),
+        j.identifier('turbopack')
+      )
+
+      // Add the middle properties
+      for (const prop of middleProps) {
+        newLeft = j.memberExpression(newLeft, j.identifier(prop))
+      }
+
+      // Add the final property
+      newLeft = j.memberExpression(newLeft, j.identifier(finalProp))
+
+      const newAssignment = j.assignmentExpression(
+        '=',
+        newLeft,
+        path.node.right
+      )
+
+      j(path).replaceWith(newAssignment)
+      hasChanges = true
+    }
+  })
+
+  // Only return a string if we changed the AST, otherwise return the original source
+  return hasChanges ? root.toSource(options) : file.source
+}
+
+function isStaticProperty(
+  prop:
+    | Property
+    | ObjectProperty
+    | SpreadElement
+    | SpreadProperty
+    | ObjectMethod
+): prop is Property | ObjectProperty {
+  return prop.type === 'Property' || prop.type === 'ObjectProperty'
+}

--- a/packages/next-codemod/transforms/next-image-experimental.ts
+++ b/packages/next-codemod/transforms/next-image-experimental.ts
@@ -10,6 +10,7 @@ import type {
   Options,
 } from 'jscodeshift'
 import { createParserFromPath } from '../lib/parser'
+import { isNextConfigFile } from './lib/utils'
 
 function findAndReplaceProps(
   j: JSCodeshift,
@@ -262,16 +263,12 @@ export default function transformer(
   const j = createParserFromPath(file.path)
   const root = j(file.source)
 
-  const parsed = parse(file.path || '/')
-  const isConfig =
-    parsed.base === 'next.config.js' ||
-    parsed.base === 'next.config.ts' ||
-    parsed.base === 'next.config.mjs' ||
-    parsed.base === 'next.config.cjs'
+  const isConfig = isNextConfigFile(file)
 
   if (isConfig) {
-    const result = nextConfigTransformer(j, root, parsed.dir)
-    return result.toSource()
+    const fileDir = parse(file.path).dir
+    const result = nextConfigTransformer(j, root, fileDir)
+    return result.toSource(options)
   }
 
   // Before: import Image from "next/legacy/image"

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -438,6 +438,7 @@ export interface ExperimentalConfig {
 
   /**
    * @deprecated Use `config.turbopack` instead.
+   * Run `npx @next/codemod@latest next-experimental-turbo-to-turbopack .` to migrate automatically.
    */
   turbo?: DeprecatedExperimentalTurboOptions
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1480,7 +1480,7 @@ export default async function loadConfig(
 
     if (userConfig.experimental?.turbo) {
       curLog.warn(
-        'The config property `experimental.turbo` is deprecated. Move this setting to `config.turbopack` as Turbopack is now stable.'
+        'The config property `experimental.turbo` is deprecated. Move this setting to `config.turbopack` or run `npx @next/codemod@latest next-experimental-turbo-to-turbopack .`'
       )
 
       // Merge the two configs, preferring values in `config.turbopack`.


### PR DESCRIPTION
This adds a mention to the docs of the codemod to upgrade `experimental.turbo` to the top-level `turbopack` property.

This should be merged soon after the next publish of a stable version of Next.js.

---
🔄 **This is a mirror of [upstream PR #82183](https://github.com/vercel/next.js/pull/82183)**