### PR TITLE
Parse dynamic params on the client

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -764,5 +764,6 @@
   "763": "\\`unstable_rootParams\\` must not be used within a client component. Next.js should be preventing it from being included in client components statically, but did not in this case.",
   "764": "Missing workStore in %s",
   "765": "Route %s used %s inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
-  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route."
+  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.",
+  "767": "An unexpected response was received from the server."
 }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -31,6 +31,7 @@ import {
 } from '../../flight-data-helpers'
 import { getAppBuildId } from '../../app-build-id'
 import { setCacheBustingSearchParam } from './set-cache-busting-search-param'
+import { getRenderedPathname } from '../../route-params'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -235,8 +236,21 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
+    let renderedPathname
+    if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+      // Read the URL from the response object.
+      renderedPathname = getRenderedPathname(res)
+    } else {
+      // Before Segment Cache is enabled, we should not rely on the new
+      // rewrite headers (x-rewritten-path, x-rewritten-query) because that
+      // is a breaking change. Read the URL from the response body.
+      const renderedUrlParts = response.c
+      renderedPathname = new URL(renderedUrlParts.join('/'), 'http://localhost')
+        .pathname
+    }
+
     return {
-      flightData: normalizeFlightData(response.f),
+      flightData: normalizeFlightData(response.f, renderedPathname),
       canonicalUrl: canonicalUrl,
       couldBeIntercepted: interception,
       prerendered: response.S,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -55,6 +55,7 @@ import {
   omitUnusedArgs,
 } from '../../../../shared/lib/server-reference-info'
 import { revalidateEntireCache } from '../../segment-cache'
+import { getRenderedPathname } from '../../../route-params'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -180,9 +181,25 @@ async function fetchServerAction(
       Promise.resolve(res),
       { callServer, findSourceMapURL, temporaryReferences }
     )
+
+    let renderedPathname
+    if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+      // Read the URL from the response object.
+      renderedPathname = getRenderedPathname(res)
+    } else {
+      // Before Segment Cache is enabled, we should not rely on the new
+      // rewrite headers (x-rewritten-path, x-rewritten-query) because that
+      // is a breaking change. Read the URL from the response body.
+      const canonicalUrlParts = response.c
+      renderedPathname = new URL(
+        canonicalUrlParts.join('/'),
+        'http://localhost'
+      ).pathname
+    }
+
     // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
     actionResult = redirectLocation ? undefined : response.a
-    actionFlightData = normalizeFlightData(response.f)
+    actionFlightData = normalizeFlightData(response.f, renderedPathname)
   } else {
     // An external redirect doesn't contain RSC data.
     actionResult = undefined

--- a/packages/next/src/client/components/segment-cache-impl/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache-key.ts
@@ -1,6 +1,3 @@
-import { NEXT_REWRITTEN_QUERY_HEADER } from '../app-router-headers'
-import type { RSCResponse } from '../router-reducer/fetch-server-response'
-
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
 
@@ -31,19 +28,4 @@ export function createCacheKey(
     nextUrl: nextUrl as NormalizedNextUrl | null,
   } as RouteCacheKey
   return cacheKey
-}
-
-export function getRenderedSearch(response: RSCResponse): NormalizedSearch {
-  // If the server performed a rewrite, the search params used to render the
-  // page will be different from the params in the request URL. In this case,
-  // the response will include a header that gives the rewritten search query.
-  const rewrittenQuery = response.headers.get(NEXT_REWRITTEN_QUERY_HEADER)
-  if (rewrittenQuery !== null) {
-    return (
-      rewrittenQuery === '' ? '' : '?' + rewrittenQuery
-    ) as NormalizedSearch
-  }
-  // If the header is not present, there was no rewrite, so we use the search
-  // query of the response URL.
-  return new URL(response.url).search as NormalizedSearch
 }

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../../shared/lib/app-router-context.shared-runtime'
 import type {
   CacheNodeSeedData,
+  DynamicParamTypesShort,
   Segment as FlightRouterStateSegment,
 } from '../../../server/app-render/types'
 import { HasLoadingBoundary } from '../../../server/app-render/types'
@@ -42,7 +43,13 @@ import type {
   NormalizedSearch,
   RouteCacheKey,
 } from './cache-key'
-import { getRenderedSearch } from './cache-key'
+import {
+  doesStaticSegmentAppearInURL,
+  getRenderedPathname,
+  getRenderedSearch,
+  parseDynamicParamFromURLPart,
+  type RouteParam,
+} from '../../route-params'
 import { createTupleMap, type TupleMap, type Prefix } from './tuple-map'
 import { createLRU } from './lru'
 import {
@@ -88,7 +95,10 @@ import { FetchStrategy } from '../segment-cache'
 
 export type RouteTree = {
   key: string
+  // TODO: Remove the `segment` field, now that it can be reconstructed
+  // from `param`.
   segment: FlightRouterStateSegment
+  param: RouteParam | null
   slots: null | {
     [parallelRouteKey: string]: RouteTree
   }
@@ -856,19 +866,69 @@ function rejectSegmentCacheEntry(
   }
 }
 
-function convertRootTreePrefetchToRouteTree(rootTree: RootTreePrefetch) {
-  return convertTreePrefetchToRouteTree(rootTree.tree, ROOT_SEGMENT_KEY)
+function convertRootTreePrefetchToRouteTree(
+  rootTree: RootTreePrefetch,
+  renderedPathname: string
+) {
+  // Remove trailing and leading slashes
+  const pathnameParts = renderedPathname.replace(/^\/|\/$/g, '').split('/')
+  const index = 0
+  return convertTreePrefetchToRouteTree(
+    rootTree.tree,
+    ROOT_SEGMENT_KEY,
+    pathnameParts,
+    index
+  )
 }
 
 function convertTreePrefetchToRouteTree(
   prefetch: TreePrefetch,
-  key: string
+  key: string,
+  pathnameParts: Array<string>,
+  pathnamePartsIndex: number
 ): RouteTree {
   // Converts the route tree sent by the server into the format used by the
   // cache. The cached version of the tree includes additional fields, such as a
   // cache key for each segment. Since this is frequently accessed, we compute
   // it once instead of on every access. This same cache key is also used to
   // request the segment from the server.
+
+  let segment = prefetch.segment
+
+  let doesAppearInURL: boolean
+  let param: RouteParam | null = null
+  if (Array.isArray(segment)) {
+    // This segment is parameterized. Get the param from the pathname.
+    const paramType = segment[2] as DynamicParamTypesShort
+    const paramValue = parseDynamicParamFromURLPart(
+      paramType,
+      pathnameParts,
+      pathnamePartsIndex
+    )
+    param = {
+      name: segment[0],
+      value: paramValue,
+      type: paramType,
+    }
+
+    // Assign a cache key to the segment, based on the param value. In the
+    // pre-Segment Cache implementation, the server computes this and sends it
+    // in the body of the response. In the Segment Cache implementation, the
+    // server sends an empty string and we fill it in here.
+    // TODO: This will land in a follow up PR.
+    // segment[1] = getCacheKeyForDynamicParam(paramValue)
+
+    doesAppearInURL = true
+  } else {
+    doesAppearInURL = doesStaticSegmentAppearInURL(segment)
+  }
+
+  // Only increment the index if the segment appears in the URL. If it's a
+  // "virtual" segment, like a route group, it remains the same.
+  const childPathnamePartsIndex = doesAppearInURL
+    ? pathnamePartsIndex + 1
+    : pathnamePartsIndex
+
   let slots: { [parallelRouteKey: string]: RouteTree } | null = null
   const prefetchSlots = prefetch.slots
   if (prefetchSlots !== null) {
@@ -886,13 +946,17 @@ function convertTreePrefetchToRouteTree(
       )
       slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
         childPrefetch,
-        childKey
+        childKey,
+        pathnameParts,
+        childPathnamePartsIndex
       )
     }
   }
+
   return {
     key,
-    segment: prefetch.segment,
+    segment,
+    param,
     slots,
     isRootLayout: prefetch.isRootLayout,
     // This field is only relevant to dynamic routes. For a PPR/static route,
@@ -940,26 +1004,39 @@ function convertFlightRouterStateToRouteTree(
       slots[parallelRouteKey] = childTree
     }
   }
-
-  // The navigation implementation expects the search params to be included
-  // in the segment. However, in the case of a static response, the search
-  // params are omitted. So the client needs to add them back in when reading
-  // from the Segment Cache.
-  //
-  // For consistency, we'll do this for dynamic responses, too.
-  //
-  // TODO: We should move search params out of FlightRouterState and handle them
-  // entirely on the client, similar to our plan for dynamic params.
   const originalSegment = flightRouterState[0]
-  const segmentWithoutSearchParams =
-    typeof originalSegment === 'string' &&
-    originalSegment.startsWith(PAGE_SEGMENT_KEY)
-      ? PAGE_SEGMENT_KEY
-      : originalSegment
+
+  let segment: FlightRouterStateSegment
+  let param: RouteParam | null = null
+  if (Array.isArray(originalSegment)) {
+    const paramValue = originalSegment[3]
+    param = {
+      name: originalSegment[0],
+      value: paramValue === undefined ? null : paramValue,
+      type: originalSegment[2] as DynamicParamTypesShort,
+    }
+    segment = originalSegment
+  } else {
+    // The navigation implementation expects the search params to be included
+    // in the segment. However, in the case of a static response, the search
+    // params are omitted. So the client needs to add them back in when reading
+    // from the Segment Cache.
+    //
+    // For consistency, we'll do this for dynamic responses, too.
+    //
+    // TODO: We should move search params out of FlightRouterState and handle
+    // them entirely on the client, similar to our plan for dynamic params.
+    segment =
+      typeof originalSegment === 'string' &&
+      originalSegment.startsWith(PAGE_SEGMENT_KEY)
+        ? PAGE_SEGMENT_KEY
+        : originalSegment
+  }
 
   return {
     key,
-    segment: segmentWithoutSearchParams,
+    segment,
+    param,
     slots,
     isRootLayout: flightRouterState[4] === true,
     hasLoadingBoundary:
@@ -1144,15 +1221,21 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
-      // Get the search params that were used to render the target page. This may
-      // be different from the search params in the request URL, if the page
+      // Get the params that were used to render the target page. These may
+      // be different from the params in the request URL, if the page
       // was rewritten.
+      const renderedPathname = getRenderedPathname(response)
       const renderedSearch = getRenderedSearch(response)
+
+      const routeTree = convertRootTreePrefetchToRouteTree(
+        serverData,
+        renderedPathname
+      )
 
       const staleTimeMs = serverData.staleTime * 1000
       fulfillRouteCacheEntry(
         entry,
-        convertRootTreePrefetchToRouteTree(serverData),
+        routeTree,
         serverData.head,
         serverData.isHeadPartial,
         Date.now() + staleTimeMs,
@@ -1463,7 +1546,15 @@ function writeDynamicTreeResponseIntoCache(
   canonicalUrl: string,
   routeIsPPREnabled: boolean
 ) {
-  const normalizedFlightDataResult = normalizeFlightData(serverData.f)
+  // Get the URL that was used to render the target page. This may be different
+  // from the URL in the request URL, if the page was rewritten.
+  const renderedSearch = getRenderedSearch(response)
+  const renderedPathname = getRenderedPathname(response)
+
+  const normalizedFlightDataResult = normalizeFlightData(
+    serverData.f,
+    renderedPathname
+  )
   if (
     // A string result means navigating to this route will result in an
     // MPA navigation.
@@ -1496,11 +1587,6 @@ function writeDynamicTreeResponseIntoCache(
   // and the head is completely static.
   const isResponsePartial =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
-
-  // Get the search params that were used to render the target page. This may
-  // be different from the search params in the request URL, if the page
-  // was rewritten.
-  const renderedSearch = getRenderedSearch(response)
 
   const fulfilledEntry = fulfillRouteCacheEntry(
     entry,
@@ -1571,7 +1657,12 @@ function writeDynamicRenderResponseIntoCache(
     }
     return null
   }
-  const flightDatas = normalizeFlightData(serverData.f)
+
+  // Get the URL that was used to render the target page. This may be different
+  // from the URL in the request URL, if the page was rewritten.
+  const renderedPathname = getRenderedPathname(response)
+
+  const flightDatas = normalizeFlightData(serverData.f, renderedPathname)
   if (typeof flightDatas === 'string') {
     // This means navigating to this route will result in an MPA navigation.
     // TODO: We should cache this, too, so that the MPA navigation is immediate.

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -19,6 +19,7 @@
 
 export type { NavigationResult } from './segment-cache-impl/navigation'
 export type { PrefetchTask } from './segment-cache-impl/scheduler'
+export type { NormalizedSearch } from './segment-cache-impl/cache-key'
 
 const notEnabled: any = () => {
   throw new Error(

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -1,5 +1,6 @@
 import type {
   CacheNodeSeedData,
+  DynamicParamTypesShort,
   FlightData,
   FlightDataPath,
   FlightRouterState,
@@ -8,6 +9,10 @@ import type {
 } from '../server/app-render/types'
 import type { HeadData } from '../shared/lib/app-router-context.shared-runtime'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
+import {
+  doesStaticSegmentAppearInURL,
+  parseDynamicParamFromURLPart,
+} from './route-params'
 
 export type NormalizedFlightData = {
   /**
@@ -31,7 +36,8 @@ export type NormalizedFlightData = {
 // we're currently exporting it so we can use it directly. This should be fixed as part of the unification of
 // the different ways we express `FlightSegmentPath`.
 export function getFlightDataPartsFromPath(
-  flightDataPath: FlightDataPath
+  flightDataPath: FlightDataPath,
+  renderedPathname: string
 ): NormalizedFlightData {
   // Pick the last 4 items from the `FlightDataPath` to get the [tree, seedData, viewport, isHeadPartial].
   const flightDataPathLength = 4
@@ -40,6 +46,8 @@ export function getFlightDataPartsFromPath(
     flightDataPath.slice(-flightDataPathLength)
   // The `FlightSegmentPath` is everything except the last three items. For a root render, it won't be present.
   const segmentPath = flightDataPath.slice(0, -flightDataPathLength)
+
+  fillTreeWithParamValues(renderedPathname, segmentPath, tree)
 
   return {
     // TODO: Unify these two segment path helpers. We are inconsistently pushing an empty segment ("")
@@ -67,7 +75,8 @@ export function getNextFlightSegmentPath(
 }
 
 export function normalizeFlightData(
-  flightData: FlightData
+  flightData: FlightData,
+  renderedPathname: string
 ): NormalizedFlightData[] | string {
   // FlightData can be a string when the server didn't respond with a proper flight response,
   // or when a redirect happens, to signal to the client that it needs to perform an MPA navigation.
@@ -75,7 +84,9 @@ export function normalizeFlightData(
     return flightData
   }
 
-  return flightData.map(getFlightDataPartsFromPath)
+  return flightData.map((flightDataPath) =>
+    getFlightDataPartsFromPath(flightDataPath, renderedPathname)
+  )
 }
 
 /**
@@ -168,4 +179,94 @@ function shouldPreserveRefreshMarker(
   refreshMarker: FlightRouterState[3]
 ): boolean {
   return Boolean(refreshMarker && refreshMarker !== 'refresh')
+}
+
+function fillTreeWithParamValues(
+  renderedPathname: string,
+  segmentPath: FlightSegmentPath,
+  flightRouterState: FlightRouterState
+): void {
+  // Traverse the FlightRouterState and fill in the param values using the
+  // rendered pathname.
+
+  // Remove trailing and leading slashes, then split the pathname into parts.
+  // These will be assigned as params as we traverse the tree.
+  const pathnameParts = renderedPathname.replace(/^\/|\/$/g, '').split('/')
+
+  let pathnamePartsIndex = 0
+
+  // segmentPath represents the parent path of subtree. It's a repeating pattern
+  // of parallel route key and segment:
+  //
+  //   [string, Segment, string, Segment, string, Segment, ...]
+  //
+  // Iterate through the path and skip over the corresponding pathname parts.
+  for (let i = 0; i < segmentPath.length; i += 2) {
+    const segment: Segment = segmentPath[i + 1]
+    if (Array.isArray(segment) || doesStaticSegmentAppearInURL(segment)) {
+      // This segment appears in the URL, so we need to skip over this part
+      // of the pathname
+      pathnamePartsIndex++
+    }
+  }
+
+  fillTreeWithParamValuesImpl(
+    renderedPathname,
+    flightRouterState,
+    pathnameParts,
+    pathnamePartsIndex
+  )
+}
+
+function fillTreeWithParamValuesImpl(
+  renderedPathname: string,
+  flightRouterState: FlightRouterState,
+  pathnameParts: Array<string>,
+  pathnamePartsIndex: number
+): void {
+  const segment = flightRouterState[0]
+
+  let doesAppearInURL: boolean
+  if (Array.isArray(segment)) {
+    doesAppearInURL = true
+
+    // This segment is parameterized. Get the param from the pathname.
+    const paramType = segment[2] as DynamicParamTypesShort
+    const paramValue = parseDynamicParamFromURLPart(
+      paramType,
+      pathnameParts,
+      pathnamePartsIndex
+    )
+
+    // Insert the param value into the segment.
+    // TODO: Eventually this is the value that will be passed to client
+    // components that render this param.
+    segment[3] = paramValue
+
+    // Assign a cache key to the segment, based on the param value. In the
+    // pre-Segment Cache implementation, the server computes this and sends it
+    // in the body of the response. In the Segment Cache implementation, the
+    // server sends an empty string and we fill it in here.
+    // TODO: This will land in a follow up PR.
+    // const segmentCacheKey = getCacheKeyForDynamicParam(paramValue)
+    // segment[1] = segmentCacheKey
+  } else {
+    doesAppearInURL = doesStaticSegmentAppearInURL(segment)
+  }
+
+  // Only increment the index if the segment appears in the URL. If it's a
+  // "virtual" segment, like a route group, it remains the same.
+  const childPathnamePartsIndex = doesAppearInURL
+    ? pathnamePartsIndex + 1
+    : pathnamePartsIndex
+
+  const parallelRoutes = flightRouterState[1]
+  for (const parallelRouteKey in parallelRoutes) {
+    fillTreeWithParamValuesImpl(
+      renderedPathname,
+      parallelRoutes[parallelRouteKey],
+      pathnameParts,
+      childPathnamePartsIndex
+    )
+  }
 }

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -1,0 +1,116 @@
+import type { DynamicParamTypesShort } from '../server/app-render/types'
+import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
+import { ROOT_SEGMENT_KEY } from '../shared/lib/segment-cache/segment-value-encoding'
+import {
+  NEXT_REWRITTEN_PATH_HEADER,
+  NEXT_REWRITTEN_QUERY_HEADER,
+} from './components/app-router-headers'
+import type { RSCResponse } from './components/router-reducer/fetch-server-response'
+import type { NormalizedSearch } from './components/segment-cache'
+
+type RouteParamValue = string | Array<string> | null
+
+export type RouteParam = {
+  name: string
+  value: RouteParamValue
+  type: DynamicParamTypesShort
+}
+
+export function getRenderedSearch(response: RSCResponse): NormalizedSearch {
+  // If the server performed a rewrite, the search params used to render the
+  // page will be different from the params in the request URL. In this case,
+  // the response will include a header that gives the rewritten search query.
+  const rewrittenQuery = response.headers.get(NEXT_REWRITTEN_QUERY_HEADER)
+  if (rewrittenQuery !== null) {
+    return (
+      rewrittenQuery === '' ? '' : '?' + rewrittenQuery
+    ) as NormalizedSearch
+  }
+  // If the header is not present, there was no rewrite, so we use the search
+  // query of the response URL.
+  return new URL(response.url).search as NormalizedSearch
+}
+
+export function getRenderedPathname(response: RSCResponse): string {
+  // If the server performed a rewrite, the pathname used to render the
+  // page will be different from the pathname in the request URL. In this case,
+  // the response will include a header that gives the rewritten pathname.
+  const rewrittenPath = response.headers.get(NEXT_REWRITTEN_PATH_HEADER)
+  return rewrittenPath ?? new URL(response.url).pathname
+}
+
+export function parseDynamicParamFromURLPart(
+  paramType: DynamicParamTypesShort,
+  pathnameParts: Array<string>,
+  partIndex: number
+): RouteParamValue {
+  if (partIndex >= pathnameParts.length) {
+    // The route tree expected there to be more parts in the URL than there
+    // actually are. This could happen if the x-nextjs-rewritten-path header
+    // is incorrectly set, or potentially due to bug in Next.js.
+    // TODO: Should this be a hard error? During a prefetch, we can just abort.
+    // During a client navigation, we could trigger a hard refresh. But if it
+    // happens during initial render, we don't really have any recovery options.
+    return ''
+  }
+
+  // This needs to match the behavior in get-dynamic-param.ts.
+  switch (paramType) {
+    // Catchalls
+    case 'c':
+    case 'ci':
+    case 'oc':
+      // Catchalls receive all the remaining URL parts, unless this is the
+      // end of the URL.
+      return partIndex < pathnameParts.length
+        ? pathnameParts.slice(partIndex).map((s) => encodeURIComponent(s))
+        : null
+    // Dynamic
+    case 'd':
+    case 'di':
+      // Regular dynamic params receive the next URL part.
+      return encodeURIComponent(pathnameParts[partIndex])
+    default:
+      paramType satisfies never
+      return ''
+  }
+}
+
+export function doesStaticSegmentAppearInURL(segment: string): boolean {
+  // This is not a parameterized segment; however, we need to determine
+  // whether or not this segment appears in the URL. For example, this route
+  // groups do not appear in the URL, so they should be skipped. Any other
+  // special cases must be handled here.
+  // TODO: Consider encoding this directly into the router tree instead of
+  // inferring it on the client based on the segment type. Something like
+  // a `doesAppearInURL` flag in FlightRouterState.
+  if (
+    segment === ROOT_SEGMENT_KEY ||
+    // For some reason, the loader tree sometimes includes extra __PAGE__
+    // "layouts" when part of a parallel route. But it's not a leaf node.
+    // Otherwise, we wouldn't need this special case because pages are
+    // always leaf nodes.
+    // TODO: Investigate why the loader produces these fake page segments.
+    segment.startsWith(PAGE_SEGMENT_KEY) ||
+    // Route groups.
+    (segment[0] === '(' && segment.endsWith(')'))
+  ) {
+    return false
+  } else {
+    // All other segment types appear in the URL
+    return true
+  }
+}
+
+export function getCacheKeyForDynamicParam(
+  paramValue: RouteParamValue
+): string {
+  // This needs to match the logic in get-dynamic-param.ts, until we're able to
+  // unify the various implementations so that these are always computed on
+  // the client.
+  return typeof paramValue === 'string'
+    ? paramValue
+    : paramValue === null
+      ? ''
+      : paramValue.join('/')
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -492,12 +492,14 @@ async function generateDynamicRSCPayload(
       a: options.actionResult,
       f: flightData,
       b: ctx.sharedContext.buildId,
+      c: prepareInitialCanonicalUrl(url),
     }
   }
 
   // Otherwise, it's a regular RSC response.
   return {
     b: ctx.sharedContext.buildId,
+    c: prepareInitialCanonicalUrl(url),
     f: flightData,
     S: workStore.isStaticGeneration,
   }

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -3,7 +3,6 @@ import type {
   FlightRouterState,
   InitialRSCPayload,
   Segment as FlightRouterStateSegment,
-  DynamicParamTypesShort,
 } from './types'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
@@ -309,7 +308,7 @@ function collectSegmentDataImpl(
 }
 
 function encodeSegmentWithPossibleFallbackParam(
-  segment: [string, string, DynamicParamTypesShort],
+  segment: Exclude<FlightRouterStateSegment, string>,
   fallbackRouteParams: FallbackRouteParams
 ): EncodedSegment {
   const name = segment[0]

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -36,7 +36,22 @@ export type DynamicParamTypesShort = s.Infer<typeof dynamicParamTypesSchema>
 
 const segmentSchema = s.union([
   s.string(),
-  s.tuple([s.string(), s.string(), dynamicParamTypesSchema]),
+  s.union([
+    s.tuple([s.string(), s.string(), dynamicParamTypesSchema]),
+    // On the client, the dynamic param array contains an additional
+    // slot for param value.
+    s.tuple([
+      // Param name
+      s.string(),
+      // Param cache key (almost the same as the value, but arrays are
+      // concatenated into strings)
+      s.string(),
+      // Dynamic param type
+      dynamicParamTypesSchema,
+      // Param value (the one passed to components)
+      s.nullable(s.union([s.string(), s.array(s.string())])),
+    ]),
+  ]),
 ])
 
 export type Segment = s.Infer<typeof segmentSchema>
@@ -313,6 +328,9 @@ export type InitialRSCPayload = {
   b: string
   /** assetPrefix */
   p: string
+  // TODO: This isn't really the "canonical" URL (which we usually use to refer
+  // to the URL shown in the browser), it's the URL used to render the page,
+  // which may have been rewritten on the server.
   /** initialCanonicalUrlParts */
   c: string[]
   /** couldBeIntercepted */
@@ -333,6 +351,11 @@ export type InitialRSCPayload = {
 export type NavigationFlightResponse = {
   /** buildId */
   b: string
+  // TODO: This isn't really the "canonical" URL (which we usually use to refer
+  // to the URL shown in the browser), it's the URL used to render the page,
+  // which may have been rewritten on the server.
+  /** canonicalUrlParts */
+  c: string[]
   /** flightData */
   f: FlightData
   /** prerendered */
@@ -345,6 +368,11 @@ export type ActionFlightResponse = {
   a: ActionResult
   /** buildId */
   b: string
+  // TODO: This isn't really the "canonical" URL (which we usually use to refer
+  // to the URL shown in the browser), it's the URL used to render the page,
+  // which may have been rewritten on the server.
+  /** canonicalUrlParts */
+  c: string[]
   /** flightData */
   f: FlightData
 }


### PR DESCRIPTION
This is part of a larger effort to remove dynamic params from server responses except in cases where they are needed to render a Server Component. If a param is not rendered by a Server Component, then it can be omitted from the cache key, and cached responses can be reused across pages with different param values.

In this step, I've implemented client parsing of the params from the response headers.

The basic approach is to split the URL into parts, then traverse the route tree to pick off the param values, taking care to skip over things like interception routes.

Notably, this is not how the server parses param values. The server gets the params from the regex that's also used for routing. Originally, I thought I'd send the regex to the client and use it there, too. However, this ended up being needlessly complicated, because the server regexes are also used for things like interception route matching. But this is already encapsulated by the structure of the route tree. So it's easier to just walk the tree and pick off the params.

My main hesitation is that this introduces some risk of drift between the server and client params parsing; we'll need to keep them in sync. However, I think the solution is actually to update the server to also pick the params off the URL, rather than use the ones passed from the base router. It's conceptually cleaner, since it's less likely that extra concerns from the base server leaking into the application layer. As an example, compare the code needed to get a catchall param value in the [client](https://github.com/acdlite/next.js/blob/09b16a816ff4d595b5111cb1a6de540838caf97e/packages/next/src/client/client-params.ts#L57-L61) versus the [server](https://github.com/acdlite/next.js/blob/09b16a816ff4d595b5111cb1a6de540838caf97e/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts#L37-L84) implementation.

Note: Although the ultimate goal is to remove the dynamic params from the response body (e.g. FlightRouterState), I have not done so yet this PR. The rest of the work will be split up into multiple subsequent PRs.

---
🔄 **This is a mirror of [upstream PR #82185](https://github.com/vercel/next.js/pull/82185)**