### PR TITLE
Fix: the unexpected clearing of symbolic link directories

### DIFF
--- a/.changeset/lemon-islands-care.md
+++ b/.changeset/lemon-islands-care.md
@@ -1,0 +1,5 @@
+---
+'next': patch
+---
+
+Fix the unexpected clearing of symbolic link directories

--- a/packages/next/src/lib/recursive-delete.ts
+++ b/packages/next/src/lib/recursive-delete.ts
@@ -79,7 +79,7 @@ export async function recursiveDelete(
       const isNotExcluded = !exclude || !exclude.test(pp)
 
       if (isNotExcluded) {
-        if (isDirectory) {
+        if (!isSymlink && isDirectory) {
           await recursiveDelete(absolutePath, exclude, pp)
         }
         return unlinkPath(absolutePath, !isSymlink && isDirectory)


### PR DESCRIPTION
When I was using the standalone build, the second build would delete the contents of local packages. As a result, developers had to delete the cache of local empty directories and re-download the packages. I added a condition for recursive deletion to avoid this situation.

Fixes #82157 

---
🔄 **This is a mirror of [upstream PR #82191](https://github.com/vercel/next.js/pull/82191)**