### PR TITLE
simplify metadata pathname promise creation

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -769,5 +769,6 @@
   "768": "createPrerenderSearchParamsForClientPage should not be called in a runtime prerender.",
   "769": "createSearchParamsFromClient should not be called in a runtime prerender.",
   "770": "createParamsFromClient should not be called in a runtime prerender.",
-  "771": "\\`%s\\` was called during a runtime prerender. Next.js should be preventing %s from being included in server components statically, but did not in this case."
+  "771": "\\`%s\\` was called during a runtime prerender. Next.js should be preventing %s from being included in server components statically, but did not in this case.",
+  "772": "FetchStrategy.PPRRuntime should never be used when `experimental.clientSegmentCache` is disabled"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -764,5 +764,10 @@
   "763": "\\`unstable_rootParams\\` must not be used within a client component. Next.js should be preventing it from being included in client components statically, but did not in this case.",
   "764": "Missing workStore in %s",
   "765": "Route %s used %s inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
-  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route."
+  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.",
+  "767": "A runtime prerender store should not be used for a route handler.",
+  "768": "createPrerenderSearchParamsForClientPage should not be called in a runtime prerender.",
+  "769": "createSearchParamsFromClient should not be called in a runtime prerender.",
+  "770": "createParamsFromClient should not be called in a runtime prerender.",
+  "771": "\\`%s\\` was called during a runtime prerender. Next.js should be preventing %s from being included in server components statically, but did not in this case."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -770,5 +770,6 @@
   "769": "createSearchParamsFromClient should not be called in a runtime prerender.",
   "770": "createParamsFromClient should not be called in a runtime prerender.",
   "771": "\\`%s\\` was called during a runtime prerender. Next.js should be preventing %s from being included in server components statically, but did not in this case.",
-  "772": "FetchStrategy.PPRRuntime should never be used when `experimental.clientSegmentCache` is disabled"
+  "772": "FetchStrategy.PPRRuntime should never be used when `experimental.clientSegmentCache` is disabled",
+  "773": "createServerPathnameForMetadata was called inside a client component scope."
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -192,7 +192,7 @@ export async function handler(
    */
   const isPrefetchRSCRequest =
     getRequestMeta(req, 'isPrefetchRSCRequest') ??
-    Boolean(req.headers[NEXT_ROUTER_PREFETCH_HEADER])
+    req.headers[NEXT_ROUTER_PREFETCH_HEADER] === '1' // exclude runtime prefetches, which use '2'
 
   // NOTE: Don't delete headers[RSC] yet, it still needs to be used in renderToHTML later
 

--- a/packages/next/src/client/app-dir/form.tsx
+++ b/packages/next/src/client/app-dir/form.tsx
@@ -61,6 +61,7 @@ export default function Form({
     }
   }
 
+  // TODO(runtime-ppr): allow runtime prefetches in Form
   const prefetch =
     prefetchProp === false || prefetchProp === null ? prefetchProp : null
 

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -329,6 +329,8 @@ export const publicAppRouterInstance: AppRouterInstance = {
         const actionQueue = getAppRouterActionQueue()
         const prefetchKind = options?.kind ?? PrefetchKind.AUTO
 
+        // We don't currently offer a way to issue a runtime prefetch via `router.prefetch()`.
+        // This will be possible when we update its API to not take a PrefetchKind.
         let fetchStrategy: PrefetchTaskFetchStrategy
         switch (prefetchKind) {
           case PrefetchKind.AUTO: {

--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -12,6 +12,7 @@ export function bailoutToClientRendering(reason: string): void | never {
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
+      case 'prerender-runtime':
       case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -17,6 +17,7 @@ import {
 } from './segment-cache'
 import { startTransition } from 'react'
 import { PrefetchKind } from './router-reducer/router-reducer-types'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 type LinkElement = HTMLAnchorElement | SVGAElement
 
@@ -264,7 +265,7 @@ export function onNavigationIntent(
       process.env.__NEXT_DYNAMIC_ON_HOVER &&
       unstable_upgradeToDynamicPrefetch
     ) {
-      // Switch to a full, dynamic prefetch
+      // Switch to a full prefetch
       instance.fetchStrategy = FetchStrategy.Full
     }
     rescheduleLinkPrefetch(instance, PrefetchPriority.Intent)
@@ -377,6 +378,13 @@ function prefetchWithOldCacheImplementation(instance: PrefetchableInstance) {
       case FetchStrategy.Full: {
         prefetchKind = PrefetchKind.FULL
         break
+      }
+      case FetchStrategy.PPRRuntime: {
+        // We can only get here if Client Segment Cache is off, and in that case
+        // it shouldn't be possible for a link to request a runtime prefetch.
+        throw new InvariantError(
+          'FetchStrategy.PPRRuntime should never be used when `experimental.clientSegmentCache` is disabled'
+        )
       }
       default: {
         instance.fetchStrategy satisfies never

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -24,6 +24,7 @@ function hasFallbackRouteParams(): boolean {
         return fallbackParams ? fallbackParams.size > 0 : false
       case 'prerender-legacy':
       case 'request':
+      case 'prerender-runtime':
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -55,7 +55,7 @@ export type RequestHeaders = {
   [RSC_HEADER]?: '1'
   [NEXT_ROUTER_STATE_TREE_HEADER]?: string
   [NEXT_URL]?: string
-  [NEXT_ROUTER_PREFETCH_HEADER]?: '1'
+  [NEXT_ROUTER_PREFETCH_HEADER]?: '1' | '2'
   [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]?: string
   'x-deployment-id'?: string
   [NEXT_HMR_REFRESH_HEADER]?: '1'

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -142,9 +142,13 @@ export const enum PrefetchPriority {
 }
 
 export const enum FetchStrategy {
-  PPR,
-  Full,
-  LoadingBoundary,
+  // Deliberately ordered so we can easily compare two segments
+  // and determine if one segment is "more specific" than another
+  // (i.e. if it's likely that it contains more data)
+  LoadingBoundary = 0,
+  PPR = 1,
+  PPRRuntime = 2,
+  Full = 3,
 }
 
 /**
@@ -153,4 +157,7 @@ export const enum FetchStrategy {
  * until we complete the initial tree prefetch request, so we use `PPR` to signal both cases
  * and adjust it based on the route when actually fetching.
  * */
-export type PrefetchTaskFetchStrategy = FetchStrategy.PPR | FetchStrategy.Full
+export type PrefetchTaskFetchStrategy =
+  | FetchStrategy.PPR
+  | FetchStrategy.PPRRuntime
+  | FetchStrategy.Full

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -82,7 +82,7 @@ type InternalLinkProps = {
    * - `false`: Prefetching will not happen when entering the viewport, but will still happen on hover.
    * @defaultValue `true` (pages router) or `null` (app router)
    */
-  prefetch?: boolean | 'auto' | null
+  prefetch?: boolean | 'auto' | null | 'unstable_forceStale'
   /**
    * The active locale is automatically prepended. `locale` allows for providing a different locale.
    * When `false` `href` has to include the locale as the default behavior is disabled.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -15,7 +15,10 @@ import {
   workAsyncStorage,
   type WorkStore,
 } from '../app-render/work-async-storage.external'
-import type { RequestStore } from '../app-render/work-unit-async-storage.external'
+import type {
+  PrerenderStoreModernRuntime,
+  RequestStore,
+} from '../app-render/work-unit-async-storage.external'
 import type { NextParsedUrlQuery } from '../request-meta'
 import type { LoaderTree } from '../lib/app-dir-module'
 import type { AppPageModule } from '../route-modules/app-page/module'
@@ -54,6 +57,7 @@ import {
   RSC_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_HMR_REFRESH_HASH_COOKIE,
+  NEXT_DID_POSTPONE_HEADER,
 } from '../../client/components/app-router-headers'
 import { createMetadataContext } from '../../lib/metadata/metadata-context'
 import { createRequestStoreForRender } from '../async-storage/request-store'
@@ -133,6 +137,7 @@ import {
   consumeDynamicAccess,
   type DynamicAccess,
   logDisallowedDynamicError,
+  warnOnSyncDynamicError,
 } from './dynamic-rendering'
 import {
   getClientComponentLoaderMetrics,
@@ -193,6 +198,8 @@ import type { GlobalErrorComponent } from '../../client/components/builtin/globa
 import { normalizeConventionFilePath } from './segment-explorer-path'
 import { getRequestMeta } from '../request-meta'
 import { getDynamicParam } from '../../shared/lib/router/utils/get-dynamic-param'
+import type { ExperimentalConfig } from '../config-shared'
+import type { Params } from '../request/params'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -266,6 +273,7 @@ interface ParsedRequestHeaders {
    */
   readonly flightRouterState: FlightRouterState | undefined
   readonly isPrefetchRequest: boolean
+  readonly isRuntimePrefetchRequest: boolean
   readonly isRouteTreePrefetchRequest: boolean
   readonly isDevWarmupRequest: boolean
   readonly isHmrRefresh: boolean
@@ -281,8 +289,12 @@ function parseRequestHeaders(
   const isDevWarmupRequest = options.isDevWarmup === true
 
   // dev warmup requests are treated as prefetch RSC requests
+  // runtime prefetch requests are *not* treated as prefetch requests
+  // (TODO: this is confusing, we should refactor this to express this better)
   const isPrefetchRequest =
-    isDevWarmupRequest || headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined
+    isDevWarmupRequest || headers[NEXT_ROUTER_PREFETCH_HEADER] === '1'
+
+  const isRuntimePrefetchRequest = headers[NEXT_ROUTER_PREFETCH_HEADER] === '2'
 
   const isHmrRefresh = headers[NEXT_HMR_REFRESH_HEADER] !== undefined
 
@@ -315,6 +327,7 @@ function parseRequestHeaders(
   return {
     flightRouterState,
     isPrefetchRequest,
+    isRuntimePrefetchRequest,
     isRouteTreePrefetchRequest,
     isHmrRefresh,
     isRSCRequest,
@@ -516,6 +529,7 @@ function createErrorContext(
     revalidateReason: getRevalidateReason(ctx.workStore),
   }
 }
+
 /**
  * Produces a RenderResult containing the Flight data for the given request. See
  * `generateDynamicRSCPayload` for information on the contents of the render result.
@@ -598,6 +612,317 @@ async function generateDynamicFlightRenderResult(
   return new FlightRenderResult(flightReadableStream, {
     fetchMetrics: ctx.workStore.fetchMetrics,
   })
+}
+
+async function generateRuntimePrefetchResult(
+  req: BaseNextRequest,
+  res: BaseNextResponse,
+  ctx: AppRenderContext,
+  requestStore: RequestStore
+): Promise<RenderResult> {
+  const { workStore } = ctx
+  const renderOpts = ctx.renderOpts
+
+  function onFlightDataRenderError(err: DigestedError) {
+    return renderOpts.onInstrumentationRequestError?.(
+      err,
+      req,
+      // TODO(runtime-ppr): should we use a different value?
+      createErrorContext(ctx, 'react-server-components-payload')
+    )
+  }
+  const onError = createFlightReactServerErrorHandler(
+    false,
+    onFlightDataRenderError
+  )
+
+  const metadata: AppPageRenderResultMetadata = {}
+
+  const generatePayload = () => generateDynamicRSCPayload(ctx, undefined)
+
+  const {
+    componentMod: { tree },
+    getDynamicParamFromSegment,
+  } = ctx
+  const rootParams = getRootParams(tree, getDynamicParamFromSegment)
+
+  // We need to share caches between the prospective prerender and the final prerender,
+  // but we're not going to persist this anywhere.
+  const prerenderResumeDataCache = createPrerenderResumeDataCache()
+  // We're not resuming an existing render.
+  const renderResumeDataCache = null
+
+  await prospectiveRuntimeServerPrerender(
+    ctx,
+    generatePayload,
+    prerenderResumeDataCache,
+    renderResumeDataCache,
+    rootParams,
+    requestStore.cookies,
+    requestStore.draftMode
+  )
+
+  const response = await finalRuntimeServerPrerender(
+    ctx,
+    generatePayload,
+    prerenderResumeDataCache,
+    renderResumeDataCache,
+    rootParams,
+    requestStore.cookies,
+    requestStore.draftMode,
+    onError
+  )
+
+  applyMetadataFromPrerenderResult(response, metadata, workStore)
+  metadata.fetchMetrics = ctx.workStore.fetchMetrics
+
+  if (response.isPartial) {
+    res.setHeader(NEXT_DID_POSTPONE_HEADER, '1')
+  }
+
+  return new FlightRenderResult(response.result.prelude, metadata)
+}
+
+async function prospectiveRuntimeServerPrerender(
+  ctx: AppRenderContext,
+  getPayload: () => any,
+  prerenderResumeDataCache: PrerenderResumeDataCache | null,
+  renderResumeDataCache: RenderResumeDataCache | null,
+  rootParams: Params,
+  cookies: PrerenderStoreModernRuntime['cookies'],
+  draftMode: PrerenderStoreModernRuntime['draftMode']
+) {
+  const { implicitTags, renderOpts, workStore } = ctx
+
+  const { clientReferenceManifest, ComponentMod } = renderOpts
+
+  assertClientReferenceManifest(clientReferenceManifest)
+
+  // Prerender controller represents the lifetime of the prerender.
+  // It will be aborted when a Task is complete or a synchronously aborting
+  // API is called. Notably during cache-filling renders this does not actually
+  // terminate the render itself which will continue until all caches are filled
+  const initialServerPrerenderController = new AbortController()
+
+  // This controller represents the lifetime of the React render call. Notably
+  // during the cache-filling render it is different from the prerender controller
+  // because we don't want to end the react render until all caches are filled.
+  const initialServerRenderController = new AbortController()
+
+  // The cacheSignal helps us track whether caches are still filling or we are ready
+  // to cut the render off.
+  const cacheSignal = new CacheSignal()
+
+  const initialServerPrerenderStore: PrerenderStoreModernRuntime = {
+    type: 'prerender-runtime',
+    phase: 'render',
+    rootParams,
+    implicitTags,
+    renderSignal: initialServerRenderController.signal,
+    controller: initialServerPrerenderController,
+    // During the initial prerender we need to track all cache reads to ensure
+    // we render long enough to fill every cache it is possible to visit during
+    // the final prerender.
+    cacheSignal,
+    // We only need to track dynamic accesses during the final prerender.
+    dynamicTracking: null,
+    // Runtime prefetches are never cached server-side, only client-side,
+    // so we set `expire` and `revalidate` to their minimum values just in case.
+    revalidate: 1,
+    expire: 0,
+    stale: INFINITE_CACHE,
+    tags: [...implicitTags.tags],
+    renderResumeDataCache,
+    prerenderResumeDataCache,
+    hmrRefreshHash: undefined,
+    captureOwnerStack: undefined,
+    // These are not present in regular prerenders, but allowed in a runtime prerender.
+    cookies,
+    draftMode,
+  }
+
+  // We're not going to use the result of this render because the only time it could be used
+  // is if it completes in a microtask and that's likely very rare for any non-trivial app
+  const initialServerPayload = await workUnitAsyncStorage.run(
+    initialServerPrerenderStore,
+    getPayload
+  )
+
+  const pendingInitialServerResult = workUnitAsyncStorage.run(
+    initialServerPrerenderStore,
+    ComponentMod.prerender,
+    initialServerPayload,
+    clientReferenceManifest.clientModules,
+    {
+      filterStackFrame,
+      onError: (err) => {
+        const digest = getDigestForWellKnownError(err)
+
+        if (digest) {
+          return digest
+        }
+
+        if (initialServerPrerenderController.signal.aborted) {
+          // The render aborted before this error was handled which indicates
+          // the error is caused by unfinished components within the render
+          return
+        } else if (
+          process.env.NEXT_DEBUG_BUILD ||
+          process.env.__NEXT_VERBOSE_LOGGING
+        ) {
+          printDebugThrownValueForProspectiveRender(err, workStore.route)
+        }
+      },
+      // we don't care to track postpones during the prospective render because we need
+      // to always do a final render anyway
+      onPostpone: undefined,
+      // We don't want to stop rendering until the cacheSignal is complete so we pass
+      // a different signal to this render call than is used by dynamic APIs to signify
+      // transitioning out of the prerender environment
+      signal: initialServerRenderController.signal,
+    }
+  )
+
+  // Wait for all caches to be finished filling and for async imports to resolve
+  trackPendingModules(cacheSignal)
+  await cacheSignal.cacheReady()
+
+  initialServerRenderController.abort()
+  initialServerPrerenderController.abort()
+
+  // We don't need to continue the prerender process if we already
+  // detected invalid dynamic usage in the initial prerender phase.
+  if (workStore.invalidDynamicUsageError) {
+    throw workStore.invalidDynamicUsageError
+  }
+
+  try {
+    return await createReactServerPrerenderResult(pendingInitialServerResult)
+  } catch (err) {
+    if (
+      initialServerRenderController.signal.aborted ||
+      initialServerPrerenderController.signal.aborted
+    ) {
+      // These are expected errors that might error the prerender. we ignore them.
+    } else if (
+      process.env.NEXT_DEBUG_BUILD ||
+      process.env.__NEXT_VERBOSE_LOGGING
+    ) {
+      // We don't normally log these errors because we are going to retry anyway but
+      // it can be useful for debugging Next.js itself to get visibility here when needed
+      printDebugThrownValueForProspectiveRender(err, workStore.route)
+    }
+    return null
+  }
+}
+
+async function finalRuntimeServerPrerender(
+  ctx: AppRenderContext,
+  getPayload: () => any,
+  prerenderResumeDataCache: PrerenderResumeDataCache | null,
+  renderResumeDataCache: RenderResumeDataCache | null,
+  rootParams: Params,
+  cookies: PrerenderStoreModernRuntime['cookies'],
+  draftMode: PrerenderStoreModernRuntime['draftMode'],
+  onError: (err: unknown) => string | undefined
+) {
+  const { implicitTags, renderOpts } = ctx
+
+  const {
+    clientReferenceManifest,
+    ComponentMod,
+    experimental,
+    isDebugDynamicAccesses,
+  } = renderOpts
+
+  assertClientReferenceManifest(clientReferenceManifest)
+
+  const selectStaleTime = createSelectStaleTime(experimental)
+
+  let serverIsDynamic = false
+  const finalServerController = new AbortController()
+
+  const serverDynamicTracking = createDynamicTrackingState(
+    isDebugDynamicAccesses
+  )
+
+  const finalServerPrerenderStore: PrerenderStoreModernRuntime = {
+    type: 'prerender-runtime',
+    phase: 'render',
+    rootParams,
+    implicitTags,
+    renderSignal: finalServerController.signal,
+    controller: finalServerController,
+    // All caches we could read must already be filled so no tracking is necessary
+    cacheSignal: null,
+    dynamicTracking: serverDynamicTracking,
+    // Runtime prefetches are never cached server-side, only client-side,
+    // so we set `expire` and `revalidate` to their minimum values just in case.
+    revalidate: 1,
+    expire: 0,
+    stale: INFINITE_CACHE,
+    tags: [...implicitTags.tags],
+    prerenderResumeDataCache,
+    renderResumeDataCache,
+    hmrRefreshHash: undefined,
+    captureOwnerStack: undefined,
+    // These are not present in regular prerenders, but allowed in a runtime prerender.
+    cookies,
+    draftMode,
+  }
+
+  const finalRSCPayload = await workUnitAsyncStorage.run(
+    finalServerPrerenderStore,
+    getPayload
+  )
+
+  let prerenderIsPending = true
+  const result = await prerenderAndAbortInSequentialTasks(
+    async () => {
+      const prerenderResult = await workUnitAsyncStorage.run(
+        finalServerPrerenderStore,
+        ComponentMod.prerender,
+        finalRSCPayload,
+        clientReferenceManifest.clientModules,
+        {
+          filterStackFrame,
+          onError,
+          signal: finalServerController.signal,
+        }
+      )
+      prerenderIsPending = false
+      return prerenderResult
+    },
+    () => {
+      if (finalServerController.signal.aborted) {
+        // If the server controller is already aborted we must have called something
+        // that required aborting the prerender synchronously such as with new Date()
+        serverIsDynamic = true
+        return
+      }
+
+      if (prerenderIsPending) {
+        // If prerenderIsPending then we have blocked for longer than a Task and we assume
+        // there is something unfinished.
+        serverIsDynamic = true
+      }
+      finalServerController.abort()
+    }
+  )
+
+  warnOnSyncDynamicError(serverDynamicTracking)
+
+  return {
+    result,
+    // TODO(runtime-ppr): do we need to produce a digest map here?
+    // digestErrorsMap: ...,
+    dynamicAccess: serverDynamicTracking,
+    isPartial: serverIsDynamic,
+    collectedRevalidate: finalServerPrerenderStore.revalidate,
+    collectedExpire: finalServerPrerenderStore.expire,
+    collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
+    collectedTags: finalServerPrerenderStore.tags,
+  }
 }
 
 /**
@@ -1300,6 +1625,7 @@ async function renderToHTMLOrFlightImpl(
   const {
     flightRouterState,
     isPrefetchRequest,
+    isRuntimePrefetchRequest,
     isRSCRequest,
     isDevWarmupRequest,
     isHmrRefresh,
@@ -1449,41 +1775,7 @@ async function renderToHTMLOrFlightImpl(
       }
     }
 
-    if (response.collectedTags) {
-      metadata.fetchTags = response.collectedTags.join(',')
-    }
-
-    // Let the client router know how long to keep the cached entry around.
-    const staleHeader = String(response.collectedStale)
-    res.setHeader(NEXT_ROUTER_STALE_TIME_HEADER, staleHeader)
-    metadata.headers ??= {}
-    metadata.headers[NEXT_ROUTER_STALE_TIME_HEADER] = staleHeader
-
-    // If force static is specifically set to false, we should not revalidate
-    // the page.
-    if (workStore.forceStatic === false || response.collectedRevalidate === 0) {
-      metadata.cacheControl = { revalidate: 0, expire: undefined }
-    } else {
-      // Copy the cache control value onto the render result metadata.
-      metadata.cacheControl = {
-        revalidate:
-          response.collectedRevalidate >= INFINITE_CACHE
-            ? false
-            : response.collectedRevalidate,
-        expire:
-          response.collectedExpire >= INFINITE_CACHE
-            ? undefined
-            : response.collectedExpire,
-      }
-    }
-
-    // provide bailout info for debugging
-    if (metadata.cacheControl?.revalidate === 0) {
-      metadata.staticBailoutInfo = {
-        description: workStore.dynamicUsageDescription,
-        stack: workStore.dynamicUsageStack,
-      }
-    }
+    applyMetadataFromPrerenderResult(response, metadata, workStore)
 
     if (response.renderResumeDataCache) {
       metadata.renderResumeDataCache = response.renderResumeDataCache
@@ -1531,7 +1823,11 @@ async function renderToHTMLOrFlightImpl(
     if (isDevWarmupRequest) {
       return warmupDevRender(req, ctx)
     } else if (isRSCRequest) {
-      return generateDynamicFlightRenderResult(req, ctx, requestStore)
+      if (isRuntimePrefetchRequest) {
+        return generateRuntimePrefetchResult(req, res, ctx, requestStore)
+      } else {
+        return generateDynamicFlightRenderResult(req, ctx, requestStore)
+      }
     }
 
     const renderToStreamWithTracing = getTracer().wrap(
@@ -1734,6 +2030,53 @@ export const renderToHTMLOrFlight: AppPageRender = (
     sharedContext,
     fallbackRouteParams
   )
+}
+
+function applyMetadataFromPrerenderResult(
+  response: Pick<
+    PrerenderToStreamResult,
+    | 'collectedExpire'
+    | 'collectedRevalidate'
+    | 'collectedStale'
+    | 'collectedTags'
+  >,
+  metadata: AppPageRenderResultMetadata,
+  workStore: WorkStore
+) {
+  if (response.collectedTags) {
+    metadata.fetchTags = response.collectedTags.join(',')
+  }
+
+  // Let the client router know how long to keep the cached entry around.
+  const staleHeader = String(response.collectedStale)
+  metadata.headers ??= {}
+  metadata.headers[NEXT_ROUTER_STALE_TIME_HEADER] = staleHeader
+
+  // If force static is specifically set to false, we should not revalidate
+  // the page.
+  if (workStore.forceStatic === false || response.collectedRevalidate === 0) {
+    metadata.cacheControl = { revalidate: 0, expire: undefined }
+  } else {
+    // Copy the cache control value onto the render result metadata.
+    metadata.cacheControl = {
+      revalidate:
+        response.collectedRevalidate >= INFINITE_CACHE
+          ? false
+          : response.collectedRevalidate,
+      expire:
+        response.collectedExpire >= INFINITE_CACHE
+          ? undefined
+          : response.collectedExpire,
+    }
+  }
+
+  // provide bailout info for debugging
+  if (metadata.cacheControl?.revalidate === 0) {
+    metadata.staticBailoutInfo = {
+      description: workStore.dynamicUsageDescription,
+      stack: workStore.dynamicUsageStack,
+    }
+  }
 }
 
 async function renderToStream(
@@ -2945,11 +3288,7 @@ async function prerenderToStream(
     setMetadataHeader(name)
   }
 
-  const selectStaleTime = (stale: number) =>
-    stale === INFINITE_CACHE &&
-    typeof experimental.staleTimes?.static === 'number'
-      ? experimental.staleTimes.static
-      : stale
+  const selectStaleTime = createSelectStaleTime(experimental)
 
   let prerenderStore: PrerenderStore | null = null
 
@@ -4169,6 +4508,14 @@ const getGlobalErrorStyles = async (
     GlobalError: GlobalErrorComponent,
     styles: globalErrorStyles,
   }
+}
+
+function createSelectStaleTime(experimental: ExperimentalConfig) {
+  return (stale: number) =>
+    stale === INFINITE_CACHE &&
+    typeof experimental.staleTimes?.static === 'number'
+      ? experimental.staleTimes.static
+      : stale
 }
 
 async function collectSegmentData(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1190,6 +1190,7 @@ async function renderToHTMLOrFlightImpl(
       switch (workUnitStore.type) {
         case 'prerender':
         case 'prerender-client':
+        case 'prerender-runtime':
         case 'cache':
         case 'private-cache':
           return true

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -300,6 +300,7 @@ async function createComponentTreeInternal(
     if (workUnitStore) {
       switch (workUnitStore.type) {
         case 'prerender':
+        case 'prerender-runtime':
         case 'prerender-legacy':
         case 'prerender-ppr':
           if (workUnitStore.revalidate > defaultRevalidate) {

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -336,6 +336,21 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
   )
 }
 
+/**
+ * Use this function when dynamically prerendering with dynamicIO.
+ * We don't want to error, because it's better to return something
+ * (and we've already aborted the render at the point where the sync dynamic error occured),
+ * but we should log an error server-side.
+ * @internal
+ */
+export function warnOnSyncDynamicError(dynamicTracking: DynamicTrackingState) {
+  if (dynamicTracking.syncDynamicErrorWithStack) {
+    // the server did something sync dynamic, likely
+    // leading to an early termination of the prerender.
+    console.error(dynamicTracking.syncDynamicErrorWithStack)
+  }
+}
+
 // For now these implementations are the same so we just reexport
 export const trackSynchronousRequestDataAccessInDev =
   trackSynchronousPlatformIOAccessInDev

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -230,6 +230,7 @@ export function trackDynamicDataInDynamicRender(workUnitStore: WorkUnitStore) {
       // A private cache scope is already dynamic by definition.
       return
     case 'prerender':
+    case 'prerender-runtime':
     case 'prerender-legacy':
     case 'prerender-ppr':
     case 'prerender-client':
@@ -519,6 +520,7 @@ export function createHangingInputAbortSignal(
 ): AbortSignal | undefined {
   switch (workUnitStore.type) {
     case 'prerender':
+    case 'prerender-runtime':
       const controller = new AbortController()
 
       if (workUnitStore.cacheSignal) {
@@ -599,6 +601,10 @@ export function useDynamicRouteParams(expression: string) {
         }
         break
       }
+      case 'prerender-runtime':
+        throw new InvariantError(
+          `\`${expression}\` was called during a runtime prerender. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
+        )
       case 'cache':
       case 'private-cache':
         throw new InvariantError(

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -260,6 +260,7 @@ export async function decryptActionBoundArgs(
 
         switch (workUnitStore?.type) {
           case 'prerender':
+          case 'prerender-runtime':
             // Explicitly don't close the stream here (until prerendering is
             // complete) so that hanging promises are not rejected.
             if (workUnitStore.renderSignal.aborted) {

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -71,6 +71,7 @@ export function useFlightStream<T>(
         flightResponses.set(flightStream, responseOnNextTick)
         return responseOnNextTick
       case 'prerender':
+      case 'prerender-runtime':
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -370,6 +370,7 @@ export function createPatchedFetcher(
         if (workUnitStore) {
           switch (workUnitStore.type) {
             case 'prerender':
+            case 'prerender-runtime':
             // TODO: Stop accumulating tags in client prerender. (fallthrough)
             case 'prerender-client':
             case 'prerender-ppr':
@@ -412,6 +413,7 @@ export function createPatchedFetcher(
               break
             case 'prerender':
             case 'prerender-client':
+            case 'prerender-runtime':
             case 'prerender-ppr':
             case 'prerender-legacy':
             case 'request':
@@ -552,6 +554,7 @@ export function createPatchedFetcher(
         if (hasNoExplicitCacheConfig && workUnitStore !== undefined) {
           switch (workUnitStore.type) {
             case 'prerender':
+            case 'prerender-runtime':
             // While we don't want to do caching in the client scope we know the
             // fetch will be dynamic for cacheComponents so we may as well avoid the
             // call here. (fallthrough)
@@ -668,6 +671,7 @@ export function createPatchedFetcher(
               switch (workUnitStore.type) {
                 case 'prerender':
                 case 'prerender-client':
+                case 'prerender-runtime':
                   if (cacheSignal) {
                     cacheSignal.endRead()
                     cacheSignal = null
@@ -721,6 +725,7 @@ export function createPatchedFetcher(
               break
             case 'prerender':
             case 'prerender-client':
+            case 'prerender-runtime':
             case 'prerender-ppr':
             case 'prerender-legacy':
             case 'unstable-cache':
@@ -840,6 +845,7 @@ export function createPatchedFetcher(
                 switch (workUnitStore?.type) {
                   case 'prerender':
                   case 'prerender-client':
+                  case 'prerender-runtime':
                     return createCachedPrerenderResponse(
                       res,
                       cacheKey,
@@ -912,6 +918,7 @@ export function createPatchedFetcher(
               switch (workUnitStore.type) {
                 case 'prerender':
                 case 'prerender-client':
+                case 'prerender-runtime':
                   // We sometimes use the cache to dedupe fetches that do not
                   // specify a cache configuration. In these cases we want to
                   // make sure we still exclude them from prerenders if
@@ -1013,6 +1020,7 @@ export function createPatchedFetcher(
               switch (workUnitStore.type) {
                 case 'prerender':
                 case 'prerender-client':
+                case 'prerender-runtime':
                   if (cacheSignal) {
                     cacheSignal.endRead()
                     cacheSignal = null
@@ -1052,6 +1060,7 @@ export function createPatchedFetcher(
                 switch (workUnitStore.type) {
                   case 'prerender':
                   case 'prerender-client':
+                  case 'prerender-runtime':
                     return makeHangingPromise<Response>(
                       workUnitStore.renderSignal,
                       'fetch()'

--- a/packages/next/src/server/node-environment-extensions/console-dev.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dev.tsx
@@ -141,6 +141,7 @@ function patchConsoleMethodDEV(methodName: InterceptableConsoleMethod): void {
       switch (workUnitStore?.type) {
         case 'prerender':
         case 'prerender-client':
+        case 'prerender-runtime':
           originalMethod.apply(this, dimConsoleCall(methodName, args))
           break
         case 'prerender-ppr':

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -20,7 +20,8 @@ export function io(expression: string, type: ApiType) {
   }
 
   switch (workUnitStore.type) {
-    case 'prerender': {
+    case 'prerender':
+    case 'prerender-runtime': {
       const prerenderSignal = workUnitStore.controller.signal
 
       if (prerenderSignal.aborted === false) {

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -53,7 +53,7 @@ export function connection(): Promise<void> {
         }
         case 'private-cache': {
           // It might not be intuitive to throw for private caches as well, but
-          // we don't consider dynamic prefetches as "actual requests" (in the
+          // we don't consider runtime prefetches as "actual requests" (in the
           // navigation sense), despite allowing them to read cookies.
           const error = new Error(
             `Route ${workStore.route} used "connection" inside "use cache: private". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
@@ -68,6 +68,7 @@ export function connection(): Promise<void> {
           )
         case 'prerender':
         case 'prerender-client':
+        case 'prerender-runtime':
           // We return a promise that never resolves to allow the prerender to
           // stall at this point.
           return makeHangingPromise(

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -114,6 +114,7 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
             workStore,
             workUnitStore
           )
+        case 'prerender-runtime':
         case 'private-cache':
           return makeUntrackedExoticCookies(workUnitStore.cookies)
         case 'request':
@@ -470,6 +471,7 @@ function syncIODev(route: string | undefined, expression: string) {
         break
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-runtime':
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'cache':

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -55,6 +55,7 @@ export function draftMode(): Promise<DraftMode> {
   }
 
   switch (workUnitStore.type) {
+    case 'prerender-runtime':
     case 'request':
       return createOrGetCachedDraftMode(workUnitStore.draftMode, workStore)
 
@@ -62,8 +63,8 @@ export function draftMode(): Promise<DraftMode> {
     case 'private-cache':
     case 'unstable-cache':
       // Inside of `"use cache"` or `unstable_cache`, draft mode is available if
-      // the outmost work unit store is a request store, and if draft mode is
-      // enabled.
+      // the outmost work unit store is a request store (or a runtime prerender),
+      // and if draft mode is enabled.
       const draftModeProvider = getDraftModeProviderForCacheScope(
         workStore,
         workUnitStore
@@ -257,6 +258,7 @@ function syncIODev(route: string | undefined, expression: string) {
         break
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-runtime':
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'cache':
@@ -322,7 +324,9 @@ function trackDynamicDraftMode(expression: string, constructorOpt: Function) {
           throw new Error(
             `Route ${workStore.route} used "${expression}" inside a function cached with "unstable_cache(...)". The enabled status of draftMode can be read in caches but you must not enable or disable draftMode inside a cache. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
           )
-        case 'prerender': {
+
+        case 'prerender':
+        case 'prerender-runtime': {
           const error = new Error(
             `Route ${workStore.route} used ${expression} without first calling \`await connection()\`. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-headers`
           )

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -101,6 +101,7 @@ export function headers(): Promise<ReadonlyHeaders> {
           )
         case 'prerender':
         case 'prerender-client':
+        case 'prerender-runtime':
         case 'prerender-ppr':
         case 'prerender-legacy':
         case 'request':
@@ -119,6 +120,7 @@ export function headers(): Promise<ReadonlyHeaders> {
     if (workUnitStore) {
       switch (workUnitStore.type) {
         case 'prerender':
+        case 'prerender-runtime':
           return makeHangingHeaders(workUnitStore)
         case 'prerender-client':
           const exportName = '`headers`'
@@ -433,6 +435,7 @@ function syncIODev(route: string | undefined, expression: string) {
         break
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-runtime':
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'cache':

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -10,10 +10,10 @@ import {
 
 import {
   workUnitAsyncStorage,
-  type PrerenderStore,
   type PrerenderStorePPR,
   type PrerenderStoreLegacy,
-  type PrerenderStoreModern,
+  type StaticPrerenderStoreModern,
+  type StaticPrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
@@ -74,6 +74,10 @@ export function createParamsFromClient(
         throw new InvariantError(
           'createParamsFromClient should not be called in cache contexts.'
         )
+      case 'prerender-runtime':
+        throw new InvariantError(
+          'createParamsFromClient should not be called in a runtime prerender.'
+        )
       case 'request':
         break
       default:
@@ -106,6 +110,7 @@ export function createServerParamsForRoute(
         throw new InvariantError(
           'createServerParamsForRoute should not be called in cache contexts.'
         )
+      case 'prerender-runtime':
       case 'request':
         break
       default:
@@ -133,6 +138,7 @@ export function createServerParamsForServerSegment(
         throw new InvariantError(
           'createServerParamsForServerSegment should not be called in cache contexts.'
         )
+      case 'prerender-runtime':
       case 'request':
         break
       default:
@@ -171,6 +177,7 @@ export function createPrerenderParamsForClientSegment(
         )
       case 'prerender-ppr':
       case 'prerender-legacy':
+      case 'prerender-runtime':
       case 'request':
         break
       default:
@@ -186,7 +193,7 @@ export function createPrerenderParamsForClientSegment(
 function createPrerenderParams(
   underlyingParams: Params,
   workStore: WorkStore,
-  prerenderStore: PrerenderStore
+  prerenderStore: StaticPrerenderStore
 ): Promise<Params> {
   switch (prerenderStore.type) {
     case 'prerender':
@@ -291,7 +298,7 @@ const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
 
 function makeHangingParams(
   underlyingParams: Params,
-  prerenderStore: PrerenderStoreModern
+  prerenderStore: StaticPrerenderStoreModern
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
@@ -578,6 +585,7 @@ function syncIODev(
         break
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-runtime':
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'cache':

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   workUnitAsyncStorage,
-  type PrerenderStore,
+  type StaticPrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -35,6 +35,8 @@ export function createServerPathnameForMetadata(
         throw new InvariantError(
           'createServerPathnameForMetadata should not be called in cache contexts.'
         )
+
+      case 'prerender-runtime':
       case 'request':
         break
       default:
@@ -47,7 +49,7 @@ export function createServerPathnameForMetadata(
 function createPrerenderPathname(
   underlyingPathname: string,
   workStore: WorkStore,
-  prerenderStore: PrerenderStore
+  prerenderStore: StaticPrerenderStore
 ): Promise<string> {
   switch (prerenderStore.type) {
     case 'prerender-client':

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -9,9 +9,9 @@ import {
 } from '../app-render/work-async-storage.external'
 import {
   workUnitAsyncStorage,
-  type PrerenderStore,
   type PrerenderStoreLegacy,
   type PrerenderStorePPR,
+  type StaticPrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import type { FallbackRouteParams } from './fallback-params'
@@ -56,6 +56,7 @@ export async function unstable_rootParams(): Promise<Params> {
         workUnitStore
       )
     case 'private-cache':
+    case 'prerender-runtime':
     case 'request':
       return Promise.resolve(workUnitStore.rootParams)
     default:
@@ -66,7 +67,7 @@ export async function unstable_rootParams(): Promise<Params> {
 function createPrerenderRootParams(
   underlyingParams: Params,
   workStore: WorkStore,
-  prerenderStore: PrerenderStore
+  prerenderStore: StaticPrerenderStore
 ): Promise<Params> {
   switch (prerenderStore.type) {
     case 'prerender-client': {
@@ -245,6 +246,7 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
       )
     }
     case 'private-cache':
+    case 'prerender-runtime':
     case 'request': {
       break
     }
@@ -258,7 +260,7 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
 function createPrerenderRootParamPromise(
   paramName: string,
   workStore: WorkStore,
-  prerenderStore: PrerenderStore,
+  prerenderStore: StaticPrerenderStore,
   apiName: string
 ): Promise<ParamValue> {
   switch (prerenderStore.type) {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -1189,6 +1189,10 @@ function trackDynamic(
         throw new InvariantError(
           'A client prerender store should not be used for a route handler.'
         )
+      case 'prerender-runtime':
+        throw new InvariantError(
+          'A runtime prerender store should not be used for a route handler.'
+        )
       case 'prerender-ppr':
         return postponeWithTracking(
           store.route,

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -96,6 +96,7 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
   switch (workUnitStore?.type) {
     case 'prerender':
     case 'prerender-client':
+    case 'prerender-runtime':
     case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':

--- a/packages/next/src/server/use-cache/cache-tag.ts
+++ b/packages/next/src/server/use-cache/cache-tag.ts
@@ -13,6 +13,7 @@ export function cacheTag(...tags: string[]): void {
   switch (workUnitStore?.type) {
     case 'prerender':
     case 'prerender-client':
+    case 'prerender-runtime':
     case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':

--- a/packages/next/src/server/use-cache/constants.ts
+++ b/packages/next/src/server/use-cache/constants.ts
@@ -1,2 +1,2 @@
 export const DYNAMIC_EXPIRE = 300 // 5 minutes
-export const DYNAMIC_PREFETCH_DYNAMIC_STALE = 30 // 30 seconds
+export const RUNTIME_PREFETCH_DYNAMIC_STALE = 30 // 30 seconds

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -298,9 +298,8 @@ export async function adapter(
                 onAfterTaskError: undefined,
               },
               requestEndedState: { ended: false },
-              isPrefetchRequest: request.headers.has(
-                NEXT_ROUTER_PREFETCH_HEADER
-              ),
+              isPrefetchRequest:
+                request.headers.get(NEXT_ROUTER_PREFETCH_HEADER) === '1',
               buildId: buildId ?? '',
               previouslyRevalidatedTags: [],
             })

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -110,6 +110,7 @@ function revalidate(tags: string[], expression: string) {
           `Route ${store.route} used "${expression}" inside a function cached with "unstable_cache(...)" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
         )
       case 'prerender':
+      case 'prerender-runtime':
         // cacheComponents Prerender
         const error = new Error(
           `Route ${store.route} used ${expression} without first calling \`await connection()\`.`

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -163,6 +163,7 @@ export function unstable_cache<T extends Callback>(
             case 'cache':
             case 'private-cache':
             case 'prerender':
+            case 'prerender-runtime':
             case 'prerender-ppr':
             case 'prerender-legacy':
               // We update the store's revalidate property if the option.revalidate is a higher precedence
@@ -384,6 +385,7 @@ function getFetchUrlPrefix(
       return `${pathname}${sortedSearch.length ? '?' : ''}${sortedSearch}`
     case 'prerender':
     case 'prerender-client':
+    case 'prerender-runtime':
     case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -34,6 +34,7 @@ export function unstable_noStore() {
       switch (workUnitStore.type) {
         case 'prerender':
         case 'prerender-client':
+        case 'prerender-runtime':
           // unstable_noStore() is a noop in Dynamic I/O.
           return
         case 'prerender-ppr':

--- a/packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts
+++ b/packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts
@@ -1,7 +1,7 @@
 import { hexHash } from '../../hash'
 
 export function computeCacheBustingSearchParam(
-  prefetchHeader: '1' | '0' | undefined,
+  prefetchHeader: '1' | '2' | '0' | undefined,
   segmentPrefetchHeader: string | string[] | undefined,
   stateTreeHeader: string | string[] | undefined,
   nextUrlHeader: string | string[] | undefined

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
@@ -16,13 +16,13 @@ export default async function Page(props) {
           <Link href="/search-params?id=2">/search-params?id=2</Link>
         </li>
         <li>
-          <Link href="/search-params?id=3" prefetch>
-            /search-params?id=3 (prefetch: true)
+          <Link href="/search-params?id=3" prefetch="unstable_forceStale">
+            /search-params?id=3 (prefetch: unstable_forceStale)
           </Link>
         </li>
         <li>
-          <Link href="/search-params" prefetch>
-            /search-params (prefetch: true)
+          <Link href="/search-params" prefetch="unstable_forceStale">
+            /search-params (prefetch: unstable_forceStale)
           </Link>
         </li>
         <li>

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/with-middleware/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/with-middleware/page.tsx
@@ -5,7 +5,7 @@ export default function Page() {
     <ul>
       <li>
         <Link href="/with-middleware/search-params?id=1">
-          /search-params?id=1 (prefetch: true)
+          /search-params?id=1
         </Link>
       </li>
       <li>
@@ -14,12 +14,18 @@ export default function Page() {
         </Link>
       </li>
       <li>
-        <Link href="/with-middleware/search-params?id=3" prefetch>
+        <Link
+          href="/with-middleware/search-params?id=3"
+          prefetch="unstable_forceStale"
+        >
           /search-params?id=3 (prefetch: true)
         </Link>
       </li>
       <li>
-        <Link href="/with-middleware/search-params" prefetch>
+        <Link
+          href="/with-middleware/search-params"
+          prefetch="unstable_forceStale"
+        >
           /search-params (prefetch: true)
         </Link>
       </li>

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -11,6 +11,8 @@ describe('segment cache (CDN cache busting)', () => {
     return
   }
 
+  // TODO(runtime-ppr): add tests for runtime prefetches
+
   // To debug these tests locally, run:
   //   node start.mjs
   //

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -10,7 +10,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
 }) {
   const [isVisible, setIsVisible] = useState(false)
   return (

--- a/test/e2e/app-dir/segment-cache/client-only-opt-in/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/client-only-opt-in/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -10,7 +10,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
 }) {
   const [isVisible, setIsVisible] = useState(false)
   return (

--- a/test/e2e/app-dir/segment-cache/deployment-skew/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -10,7 +10,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
 }) {
   const [isVisible, setIsVisible] = useState(false)
   return (

--- a/test/e2e/app-dir/segment-cache/dynamic-on-hover/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/dynamic-on-hover/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -11,7 +11,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
   unstable_dynamicOnHover?: boolean
 }) {
   const [isVisible, setIsVisible] = useState(false)

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -11,7 +11,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: string
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
   id?: string
 }) {
   const [isVisible, setIsVisible] = useState(false)

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/page.tsx
@@ -22,10 +22,10 @@ export default function MixedFetchStrategies() {
             <li>
               <LinkAccordion
                 id="ppr-enabled-prefetch-true"
-                prefetch={true}
+                prefetch="unstable_forceStale"
                 href="/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-enabled"
               >
-                Same link, but with prefetch=true
+                Same link, but with prefetch="unstable_forceStale"
               </LinkAccordion>
             </li>
           </ul>

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -285,7 +285,7 @@ describe('segment cache (incremental opt in)', () => {
   )
 
   it(
-    'when a link is prefetched with <Link prefetch=true>, no dynamic request ' +
+    'when a link is prefetched with <Link prefetch="unstable_forceStale">, no dynamic request ' +
       'is made on navigation',
     async () => {
       let act
@@ -324,7 +324,7 @@ describe('segment cache (incremental opt in)', () => {
   )
 
   it(
-    'when prefetching with prefetch=true, refetches cache entries that only ' +
+    'when prefetching with prefetch="unstable_forceStale", refetches cache entries that only ' +
       'contain partial data',
     async () => {
       let act
@@ -343,7 +343,7 @@ describe('segment cache (incremental opt in)', () => {
         { includes: 'Loading (PPR shell of shared-layout)...' }
       )
 
-      // Prefetch the same link again, this time with prefetch=true to include
+      // Prefetch the same link again, this time with prefetch="unstable_forceStale" to include
       // the dynamic data
       await act(
         async () => {
@@ -370,7 +370,7 @@ describe('segment cache (incremental opt in)', () => {
           // If this fails, it likely means that the partial cache entry that
           // resulted from prefetching the normal link (<Link prefetch={false}>)
           // was not properly re-fetched when the full link (<Link
-          // prefetch={true}>) was prefetched.
+          // prefetch='unstable_forceStale'>) was prefetched.
           await browser.elementById('page-content')
         },
         // Assert that no network requests are initiated within this block.
@@ -380,7 +380,7 @@ describe('segment cache (incremental opt in)', () => {
   )
 
   it(
-    'when prefetching with prefetch=true, refetches partial cache entries ' +
+    'when prefetching with prefetch="unstable_forceStale", refetches partial cache entries ' +
       "even if there's already a pending PPR request",
     async () => {
       // This test is hard to describe succinctly because it involves a fairly
@@ -427,7 +427,7 @@ describe('segment cache (incremental opt in)', () => {
         )
 
         // Before the previous prefetch finishes, prefetch the same link again,
-        // this time with prefetch=true to include the dynamic data.
+        // this time with prefetch="unstable_forceStale" to include the dynamic data.
         await act(
           async () => {
             const checkbox = await browser.elementById(
@@ -457,7 +457,7 @@ describe('segment cache (incremental opt in)', () => {
           // If this fails, it likely means that the pending cache entry that
           // resulted from prefetching the normal link (<Link prefetch={false}>)
           // was not properly re-fetched when the full link (<Link
-          // prefetch={true}>) was prefetched.
+          // prefetch='unstable_forceStale'>) was prefetched.
           await browser.elementById('page-content')
         },
         // Assert that no network requests are initiated within this block.

--- a/test/e2e/app-dir/segment-cache/metadata/app/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -11,7 +11,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: string
-  prefetch?: boolean | 'unstable_forceStale' | 'auto'
+  prefetch?: LinkProps['prefetch']
   id?: string
 }) {
   const [isVisible, setIsVisible] = useState(false)
@@ -25,7 +25,6 @@ export function LinkAccordion({
         id={id}
       />
       {isVisible ? (
-        // @ts-expect-error - unstable_forceStale is not yet part of the types
         <Link href={href} prefetch={prefetch}>
           {children}
         </Link>

--- a/test/e2e/app-dir/segment-cache/metadata/app/page-with-runtime-prefetchable-head/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/page-with-runtime-prefetchable-head/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next'
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export async function generateMetadata(): Promise<Metadata> {
+  await cookies()
+  return {
+    title: 'Runtime-prefetchable title',
+  }
+}
+
+async function Content() {
+  await cookies()
+  return <div id="target-page">Target page</div>
+}
+
+export default function PageWithRuntimePrefetchableTitle() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
@@ -5,16 +5,19 @@ export default function Page() {
     <>
       <ul>
         <li>
-          <LinkAccordion prefetch={true} href="/page-with-dynamic-head">
-            Page with dynamic head (prefetch=true))
+          <LinkAccordion
+            prefetch="unstable_forceStale"
+            href="/page-with-dynamic-head"
+          >
+            Page with dynamic head (prefetch=unstable_forceStale)
           </LinkAccordion>
         </li>
         <li>
           <LinkAccordion
-            prefetch={true}
+            prefetch="unstable_forceStale"
             href="/rewrite-to-page-with-dynamic-head"
           >
-            Rewrite to page with dynamic head (prefetch=true)
+            Rewrite to page with dynamic head (prefetch=unstable_forceStale)
           </LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
@@ -21,6 +21,25 @@ export default function Page() {
           </LinkAccordion>
         </li>
       </ul>
+      <hr />
+      <ul>
+        <li>
+          <LinkAccordion
+            prefetch="unstable_forceStale"
+            href="/page-with-runtime-prefetchable-head"
+          >
+            Page with runtime-prefetchable head (prefetch=true)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            prefetch="unstable_forceStale"
+            href="/rewrite-to-page-with-runtime-prefetchable-head"
+          >
+            Rewrite to page with runtime-prefetchable head (prefetch=true)
+          </LinkAccordion>
+        </li>
+      </ul>
     </>
   )
 }

--- a/test/e2e/app-dir/segment-cache/metadata/next.config.js
+++ b/test/e2e/app-dir/segment-cache/metadata/next.config.js
@@ -12,6 +12,10 @@ const nextConfig = {
         source: '/rewrite-to-page-with-dynamic-head',
         destination: '/page-with-dynamic-head',
       },
+      {
+        source: '/rewrite-to-page-with-runtime-prefetchable-head',
+        destination: '/page-with-runtime-prefetchable-head',
+      },
     ]
   },
 }

--- a/test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
+++ b/test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
@@ -9,12 +9,9 @@ describe('segment cache (metadata)', () => {
     test('disabled in development', () => {})
     return
   }
-
-  it(
-    "regression: prefetch the head if it's missing even if all other data " +
-      'is cached',
-    async () => {
-      let act
+  describe("regression: prefetch the head if it's missing even if all other data is cached", () => {
+    it('pages with dynamic content and dynamic metadata, using a full prefetch', async () => {
+      let act: ReturnType<typeof createRouterAct>
       const browser = await next.browser('/', {
         beforePageLoad(p) {
           act = createRouterAct(p)
@@ -75,6 +72,71 @@ describe('segment cache (metadata)', () => {
         const title = await browser.eval(() => document.title)
         expect(title).toBe('Dynamic Title')
       }, 'no-requests')
-    }
-  )
+    })
+
+    it('pages with runtime-prefetchable content and dynamic metadata, using a runtime prefetch', async () => {
+      let act: ReturnType<typeof createRouterAct>
+      const browser = await next.browser('/', {
+        beforePageLoad(p) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Runtime-prefetch a page.
+      // It only uses cookies, so this should be a complete prefetch.
+      await act(async () => {
+        const checkbox = await browser.elementByCss(
+          'input[data-link-accordion="/page-with-runtime-prefetchable-head"]'
+        )
+        await checkbox.click()
+      }, [
+        // Because the link is prefetched with prefetch="unstable_forceStale",
+        // we should be able to prefetch the title, even though it's dynamic.
+        {
+          includes: 'Runtime-prefetchable title',
+        },
+        {
+          includes: 'Target page',
+        },
+      ])
+
+      // Now runtime-prefetch a link that rewrites to the same underlying page.
+      await act(async () => {
+        const checkbox = await browser.elementByCss(
+          'input[data-link-accordion="/rewrite-to-page-with-runtime-prefetchable-head"]'
+        )
+        await checkbox.click()
+      }, [
+        // TODO: Ideally, this would not prefetch the dynamic title again,
+        // because it was already prefetched by the previous link, and both
+        // links resolve to the same underlying route. This is because, unlike
+        // segment data, we cache routes solely by their input URL, not by the
+        // path of the underlying route. Similarly, we don't cache metadata
+        // separately from the route tree. We should probably do one or both.
+        {
+          includes: 'Runtime-prefetchable title',
+        },
+        // It should not prefetch the page content again, because it was
+        // already cached.
+        {
+          includes: 'Target page',
+          block: 'reject',
+        },
+      ])
+
+      // When we navigate to the page, it should not make any additional
+      // network requests, because both the segment data and the head were
+      // fully prefetched.
+      await act(async () => {
+        const link = await browser.elementByCss(
+          'a[href="/rewrite-to-page-with-runtime-prefetchable-head"]'
+        )
+        await link.click()
+        const pageContent = await browser.elementById('target-page')
+        expect(await pageContent.text()).toBe('Target page')
+        const title = await browser.eval(() => document.title)
+        expect(title).toBe('Runtime-prefetchable title')
+      }, 'no-requests')
+    })
+  })
 })

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -10,7 +10,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
 }) {
   const [isVisible, setIsVisible] = useState(false)
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-auto/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-auto/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link, { LinkProps } from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/layout.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body style={{ fontFamily: 'monospace' }}>
+        <Header />
+        {children}
+      </body>
+    </html>
+  )
+}
+
+function Header() {
+  return (
+    <header>
+      <Link href="/" prefetch={false}>
+        Home
+      </Link>
+    </header>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/page.tsx
@@ -1,0 +1,58 @@
+import { DebugLinkAccordion } from '../components/link-accordion'
+import { unstable_cacheLife } from 'next/cache'
+
+export default async function Page() {
+  'use cache'
+  unstable_cacheLife('minutes')
+  return (
+    <main>
+      <h2>shared layout prefetching - layout with cookies and dynamic data</h2>
+      <ul>
+        <li>
+          <DebugLinkAccordion href="/shared-layout/one" prefetch={true} />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/shared-layout/one"
+            prefetch={'unstable_forceStale'}
+          />
+        </li>
+      </ul>
+      <ul>
+        <li>
+          <DebugLinkAccordion href="/shared-layout/two" prefetch={'auto'} />
+        </li>
+        <li>
+          <DebugLinkAccordion href="/shared-layout/two" prefetch={true} />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/shared-layout/two"
+            prefetch={'unstable_forceStale'}
+          />
+        </li>
+      </ul>
+      <h2>shared layout prefetching - layout with cookies</h2>
+      <ul>
+        <li>
+          <DebugLinkAccordion
+            href="/runtime-prefetchable-layout/one"
+            prefetch={true}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/runtime-prefetchable-layout/two"
+            prefetch={'auto'}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/runtime-prefetchable-layout/two"
+            prefetch={'unstable_forceStale'}
+          />
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/layout.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../shared'
+
+export default async function Layout({ children }) {
+  return (
+    <main>
+      <div>
+        <h2>Shared layout</h2>
+        <DebugRenderKind />
+        <p id="shared-layout-description">
+          This shared layout uses cookies and no uncached IO, so it should be
+          completely runtime-prefetchable.
+        </p>
+        <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+          <RuntimePrefetchable />
+        </Suspense>
+      </div>
+      <hr />
+      {children}
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value-layout">{`Cookie from layout: ${cookieValue}`}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/one/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/one/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import { cachedDelay } from '../../shared'
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return (
+    <main>
+      <h1 style={{ color: 'yellow' }}>Page one</h1>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>
+      {/*
+        TODO: a runtime-prefetched layout that had no holes itself will still be considered partial
+        if any other segment in the response is partial, because we don't track partiality per-segment,
+        so if we want to test that full prefetches can reuse layouts from runtime prefetches,
+        the whole page needs to be dynamically prerenderable.
+       */}
+      {/* <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense> */}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/two/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/two/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react'
+import { cachedDelay, uncachedIO } from '../../shared'
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return (
+    <main>
+      <h1 style={{ color: 'green' }}>Page two</h1>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content-page">Dynamic content from page two</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/layout.tsx
@@ -1,0 +1,48 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../shared'
+import { connection } from 'next/server'
+
+export default async function Layout({ children }) {
+  return (
+    <main>
+      <div>
+        <h2>Shared layout</h2>
+        <DebugRenderKind />
+        <p id="shared-layout-description">
+          This shared layout uses cookies and some uncached IO, so parts of it
+          should be runtime-prefetchable.
+        </p>
+        <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+          <RuntimePrefetchable />
+        </Suspense>
+      </div>
+      <hr />
+      {children}
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value-layout">{`Cookie from layout: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content-layout">Dynamic content from layout</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/one/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/one/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react'
+import { cachedDelay, uncachedIO } from '../../shared'
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return (
+    <main>
+      <h1 style={{ color: 'yellow' }}>Page one</h1>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content-page">Dynamic content from page one</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/two/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/two/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react'
+import { cachedDelay, uncachedIO } from '../../shared'
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return (
+    <main>
+      <h1 style={{ color: 'green' }}>Page two</h1>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content-page">Dynamic content from page two</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared.tsx
@@ -1,0 +1,34 @@
+import { unstable_cacheLife } from 'next/cache'
+import { setTimeout } from 'timers/promises'
+
+export async function uncachedIO() {
+  await setTimeout(500)
+}
+
+export async function cachedDelay(time: number, cacheBuster?: any) {
+  'use cache'
+  unstable_cacheLife('minutes')
+  console.log('cachedDelay', time, cacheBuster)
+  await setTimeout(time)
+}
+
+export function DebugRenderKind() {
+  const { workUnitAsyncStorage } =
+    require('next/dist/server/app-render/work-unit-async-storage.external') as typeof import('next/dist/server/app-render/work-unit-async-storage.external')
+  const workUnitStore = workUnitAsyncStorage.getStore()!
+  return (
+    <div>
+      workUnitStore.type: {workUnitStore.type}
+      {(() => {
+        switch (workUnitStore.type) {
+          case 'prerender':
+            return '(static prefetch)'
+          case 'prerender-runtime':
+            return '(runtime prefetch)'
+          default:
+            return null
+        }
+      })()}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/components/link-accordion.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { ComponentProps, useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+        data-prefetch={getPrefetchKind(prefetch)}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}
+
+export function DebugLinkAccordion({
+  href,
+  prefetch,
+}: Omit<ComponentProps<typeof LinkAccordion>, 'children'>) {
+  const prefetchKind = getPrefetchKind(prefetch)
+  return (
+    <LinkAccordion href={href} prefetch={prefetch} data-prefetch={prefetch}>
+      {href} ({prefetchKind})
+    </LinkAccordion>
+  )
+}
+
+function getPrefetchKind(prefetch: LinkProps['prefetch']) {
+  switch (prefetch) {
+    case false:
+      return 'disabled'
+    case undefined:
+    case null:
+    case 'auto':
+      return 'auto'
+    case true:
+      return 'runtime'
+    case 'unstable_forceStale':
+      return 'full'
+    default:
+      prefetch satisfies never
+  }
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: { cacheComponents: true, clientSegmentCache: true },
+  productionBrowserSourceMaps: true,
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
@@ -1,0 +1,575 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from '../router-act'
+
+describe('layout sharing in non-static prefetches', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('disabled in development', () => {})
+    return
+  }
+
+  // Glossary:
+  //
+  // - A "full prefetch" is `<Link prefetch="unstable_forceStale">` (a.k.a old `prefetch={true}`, before cacheComponents).
+  //  It includes cached and uncached IO.
+
+  // - A "runtime prefetch" is the new `<Link prefetch={true}>` (only available in cacheComponents mode).
+  //   It includes cached IO, and allows access to cookies/params/searchParams/"use cache: private", but excludes uncached IO.
+
+  it('runtime prefetches should omit layouts that were already prefetched with a runtime prefetch', async () => {
+    // Prefetches should re-use results from previous prefetches with the same fetch strategy.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a runtime prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="runtime"][data-link-accordion="/shared-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // should prefetch page one, and allow reading cookies
+      {
+        includes: 'Cookie from page: testValue',
+      },
+      // Should not prefetch any dynamic content
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Reveal the link to trigger a runtime prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="runtime"][data-link-accordion="/shared-layout/two"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should not prefetch the shared layout, because we already have it in the cache
+      {
+        includes: 'Cookie from layout: testValue',
+        block: 'reject',
+      },
+      // should prefetch page two, and allow reading cookies
+      {
+        includes: 'Cookie from page: testValue',
+      },
+      // Should not prefetch the dynamic content from either of them
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to page two
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss(`a[href="/shared-layout/two"]`).click()
+        },
+        {
+          // Temporarily block the navigation request.
+          // The runtime-prefetched parts of the tree should be visible before it finishes.
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+      expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+      expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+      expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+        'Cookie from layout: testValue'
+      )
+      expect(await browser.elementById('cookie-value-page').text()).toEqual(
+        'Cookie from page: testValue'
+      )
+    })
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+      'Cookie from layout: testValue'
+    )
+    expect(await browser.elementById('cookie-value-page').text()).toEqual(
+      'Cookie from page: testValue'
+    )
+    expect(await browser.elementById('dynamic-content-layout').text()).toEqual(
+      'Dynamic content from layout'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+
+  it('full prefetches should omit layouts that were already prefetched with a full prefetch', async () => {
+    // Prefetches should re-use results from previous prefetches with the same fetch strategy.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a full prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="full"][data-link-accordion="/shared-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should prefetch the dynamic content
+      {
+        includes: 'Dynamic content from page one',
+      },
+    ])
+
+    // Reveal the link to trigger a full prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="full"][data-link-accordion="/shared-layout/two"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should not prefetch the shared layout, because we already have it in the cache
+      {
+        includes: 'Dynamic content from layout',
+        block: 'reject',
+      },
+      // Should prefetch the dynamic content
+      {
+        includes: 'Dynamic content from page two',
+      },
+    ])
+
+    // Navigate to page two. We have everything in the cache, so we shouldn't issue any new requests
+    await act(async () => {
+      await browser.elementByCss(`a[href="/shared-layout/two"]`).click()
+    }, 'no-requests')
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('dynamic-content-layout').text()).toEqual(
+      'Dynamic content from layout'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+
+  it('navigations should omit layouts that were already prefetched with a full prefetch', async () => {
+    // A navigation is mostly equivalent to a full prefetch, so it should re-use results from full prefetches.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a full prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="full"][data-link-accordion="/shared-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should prefetch the dynamic content
+      {
+        includes: 'Dynamic content from page one',
+      },
+    ])
+
+    // Reveal the link to trigger an auto prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="auto"][data-link-accordion="/shared-layout/two"]`
+      )
+      await linkToggle.click()
+    })
+
+    // Navigate to page two. We have everything in the cache, so we shouldn't issue any new requests
+    await act(async () => {
+      await browser.elementByCss(`a[href="/shared-layout/two"]`).click()
+    }, [
+      // Should not fetch the shared layout, because we already have it in the cache
+      {
+        includes: 'Dynamic content from layout',
+        block: 'reject',
+      },
+      // Should fetch the dynamic content
+      {
+        includes: 'Dynamic content from page two',
+      },
+    ])
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('dynamic-content-layout').text()).toEqual(
+      'Dynamic content from layout'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+
+  it('runtime prefetches should omit layouts that were already prefetched with a full prefetch', async () => {
+    // A prefetch should re-use layouts from past prefetches with more specific fetch strategies.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a full prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="full"][data-link-accordion="/shared-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should prefetch the dynamic content
+      {
+        includes: 'Dynamic content from page one',
+      },
+    ])
+
+    // Reveal the link to trigger a runtime prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="runtime"][data-link-accordion="/shared-layout/two"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should not prefetch the shared layout, because we already have it in the cache
+      {
+        includes: 'Cookie from layout: testValue',
+        block: 'reject',
+      },
+      // should prefetch page two, and allow reading cookies
+      {
+        includes: 'Cookie from page: testValue',
+      },
+      // Should not prefetch any dynamic content
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to page two
+    await act(async () => {
+      await act(async () => {
+        await browser.elementByCss(`a[href="/shared-layout/two"]`).click()
+      }, [
+        // Should not fetch the shared layout, because we already have a full prefetch of it
+        {
+          includes: 'Cookie from layout: testValue',
+          block: 'reject',
+        },
+        {
+          // Temporarily block the navigation request.
+          // The runtime-prefetched parts of the tree should be visible before it finishes.
+          includes: 'Dynamic content',
+          block: true,
+        },
+      ])
+      expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+      expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+      expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+        'Cookie from layout: testValue'
+      )
+      expect(await browser.elementById('cookie-value-page').text()).toEqual(
+        'Cookie from page: testValue'
+      )
+    })
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+      'Cookie from layout: testValue'
+    )
+    expect(await browser.elementById('cookie-value-page').text()).toEqual(
+      'Cookie from page: testValue'
+    )
+    expect(await browser.elementById('dynamic-content-layout').text()).toEqual(
+      'Dynamic content from layout'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+
+  it('full prefetches should include layouts that were only prefetched with a runtime prefetch', async () => {
+    // A prefetch should NOT re-use layouts from past prefetches if they used a less specific fetch strategy.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a runtime prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="runtime"][data-link-accordion="/shared-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // should prefetch page one, and allow reading cookies
+      {
+        includes: 'Cookie from page: testValue',
+      },
+      // Should not prefetch any dynamic content
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Reveal the link to trigger a full prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="full"][data-link-accordion="/shared-layout/two"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should prefetch the shared layout, because we didn't prefetch it fully
+      {
+        includes: 'Dynamic content from layout',
+      },
+    ])
+
+    // Navigate to page two. We have everything in the cache, so we shouldn't issue any new requests
+    await act(async () => {
+      await browser.elementByCss(`a[href="/shared-layout/two"]`).click()
+    }, 'no-requests')
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+      'Cookie from layout: testValue'
+    )
+    expect(await browser.elementById('cookie-value-page').text()).toEqual(
+      'Cookie from page: testValue'
+    )
+    expect(await browser.elementById('dynamic-content-layout').text()).toEqual(
+      'Dynamic content from layout'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+
+  it('full prefetches should omit layouts that were prefetched with a runtime prefetch and had no dynamic holes', async () => {
+    // If a runtime prefetch gave us a complete segment with no dynamic holes left, then it's equivalent to a full prefetch.
+    //
+    // TODO: This doesn't work in all cases -- if any segment in a runtime prefetch was partial, we'll mark all of them as partial,
+    // which means they can't be reused in a full prefetch or a navigation. So this only works if the dynaimic prefetch has no holes at all.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a runtime prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="runtime"][data-link-accordion="/runtime-prefetchable-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // should prefetch page one, and allow reading cookies
+      {
+        includes: 'Cookie from page: testValue',
+      },
+    ])
+
+    // Navigate to page one. It should have been completely prefetched by the runtime prefetch.
+    await act(async () => {
+      await browser
+        .elementByCss(`a[href="/runtime-prefetchable-layout/one"]`)
+        .click()
+    }, 'no-requests')
+
+    await browser.back()
+
+    // Reveal the link to trigger a full prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="full"][data-link-accordion="/runtime-prefetchable-layout/two"]`
+      )
+      await linkToggle.click()
+    }, [
+      // Should not prefetch the shared layout, because we already got a complete result for it.
+      {
+        includes: 'Cookie from layout',
+        block: 'reject',
+      },
+      // Should fully prefetch the page, which we haven't prefetched before.
+      {
+        includes: 'Dynamic content from page two',
+      },
+    ])
+
+    // Navigate to page two. We have everything in the cache, so we shouldn't issue any new requests
+    await act(async () => {
+      await browser
+        .elementByCss(`a[href="/runtime-prefetchable-layout/two"]`)
+        .click()
+    }, 'no-requests')
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+      'Cookie from layout: testValue'
+    )
+    expect(await browser.elementById('cookie-value-page').text()).toEqual(
+      'Cookie from page: testValue'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+
+  it('navigations should omit layouts that were prefetched with a runtime prefetch and had no dynamic holes', async () => {
+    // If a runtime prefetch gave us a complete segment with no dynamic holes left, then it's equivalent to a full prefetch.
+    //
+    // TODO: This doesn't work in all cases -- if any segment in a runtime prefetch was partial, we'll mark all of them as partial,
+    // which means they can't be reused in a full prefetch or a navigation. So this only works if the dynaimic prefetch has no holes at all.
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Clear cookies after the test. This currently doesn't happen automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    const act = createRouterAct(page)
+
+    await browser.addCookie({ name: 'testCookie', value: 'testValue' })
+
+    // Reveal the link to trigger a runtime prefetch for page one
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="runtime"][data-link-accordion="/runtime-prefetchable-layout/one"]`
+      )
+      await linkToggle.click()
+    }, [
+      // should prefetch page one, and allow reading cookies
+      {
+        includes: 'Cookie from page: testValue',
+      },
+    ])
+
+    // Navigate to page one. It should have been completely prefetched by the runtime prefetch.
+    await act(async () => {
+      await browser
+        .elementByCss(`a[href="/runtime-prefetchable-layout/one"]`)
+        .click()
+    }, 'no-requests')
+
+    await browser.back()
+
+    // Reveal the link to trigger an auto prefetch for page two
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-prefetch="auto"][data-link-accordion="/runtime-prefetchable-layout/two"]`
+      )
+      await linkToggle.click()
+    })
+
+    // Navigate to page two. We need to request the page segment dynamically, but the shared layout should be cached.
+    await act(async () => {
+      await browser
+        .elementByCss(`a[href="/runtime-prefetchable-layout/two"]`)
+        .click()
+    }, [
+      // Should not fetch the shared layout, because we already got a complete result for it.
+      {
+        includes: 'Cookie from layout',
+        block: 'reject',
+      },
+      // Should fetch the page, which we haven't prefetched before.
+      {
+        includes: 'Dynamic content from page two',
+      },
+    ])
+
+    // After navigating, we should see both the parts that we prefetched and dynamic content.
+    expect(await browser.elementByCss('h2').text()).toEqual('Shared layout')
+    expect(await browser.elementByCss('h1').text()).toEqual('Page two')
+    expect(await browser.elementById('cookie-value-layout').text()).toEqual(
+      'Cookie from layout: testValue'
+    )
+    expect(await browser.elementById('cookie-value-page').text()).toEqual(
+      'Cookie from page: testValue'
+    )
+    expect(await browser.elementById('dynamic-content-page').text()).toEqual(
+      'Dynamic content from page two'
+    )
+  })
+})
+
+function defer(callback: () => Promise<void>) {
+  return {
+    [Symbol.asyncDispose]: callback,
+  }
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { unstable_cacheLife } from 'next/cache'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page uses a short-lived private cache (staleTime &lt;
+        RUNTIME_PREFETCH_DYNAMIC_STALE, which is 30s), which should not be
+        included in a runtime prefetch
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
+        <CachedButShortLived />
+      </Suspense>
+    </main>
+  )
+}
+
+async function CachedButShortLived() {
+  'use cache: private'
+  unstable_cacheLife({
+    stale: 5,
+    // the rest of the settings don't matter for private caches,
+    // because they are not persisted server-side
+  })
+  await cachedDelay(500, [__filename])
+
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      Short-lived cached content
+      <div id="cached-value">{Date.now()}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { unstable_cacheLife } from 'next/cache'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page uses a short-lived public cache (expire &lt; DYNAMIC_EXPIRE,
+        5min), which should not be included in a static prefetch, but should be
+        included in a runtime prefetch, because it has a long enough stale time
+        (&gt; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
+        <ShortLivedCache />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ShortLivedCache() {
+  'use cache'
+  unstable_cacheLife({
+    stale: 60, // > RUNTIME_PREFETCH_DYNAMIC_STALE
+    revalidate: 2 * 60,
+    expire: 3 * 60, // < DYNAMIC_EXPIRE
+  })
+  await cachedDelay(500, [__filename])
+
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      Short-lived cached content
+      <div id="cached-value">{Date.now()}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { unstable_cacheLife } from 'next/cache'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page uses a short-lived public cache (expire &lt; DYNAMIC_EXPIRE,
+        5min), which should not be included in a static prefetch, and should
+        also not be included in a runtime prefetch, because it has a short
+        enough stale time (&lt; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
+        <ShortLivedCache />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ShortLivedCache() {
+  'use cache'
+  unstable_cacheLife({
+    stale: 20, // < RUNTIME_PREFETCH_DYNAMIC_STALE
+    revalidate: 2 * 60,
+    expire: 3 * 60, // < DYNAMIC_EXPIRE
+  })
+  await cachedDelay(500, [__filename])
+
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      Short-lived cached content
+      <div id="cached-value">{Date.now()}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { ErrorBoundary } from '../../../../components/error-boundary'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page errors after a cookies call, so we should only see the error
+        in a runtime prefetch or a navigation (and not during prerendering /
+        prefetching)
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <ErrorBoundary>
+          <One />
+        </ErrorBoundary>
+      </Suspense>
+    </main>
+  )
+}
+
+async function One(): Promise<never> {
+  const cookieStore = await cookies()
+  await cachedDelay(500, ['/cookies', cookieStore.get('user-agent')?.value])
+  throw new Error('Kaboom')
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-cookies/page.tsx
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page performs sync IO after a cookies() call, so we should only see
+        the error in a runtime prefetch or a navigation (and not during
+        prerendering / prefetching)
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <One />
+      </Suspense>
+    </main>
+  )
+}
+
+async function One() {
+  const cookieStore = await cookies()
+  await cachedDelay(500, ['/cookies', cookieStore.get('user-agent')?.value])
+  return <div id="timestamp">Timestamp: {Date.now()}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -1,0 +1,13 @@
+export default async function Page() {
+  return (
+    <main>
+      <h1>Fully static</h1>
+      <p id="intro">Hello from a fully static page!</p>
+      <p>
+        {new Array({ length: 1000 })
+          .fill(null)
+          .map(() => 'Lorem ipsum dolor sit amet.')}
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -1,0 +1,29 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses cookies and no uncached IO, So it should be completely
+        prefetchable with a runtime prefetch.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -1,0 +1,56 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
+import { connection } from 'next/server'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses cookies and some uncached IO, so parts of it should be
+        runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+      <form
+        action={async (formData: FormData) => {
+          'use server'
+          const cookieStore = await cookies()
+          const cookieValue = formData.get('cookie') as string | null
+          if (cookieValue) {
+            cookieStore.set('testCookie', cookieValue)
+          }
+        }}
+      >
+        <input type="text" name="cookie" />
+        <button type="submit">Update cookie</button>
+      </form>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
+import { connection } from 'next/server'
+
+type Params = { id: string }
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses params and some uncached IO, so parts of it should be
+        runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
+  const { id } = await params
+  await cachedDelay(500, [__filename, id])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="param-value">{`Param: ${id}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -1,0 +1,51 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
+import { connection } from 'next/server'
+
+type AnySearchParams = { [key: string]: string | string[] | undefined }
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses search params and some uncached IO, so parts of it should
+        be runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  const { searchParam } = await searchParams
+  await cachedDelay(500, [__filename, searchParam])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="search-param-value">{`Search param: ${searchParam}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses cookies (from a private cache) and no uncached IO, So it
+        should be completely prefetchable with a runtime prefetch.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieValue = await privateCache()
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+    </div>
+  )
+}
+
+async function privateCache() {
+  'use cache: private'
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return cookieValue
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -1,0 +1,62 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
+import { connection } from 'next/server'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses cookies (from inside a private cache) and some uncached
+        IO, so parts of it should be runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+      <form
+        action={async (formData: FormData) => {
+          'use server'
+          const cookieStore = await cookies()
+          const cookieValue = formData.get('cookie') as string | null
+          if (cookieValue) {
+            cookieStore.set('testCookie', cookieValue)
+          }
+        }}
+      >
+        <input type="text" name="cookie" />
+        <button type="submit">Update cookie</button>
+      </form>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieValue = await privateCache()
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function privateCache() {
+  'use cache: private'
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  await cachedDelay(500, [__filename, cookieValue])
+  return cookieValue
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -1,0 +1,47 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
+import { connection } from 'next/server'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses Date.now (in a private cache) and some uncached IO, so
+        parts of it should be runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const now = await privateCache()
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="timestamp">{`Timestamp: ${now}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function privateCache() {
+  'use cache: private'
+  const now = Date.now()
+  await cachedDelay(500, [__filename])
+  return now
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -1,0 +1,49 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
+import { connection } from 'next/server'
+
+type Params = { id: string }
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses params (passed to a private cache) and some uncached IO,
+        so parts of it should be runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
+  const id = await privateCache(params)
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="param-value">{`Param: ${id}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function privateCache(params: Promise<Params>) {
+  'use cache: private'
+  const { id } = await params
+  await cachedDelay(500, [__filename, id])
+  return id
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -1,0 +1,57 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
+import { connection } from 'next/server'
+
+type AnySearchParams = { [key: string]: string | string[] | undefined }
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses search params (passed to a private cache) and some
+        uncached IO, so parts of it should be runtime-prefetchable.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  const searchParam = await privateCache(searchParams)
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="search-param-value">{`Search param: ${searchParam}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function privateCache(searchParams: Promise<AnySearchParams>) {
+  'use cache: private'
+  const { searchParam } = await searchParams
+  await cachedDelay(500, [__filename, searchParam])
+  return searchParam
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/layout.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body style={{ fontFamily: 'monospace' }}>
+        <Header />
+        {children}
+      </body>
+    </html>
+  )
+}
+
+function Header() {
+  return (
+    <header>
+      <Link href="/" prefetch={false}>
+        Home
+      </Link>
+    </header>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
@@ -1,0 +1,218 @@
+import { DebugLinkAccordion } from '../../components/link-accordion'
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+
+      <h2>directly in a page</h2>
+      <ul>
+        <li>
+          cookies + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion href="/in-page/cookies" prefetch={true} />
+            </li>
+          </ul>
+        </li>
+
+        <li>
+          search params + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-page/search-params?searchParam=123"
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/in-page/search-params?searchParam=456"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          dynamic params + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-page/dynamic-params/123"
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/in-page/dynamic-params/456"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          only cookies
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-page/cookies-only"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2>
+        <code>use cache: private</code>
+      </h2>
+      <ul>
+        <li>
+          cookies in private cache + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/cookies"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          dynamic params in private cache + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/dynamic-params/123"
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/dynamic-params/456"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          search params in private cache + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/search-params?searchParam=123"
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/search-params?searchParam=456"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          only cookies in private cache
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/cookies-only"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          Date.now() in private cache
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/in-private-cache/date-now"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2>short-lived caches</h2>
+      <ul>
+        <li>
+          private, short stale
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/private-short-stale"
+                prefetch={'auto'}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/private-short-stale"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          public, short expire, long enough stale
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/public-short-expire-long-stale"
+                prefetch={'auto'}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/public-short-expire-long-stale"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          public, short expire, short stale
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/public-short-expire-short-stale"
+                prefetch={'auto'}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/public-short-expire-short-stale"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2>misc</h2>
+      <ul>
+        <li>
+          <DebugLinkAccordion href="/fully-static" prefetch={true} />
+        </li>
+      </ul>
+
+      <h2>errors</h2>
+      <ul>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/error-after-cookies"
+            prefetch={true}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-cookies"
+            prefetch={true}
+          />
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/shared.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/shared.tsx
@@ -1,0 +1,34 @@
+import { unstable_cacheLife } from 'next/cache'
+import { setTimeout } from 'timers/promises'
+
+export async function uncachedIO() {
+  await setTimeout(500)
+}
+
+export async function cachedDelay(time: number, cacheBuster?: any) {
+  'use cache'
+  unstable_cacheLife('minutes')
+  console.log('cachedDelay', time, cacheBuster)
+  await setTimeout(time)
+}
+
+export function DebugRenderKind() {
+  const { workUnitAsyncStorage } =
+    require('next/dist/server/app-render/work-unit-async-storage.external') as typeof import('next/dist/server/app-render/work-unit-async-storage.external')
+  const workUnitStore = workUnitAsyncStorage.getStore()!
+  return (
+    <div>
+      workUnitStore.type: {workUnitStore.type}
+      {(() => {
+        switch (workUnitStore.type) {
+          case 'prerender':
+            return '(static prefetch)'
+          case 'prerender-runtime':
+            return '(runtime prefetch)'
+          default:
+            return null
+        }
+      })()}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -1,0 +1,41 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
+import { connection } from 'next/server'
+import { lang } from 'next/root-params'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses root params and some uncached IO. Root params should
+        always be available in static prerenders, so a runtime prefetch should
+        have them too.
+      </p>
+      <StaticallyPrefetchable />
+    </main>
+  )
+}
+
+async function StaticallyPrefetchable() {
+  const currentLang = await lang()
+  await cachedDelay(500, [__filename, currentLang])
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="root-param-value">{`Lang: ${currentLang}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -1,0 +1,50 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
+import { connection } from 'next/server'
+import { lang } from 'next/root-params'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses root params (inside a private cache) and some uncached
+        IO. Private caches are only rendered during runtime prefetches and
+        navigation requests, so they won't be part of a static prefetch, but
+        they should be part of a runtime prefetch.
+      </p>
+      <Suspense fallback="Loading 1...">
+        <DynamicallyPrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function DynamicallyPrefetchable() {
+  const currentLang = await privateCache()
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="root-param-value">{`Lang: ${currentLang}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function privateCache() {
+  'use cache: private'
+  const currentLang = await lang()
+  await cachedDelay(500, [__filename, currentLang])
+  return currentLang
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/layout.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { lang } from 'next/root-params'
+import { ReactNode } from 'react'
+
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const currentLang = await lang()
+  return (
+    <html lang={currentLang}>
+      <body style={{ fontFamily: 'monospace' }}>
+        <Header />
+        {children}
+      </body>
+    </html>
+  )
+}
+
+async function Header() {
+  const currentLang = await lang()
+  return (
+    <header>
+      <Link href={`/with-root-param/${currentLang}`} prefetch={false}>
+        Home (for lang: {currentLang})
+      </Link>
+    </header>
+  )
+}
+
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/page.tsx
@@ -1,0 +1,56 @@
+import { lang } from 'next/root-params'
+import { DebugLinkAccordion } from '../../../components/link-accordion'
+
+export default async function Page() {
+  const currentLang = await lang()
+  const otherLang = currentLang === 'en' ? 'de' : 'en'
+  return (
+    <main>
+      <h1>Home - with root param ({currentLang})</h1>
+
+      <h2>directly in a page</h2>
+      <ul>
+        <li>
+          root params + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href={`/with-root-param/${currentLang}/in-page/root-params`}
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href={`/with-root-param/${otherLang}/in-page/root-params`}
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2>
+        <code>use cache: private</code>
+      </h2>
+      <ul>
+        <li>
+          root params + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href={`/with-root-param/${currentLang}/in-private-cache/root-params`}
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href={`/with-root-param/${otherLang}/in-private-cache/root-params`}
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/components/error-boundary.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/components/error-boundary.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React from 'react'
+
+export class ErrorBoundary extends React.Component<{
+  children: React.ReactNode
+}> {
+  state = { error: null }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div id="error-boundary">
+          Error boundary: {this.state.error.message}
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/components/link-accordion.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { ComponentProps, useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+        data-prefetch={getPrefetchKind(prefetch)}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}
+
+export function DebugLinkAccordion({
+  href,
+  prefetch,
+}: Omit<ComponentProps<typeof LinkAccordion>, 'children'>) {
+  const prefetchKind = getPrefetchKind(prefetch)
+  return (
+    <LinkAccordion href={href} prefetch={prefetch} data-prefetch={prefetch}>
+      {href} ({prefetchKind})
+    </LinkAccordion>
+  )
+}
+
+function getPrefetchKind(prefetch: LinkProps['prefetch']) {
+  switch (prefetch) {
+    case false:
+      return 'disabled'
+    case undefined:
+    case null:
+    case 'auto':
+      return 'auto'
+    case true:
+      return 'runtime'
+    case 'unstable_forceStale':
+      return 'full'
+    default:
+      prefetch satisfies never
+  }
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: { cacheComponents: true, clientSegmentCache: true },
+  productionBrowserSourceMaps: true,
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
@@ -1,0 +1,1055 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from '../router-act'
+
+describe('<Link prefetch={true}> (runtime prefetch)', () => {
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('disabled in development', () => {})
+    return
+  }
+
+  describe.each([
+    { description: 'in a page', prefix: 'in-page' },
+    { description: 'in a private cache', prefix: 'in-private-cache' },
+  ])('$description', ({ prefix }) => {
+    it('includes dynamic params, but not dynamic content', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      // Reveal the link to trigger a runtime prefetch for one value of the dynamic param
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/dynamic-params/123"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading dynamic params
+        {
+          includes: 'Param: 123',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Reveal the link to trigger a runtime prefetch for a different value of the dynamic param
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/dynamic-params/456"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading dynamic params
+        {
+          includes: 'Param: 456',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/${prefix}/dynamic-params/123"]`)
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('param-value').text()).toEqual(
+          'Param: 123'
+        )
+      })
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('param-value').text()).toEqual(
+        'Param: 123'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+
+      await browser.back()
+
+      // Reveal the link to the second page again. It should not be prefetched again
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/dynamic-params/456"]`
+        )
+        await linkToggle.click()
+      }, 'no-requests')
+
+      // Navigate to the other page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/${prefix}/dynamic-params/456"]`)
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('param-value').text()).toEqual(
+          'Param: 456'
+        )
+      })
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('param-value').text()).toEqual(
+        'Param: 456'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+    })
+
+    it('includes root params, but not dynamic content', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/with-root-param/en', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      // Reveal the link to trigger a runtime prefetch for one value of the root param
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/with-root-param/en/${prefix}/root-params"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading root params
+        {
+          includes: 'Lang: en',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Reveal the link to trigger a runtime prefetch for a different value of the root param
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/with-root-param/de/${prefix}/root-params"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading root params
+        {
+          includes: 'Lang: de',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the first page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(
+                `a[href="/with-root-param/en/${prefix}/root-params"]`
+              )
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('root-param-value').text()).toEqual(
+          'Lang: en'
+        )
+      })
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('root-param-value').text()).toEqual(
+        'Lang: en'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+
+      await browser.back()
+
+      // Reveal the link to the second page again. It should not be prefetched again
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/with-root-param/de/${prefix}/root-params"]`
+        )
+        await linkToggle.click()
+      }, 'no-requests')
+
+      // Navigate to the other page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(
+                `a[href="/with-root-param/de/${prefix}/root-params"]`
+              )
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('root-param-value').text()).toEqual(
+          'Lang: de'
+        )
+      })
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('root-param-value').text()).toEqual(
+        'Lang: de'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+    })
+
+    it('includes search params, but not dynamic content', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      // Reveal the link to trigger a runtime prefetch for one value of the search param
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/search-params?searchParam=123"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading search params
+        {
+          includes: 'Search param: 123',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Reveal the link to trigger a runtime prefetch for a different value of the search param
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/search-params?searchParam=456"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading search params
+        {
+          includes: 'Search param: 456',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(
+                `a[href="/${prefix}/search-params?searchParam=123"]`
+              )
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('search-param-value').text()).toEqual(
+          'Search param: 123'
+        )
+      })
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('search-param-value').text()).toEqual(
+        'Search param: 123'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+
+      await browser.back()
+
+      // Reveal the link to the second page again. It should not be prefetched again
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/search-params?searchParam=456"]`
+        )
+        await linkToggle.click()
+      }, 'no-requests')
+
+      // Navigate to the other page
+      await act(
+        async () => {
+          await browser
+            .elementByCss(`a[href="/${prefix}/search-params?searchParam=456"]`)
+            .click()
+        },
+        {
+          // Now the dynamic content should be fetched
+          includes: 'Dynamic content',
+        }
+      )
+      expect(await browser.elementById('search-param-value').text()).toEqual(
+        'Search param: 456'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+    })
+
+    it('includes cookies, but not dynamic content', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      // Clear cookies after the test. This currently doesn't happen automatically.
+      await using _ = defer(() => browser.deleteCookies())
+
+      const act = createRouterAct(page)
+
+      await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+      // Reveal the link to trigger a runtime prefetch for the initial cookie value
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/cookies"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading cookies
+        {
+          includes: 'Cookie: initialValue',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser.elementByCss(`a[href="/${prefix}/cookies"]`).click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('cookie-value').text()).toEqual(
+          'Cookie: initialValue'
+        )
+      })
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('cookie-value').text()).toEqual(
+        'Cookie: initialValue'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+
+      // Update the cookie via a server action.
+      // This should cause the client cache to be dropped,
+      // so the page should get prefetched again when the link becomes visible
+      await browser.elementByCss('input[name="cookie"]').type('updatedValue')
+      await browser.elementByCss('[type="submit"]').click()
+
+      // Go back to the previous page
+      await browser.back()
+
+      // Reveal the link again to trigger a runtime prefetch for the new value of the cookie
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/cookies"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading dynamic params
+        {
+          includes: 'Cookie: updatedValue',
+        },
+        // Should not prefetch the dynamic content
+        {
+          includes: 'Dynamic content',
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser.elementByCss(`a[href="/${prefix}/cookies"]`).click()
+          },
+          {
+            includes: 'Dynamic content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('cookie-value').text()).toEqual(
+          'Cookie: updatedValue'
+        )
+      })
+
+      expect(await browser.elementById('cookie-value').text()).toEqual(
+        'Cookie: updatedValue'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+    })
+
+    it('can completely prefetch a page that uses cookies and no uncached IO', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      // Clear cookies after the test. This currently doesn't happen automatically.
+      await using _ = defer(() => browser.deleteCookies())
+
+      const act = createRouterAct(page)
+
+      await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+      // Reveal the link to trigger a runtime prefetch for the initial cookie value
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/${prefix}/cookies-only"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should allow reading cookies
+        {
+          includes: 'Cookie: initialValue',
+        },
+      ])
+
+      // Navigate to the page.
+      await act(
+        async () => {
+          await browser
+            .elementByCss(`a[href="/${prefix}/cookies-only"]`)
+            .click()
+        },
+        // The page doesn't use any other IO, so we prefetched it completely, and shouldn't issue any more requests.
+        'no-requests'
+      )
+      expect(await browser.elementById('cookie-value').text()).toEqual(
+        'Cookie: initialValue'
+      )
+    })
+  })
+
+  describe('should not cache runtime prefetch responses in the browser cache or server-side', () => {
+    // This is a bit difficult to test, but we can request the same thing repeatedly and expect different results.
+
+    it.each([
+      { description: 'in a page', prefix: 'in-page' },
+      { description: 'in a private cache', prefix: 'in-private-cache' },
+    ])(
+      'different cookies should return different prefetch results - $description',
+      async ({ prefix }) => {
+        let page: Playwright.Page
+        const browser = await next.browser('/', {
+          beforePageLoad(p: Playwright.Page) {
+            page = p
+          },
+        })
+        // Clear cookies after the test. This currently doesn't happen automatically.
+        await using _ = defer(() => browser.deleteCookies())
+
+        const act = createRouterAct(page)
+
+        await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+        // Reveal the link to trigger a runtime prefetch for the initial cookie value
+        await act(async () => {
+          const linkToggle = await browser.elementByCss(
+            `input[data-link-accordion="/${prefix}/cookies-only"]`
+          )
+          await linkToggle.click()
+        }, [
+          // Should allow reading cookies
+          {
+            includes: 'Cookie: initialValue',
+          },
+        ])
+
+        // Reload the page with a new cookie value
+        await browser.addCookie({ name: 'testCookie', value: 'updatedValue' })
+        await browser.refresh()
+
+        // Reveal the link to trigger a runtime prefetch for the updated cookie value.
+        await act(async () => {
+          const linkToggle = await browser.elementByCss(
+            `input[data-link-accordion="/${prefix}/cookies-only"]`
+          )
+          await linkToggle.click()
+        }, [
+          // The response shouldn't be cached in the browser or on the server.
+          // If it was, we'd get a stale value here.
+          {
+            includes: 'Cookie: updatedValue',
+          },
+        ])
+      }
+    )
+
+    it('private caches should return new results on each request', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      // Clear cookies after the test. This currently doesn't happen automatically.
+      await using _ = defer(() => browser.deleteCookies())
+
+      const act = createRouterAct(page)
+
+      // Reveal the link to trigger the first runtime prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/in-private-cache/date-now"]`
+        )
+        await linkToggle.click()
+      }, [
+        // The timestamp value is in a private cache, so it should be included
+        {
+          includes: 'Timestamp: ',
+        },
+      ])
+
+      // Navigate to the page to reveal the runtime-prefetched content, and save the timestamp value it had
+      let firstTimestampValue: string
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/in-private-cache/date-now"]`)
+              .click()
+          },
+          // Temporarily block the navigation request.
+          // The prefetched parts of the tree should be visible before it finishes.
+          'block'
+        )
+        firstTimestampValue = await browser.elementById('timestamp').text()
+      })
+
+      // Go back to the initial page and reload it to clear the client router cache
+      await browser.back()
+      await browser.refresh()
+
+      // Reveal the link to trigger the second runtime prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/in-private-cache/date-now"]`
+        )
+        await linkToggle.click()
+      }, [
+        // The timestamp value is in a private cache, so it should be included
+        {
+          includes: 'Timestamp: ',
+        },
+      ])
+
+      // Navigate to the page to reveal the runtime-prefetched content, and save the timestamp value it had
+      let secondTimestampValue: string
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/in-private-cache/date-now"]`)
+              .click()
+          },
+          // Temporarily block the navigation request.
+          // The prefetched parts of the tree should be visible before it finishes.
+          'block'
+        )
+        secondTimestampValue = await browser.elementById('timestamp').text()
+      })
+
+      // If the runtime prefetch response wasn't cached, the responses should be different
+      expect(firstTimestampValue).not.toEqual(secondTimestampValue)
+    })
+  })
+
+  it('can completely prefetch a page that is fully static', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+
+    const act = createRouterAct(page)
+
+    // Reveal the link to trigger a runtime prefetch for the page
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        `input[data-link-accordion="/fully-static"]`
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Hello from a fully static page!',
+      },
+    ])
+
+    // Navigate to the page.
+    await act(
+      async () => {
+        await browser.elementByCss(`a[href="/fully-static"]`).click()
+      },
+      // The page doesn't use any IO, so we prefetched it completely, and shouldn't issue any more requests.
+      'no-requests'
+    )
+    expect(await browser.elementByCss('p#intro').text()).toBe(
+      'Hello from a fully static page!'
+    )
+  })
+
+  describe('cache stale time handling', () => {
+    it('includes short-lived public caches with a long enough staleTime', async () => {
+      // If a cache has an expiration time under 5min (DYNAMIC_EXPIRE), we omit it from static prerenders.
+      // However, it should still be included in a runtime prefetch if it's stale time is above 30s. (RUNTIME_PREFETCH_DYNAMIC_STALE)
+
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      const STATIC_CONTENT = 'This page uses a short-lived public cache'
+      const DYNAMICALLY_PREFETCHABLE_CONTENT = 'Short-lived cached content'
+
+      // Reveal the link to trigger a static prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="auto"][data-link-accordion="/caches/public-short-expire-long-stale"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the static shell
+        {
+          includes: STATIC_CONTENT,
+        },
+        // Should not include the short-lived cache
+        // (We set the `expire` value to be under 5min, so it will be excluded from prerenders)
+        {
+          includes: DYNAMICALLY_PREFETCHABLE_CONTENT,
+          block: 'reject',
+        },
+      ])
+
+      // Reveal the link to trigger a runtime prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="runtime"][data-link-accordion="/caches/public-short-expire-long-stale"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the short-lived cache
+        // (We set `stale` to be above 30s, which means it shouldn't be omitted)
+        {
+          includes: DYNAMICALLY_PREFETCHABLE_CONTENT,
+        },
+      ])
+
+      // Navigate to the page. We didn't include any uncached IO, so the page is fully prefetched,
+      // and this shouldn't issue any more requests
+      await act(async () => {
+        await browser
+          .elementByCss(`a[href="/caches/public-short-expire-long-stale"]`)
+          .click()
+      }, 'no-requests')
+
+      expect(await browser.elementByCss('main').text()).toInclude(
+        DYNAMICALLY_PREFETCHABLE_CONTENT
+      )
+    })
+
+    it('omits short-lived public caches with a short enough staleTime', async () => {
+      // If a cache has a stale time below 30s (RUNTIME_PREFETCH_DYNAMIC_STALE), we should omit it from runtime prefetches.
+
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      const STATIC_CONTENT = 'This page uses a short-lived public cache'
+      const DYNAMIC_CONTENT = 'Short-lived cached content'
+
+      // Reveal the link to trigger a static prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="auto"][data-link-accordion="/caches/public-short-expire-short-stale"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the static shell
+        {
+          includes: STATIC_CONTENT,
+        },
+        // Should not include the short-lived cache
+        // (We set the `expire` value to be under 5min, so it will be excluded from prerenders)
+        {
+          includes: DYNAMIC_CONTENT,
+          block: 'reject',
+        },
+      ])
+
+      // Reveal the link to trigger a runtime prefetch.
+      // It'll essentially be the same as the static prefetch, because the only dynamic hole
+      // will be omitted from both.
+      // (NOTE: in the future, we might prevent scenarios like this via `generatePrefetch`)
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="runtime"][data-link-accordion="/caches/public-short-expire-short-stale"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the shell
+        {
+          includes: STATIC_CONTENT,
+        },
+        // Should not include the short-lived cache
+        // (We set the `stale` value to be under 30s, so it will be excluded from runtime prerenders)
+        {
+          includes: DYNAMIC_CONTENT,
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/caches/public-short-expire-short-stale"]`)
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The prefetched parts of the tree should be visible before it finishes.
+            includes: DYNAMIC_CONTENT,
+            block: true,
+          }
+        )
+        expect(await browser.elementById('intro').text()).toInclude(
+          STATIC_CONTENT
+        )
+      })
+
+      // After navigating, we should see both the parts that we prefetched and the short lived cache.
+      expect(await browser.elementById('intro').text()).toInclude(
+        STATIC_CONTENT
+      )
+      expect(await browser.elementById('cached-value').text()).toMatch(/\d+/)
+    })
+
+    it('omits private caches with a short enough staleTime', async () => {
+      // If a cache has a stale time below 30s (RUNTIME_PREFETCH_DYNAMIC_STALE), we should omit it from runtime prefetches.
+
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      const STATIC_CONTENT = 'This page uses a short-lived private cache'
+      const DYNAMIC_CONTENT = 'Short-lived cached content'
+
+      // Reveal the link to trigger a static prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="auto"][data-link-accordion="/caches/private-short-stale"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the static shell
+        {
+          includes: STATIC_CONTENT,
+        },
+        // Should not include the short-lived cache
+        // (We set the `expire` value to be under 5min, so it will be excluded from prerenders)
+        {
+          includes: DYNAMIC_CONTENT,
+          block: 'reject',
+        },
+      ])
+
+      // Reveal the link to trigger a runtime prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="runtime"][data-link-accordion="/caches/private-short-stale"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the shell
+        {
+          includes: STATIC_CONTENT,
+        },
+        // Should not prefetch the short-lived cache
+        // (We set the `stale` value to be under 30s, so it will be excluded from runtime prefetches)
+        {
+          includes: DYNAMIC_CONTENT,
+          block: 'reject',
+        },
+      ])
+
+      // Navigate to the page
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/caches/private-short-stale"]`)
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: DYNAMIC_CONTENT,
+            block: true,
+          }
+        )
+        expect(await browser.elementById('intro').text()).toInclude(
+          STATIC_CONTENT
+        )
+      })
+
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      expect(await browser.elementById('intro').text()).toInclude(
+        STATIC_CONTENT
+      )
+      const cachedValue1 = await browser.elementById('cached-value').text()
+      expect(cachedValue1).toMatch(/\d+/)
+
+      // Try navigating again. The cache is private, so we should see a different timestamp
+      await browser.back()
+
+      // Reveal the link again. The prefetch should be cached, so we shouldn't see any requests
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-link-accordion="/caches/private-short-stale"]`
+        )
+        await linkToggle.click()
+      }, 'no-requests')
+
+      // Navigate to the page again
+      await act(async () => {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`a[href="/caches/private-short-stale"]`)
+              .click()
+          },
+          {
+            // Temporarily block the navigation request.
+            // The runtime-prefetched parts of the tree should be visible before it finishes.
+            includes: 'Short-lived cached content',
+            block: true,
+          }
+        )
+        expect(await browser.elementById('intro').text()).toInclude(
+          STATIC_CONTENT
+        )
+      })
+
+      // After navigating, we should see both the parts that we prefetched and dynamic content.
+      // The private cache was omitted from the runtime prefetch, so we didn't cache it in the router,
+      // and it was not cached server-side either, so we should get a different value than the previous request.
+      const cachedValue2 = await browser.elementById('cached-value').text()
+      expect(cachedValue2).toMatch(/\d+/)
+
+      expect(cachedValue1).not.toEqual(cachedValue2)
+    })
+  })
+
+  describe('errors', () => {
+    it('aborts the prerender and logs an error when sync IO is used after cookies()', async () => {
+      // In a runtime prefetch, we might encounter sync IO usages that weren't caught during build,
+      // because they were hidden behind e.g. a cookies() call.
+      // We currently have no way to catch these statically.
+      // In that case, we should abort the prerender, but still return partial content.
+
+      // TODO: this doesn't work as well as it could, see comment before the navigation
+
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      const STATIC_CONTENT = 'This page performs sync IO after a cookies() call'
+
+      // Reveal the link to trigger a runtime prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="runtime"][data-link-accordion="/errors/sync-io-after-cookies"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the shell
+        {
+          includes: STATIC_CONTENT,
+        },
+        // Should abort the render when sync IO is encountered,
+        // so this should never be included
+        {
+          includes: 'Timestamp',
+          block: 'reject',
+        },
+      ])
+
+      if (!isNextDeploy) {
+        expect(next.cliOutput).toContain(
+          'Error: Route "/errors/sync-io-after-cookies" used `Date.now()` instead of using `performance` or without explicitly calling `await connection()` beforehand.'
+        )
+      }
+
+      // TODO(runtime-ppr): we should be able to display the (aborted, partial) prefetched contents before navigating,
+      // but it seems like when we abort the render, we're also inadvertently cutting off some promises related to metadata
+      // which end up suspending on the client and blocking react from rendering.
+      // Ideally, we'd be able to use the partial result, but this is an error scenario and we don't crash,
+      // so i'm just settling for that for now.
+
+      // Navigate to the page
+      await act(
+        async () => {
+          await browser
+            .elementByCss(`a[href="/errors/sync-io-after-cookies"]`)
+            .click()
+        },
+        {
+          includes: 'Timestamp',
+        }
+      )
+
+      // After navigating, we should see the sync IO result that we omitted from the prefetch.
+      expect(await browser.elementById('intro').text()).toInclude(
+        STATIC_CONTENT
+      )
+      expect(await browser.elementById('timestamp').text()).toMatch(
+        /Timestamp: \d+/
+      )
+    })
+
+    it('should trigger error boundaries for errors that occurred in runtime-prefetched content', async () => {
+      // A thrown error in the prerender should not stop us from sending a prefetch response.
+      // This should work without any extra effort, but I'm adding a test for it as a sanity check.
+
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      const STATIC_CONTENT = 'This page errors after a cookies call'
+
+      // Reveal the link to trigger a runtime prefetch
+      await act(async () => {
+        const linkToggle = await browser.elementByCss(
+          `input[data-prefetch="runtime"][data-link-accordion="/errors/error-after-cookies"]`
+        )
+        await linkToggle.click()
+      }, [
+        // Should include the shell
+        {
+          includes: STATIC_CONTENT,
+        },
+      ])
+
+      if (!isNextDeploy) {
+        expect(next.cliOutput).toContain('Error: Kaboom')
+      }
+
+      // Navigate to the page. We already have the paged cached.
+      // Even though the render errored, we shouldn't fetch it again.
+      await act(async () => {
+        await browser
+          .elementByCss(`a[href="/errors/error-after-cookies"]`)
+          .click()
+      }, 'no-requests')
+
+      // After navigating, we should see the sync IO result that we omitted from the prefetch.
+      expect(await browser.elementById('intro').text()).toInclude(
+        STATIC_CONTENT
+      )
+      expect(await browser.elementById('error-boundary').text()).toInclude(
+        'Error boundary: An error occurred in the Server Components render'
+      )
+    })
+  })
+})
+
+function defer(callback: () => Promise<void>) {
+  return {
+    [Symbol.asyncDispose]: callback,
+  }
+}

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
@@ -10,16 +10,17 @@ export default function RefetchOnNewBaseTreeLayout({
       <div style={{ backgroundColor: 'lightgray', padding: '1rem' }}>
         <p>
           This demonstrates what happens when a link is prefetched using{' '}
-          <code>{'prefetch={true}'}</code> and the URL changes. Next.js should
-          re-prefetch the link in case the delta between the base tree and the
-          target tree has changed.
+          <code>{'prefetch="unstable_forceStale"'}</code> and the URL changes.
+          Next.js should re-prefetch the link in case the delta between the base
+          tree and the target tree has changed.
         </p>
         <p>
           Everything in this gray section is part of a shared layout. The links
-          below are prefetched using <code>{'prefetch={true}'}</code>. If the
-          first loaded page is "/refetch-on-new-base-tree/a", the prefetch for
-          this link will be empty, because there's no delta between the base
-          tree and the target tree.
+          below are prefetched using{' '}
+          <code>{'prefetch="unstable_forceStale"'}</code>. If the first loaded
+          page is "/refetch-on-new-base-tree/a", the prefetch for this link will
+          be empty, because there's no delta between the base tree and the
+          target tree.
         </p>
         <p>
           However, if you then navigate to page B, we should re-prefetch the
@@ -48,10 +49,16 @@ export default function RefetchOnNewBaseTreeLayout({
             because it was fully prefetched.
           </li>
         </ul>
-        <LinkAccordion prefetch={true} href="/refetch-on-new-base-tree/a">
+        <LinkAccordion
+          prefetch="unstable_forceStale"
+          href="/refetch-on-new-base-tree/a"
+        >
           Page A
         </LinkAccordion>
-        <LinkAccordion prefetch={true} href="/refetch-on-new-base-tree/b">
+        <LinkAccordion
+          prefetch="unstable_forceStale"
+          href="/refetch-on-new-base-tree/b"
+        >
           Page B
         </LinkAccordion>
       </div>

--- a/test/e2e/app-dir/segment-cache/revalidation/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import Form from 'next/form'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
@@ -12,7 +12,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
 }) {
   const [isVisible, setIsVisible] = useState(false)
   return (
@@ -92,6 +92,9 @@ export function ManualPrefetchLinkAccordion({
   )
 }
 
+type Router = ReturnType<typeof useRouter>
+type PrefetchOptions = Parameters<Router['prefetch']>[1]
+
 function ManualPrefetchLink({
   href,
   children,
@@ -109,8 +112,8 @@ function ManualPrefetchLink({
       let didUnmount = false
       const pollPrefetch = () => {
         if (!didUnmount) {
-          // @ts-expect-error: onInvalidate is not yet part of public types
           router.prefetch(href, {
+            kind: 'auto' as PrefetchOptions['kind'],
             onInvalidate: pollPrefetch,
           })
         }

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -272,7 +272,7 @@ describe('segment cache (revalidation)', () => {
         includes: 'Page B content',
       },
       // Page A's content should not be prefetched because we're already on that
-      // page. When prefetching with `prefetch={true}`, we only prefetch the
+      // page. When prefetching with `prefetch='unstable_forceStale'`, we only prefetch the
       // delta between the current route and the target route.
       {
         includes: 'Page A content',

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
@@ -19,10 +19,10 @@ export default function SearchParamsPage({
         </li>
         <li>
           <LinkAccordion
-            prefetch={true}
+            prefetch="unstable_forceStale"
             href="/search-params/target-page?searchParam=b_full"
           >
-            searchParam=b_full, prefetch=true
+            searchParam=b_full, prefetch="unstable_forceStale"
           </LinkAccordion>
         </li>
         <li>
@@ -32,10 +32,10 @@ export default function SearchParamsPage({
         </li>
         <li>
           <LinkAccordion
-            prefetch={true}
+            prefetch="unstable_forceStale"
             href="/search-params/target-page?searchParam=d_full"
           >
-            searchParam=d_full, prefetch=true
+            searchParam=d_full, prefetch="unstable_forceStale"
           </LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/search-params/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/components/link-accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
 export function LinkAccordion({
@@ -10,7 +10,7 @@ export function LinkAccordion({
 }: {
   href: string
   children: React.ReactNode
-  prefetch?: boolean
+  prefetch?: LinkProps['prefetch']
 }) {
   const [isVisible, setIsVisible] = useState(false)
   return (

--- a/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
@@ -67,7 +67,7 @@ describe('segment cache (search params)', () => {
     expect(await result.innerText()).toBe('Search param: c_PPR')
   })
 
-  it('when fetching without PPR (e.g. prefetch={true}), includes the search params in the cache key', async () => {
+  it('when fetching without PPR (e.g. prefetch="unstable_forceStale"), includes the search params in the cache key', async () => {
     let act: ReturnType<typeof createRouterAct>
     const browser = await next.browser('/search-params', {
       beforePageLoad(page) {
@@ -75,7 +75,7 @@ describe('segment cache (search params)', () => {
       },
     })
 
-    // Prefetch a page with search param `b_full`. This link has prefetch={true}
+    // Prefetch a page with search param `b_full`. This link has prefetch='unstable_forceStale'
     // so it will fetch the entire page, including the search param.
     const revealB = await browser.elementByCss(
       'input[data-link-accordion="/search-params/target-page?searchParam=b_full"]'
@@ -91,7 +91,7 @@ describe('segment cache (search params)', () => {
     )
 
     // Prefetch a link with a different search param, and without
-    // prefetch={true}. This must fetch a new shell, because it can't use the
+    // prefetch='unstable_forceStale'. This must fetch a new shell, because it can't use the
     // entry we fetched for `searchParam=b_full` (because that one wasn't a
     // shell — it included the search param).
     const revealA = await browser.elementByCss(
@@ -106,7 +106,7 @@ describe('segment cache (search params)', () => {
       { includes: 'target-page-with-search-param' }
     )
 
-    // Prefetch a different link using prefetch={true}. Again, this must issue
+    // Prefetch a different link using prefetch='unstable_forceStale'. Again, this must issue
     // a new request, because it's a full page prefetch and we haven't fetched
     // this particular search param before.
     // TODO: As an future optimization, if a navigation to this link occurs

--- a/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
@@ -21,6 +21,16 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
+          <LinkAccordion href="/runtime-stale-5-minutes" prefetch={true}>
+            Page whose runtime prefetch has a stale time of 5 minutes
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/runtime-stale-10-minutes" prefetch={true}>
+            Page whose runtime prefetch has a stale time of 10 minutes
+          </LinkAccordion>
+        </li>
+        <li>
           <LinkAccordion href="/dynamic">Page with dynamic data</LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-10-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-10-minutes/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { unstable_cacheLife as cacheLife } from 'next/cache'
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <RuntimePrefetchable />
+    </Suspense>
+  )
+}
+
+async function RuntimePrefetchable() {
+  // Prevent this content from appearing in a regular prerender,
+  // But allow it to be included in a runtime prefetch.
+  await cookies()
+
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}
+
+async function Content() {
+  'use cache'
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  cacheLife({ stale: 10 * 60 })
+  return 'Content with stale time of 10 minutes'
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-5-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-5-minutes/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { unstable_cacheLife as cacheLife } from 'next/cache'
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <RuntimePrefetchable />
+    </Suspense>
+  )
+}
+
+async function RuntimePrefetchable() {
+  // Prevent this content from appearing in a regular prerender,
+  // But allow it to be included in a runtime prefetch.
+  await cookies()
+
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}
+
+async function Content() {
+  'use cache'
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  cacheLife({ stale: 5 * 60 })
+  return 'Content with stale time of 5 minutes'
+}

--- a/test/e2e/app-dir/segment-cache/staleness/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/components/link-accordion.tsx
@@ -1,9 +1,17 @@
 'use client'
 
-import Link from 'next/link'
+import Link, { LinkProps } from 'next/link'
 import { useState } from 'react'
 
-export function LinkAccordion({ href, children }) {
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
   const [isVisible, setIsVisible] = useState(false)
   return (
     <>
@@ -14,7 +22,9 @@ export function LinkAccordion({ href, children }) {
         data-link-accordion={href}
       />
       {isVisible ? (
-        <Link href={href}>{children}</Link>
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
       ) : (
         `${children} (link is hidden)`
       )}

--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
@@ -79,6 +79,74 @@ describe('segment cache (staleness)', () => {
     )
   })
 
+  it('expires runtime prefetches when their stale time has elapsed', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    await page.clock.install()
+
+    // Reveal the links to trigger a runtime prefetch
+    const toggle5MinutesLink = await browser.elementByCss(
+      'input[data-link-accordion="/runtime-stale-5-minutes"]'
+    )
+    const toggle10MinutesLink = await browser.elementByCss(
+      'input[data-link-accordion="/runtime-stale-10-minutes"]'
+    )
+    await act(
+      async () => {
+        await toggle5MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-5-minutes"]')
+      },
+      {
+        includes: 'Content with stale time of 5 minutes',
+      }
+    )
+    await act(
+      async () => {
+        await toggle10MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-10-minutes"]')
+      },
+      {
+        includes: 'Content with stale time of 10 minutes',
+      }
+    )
+
+    // Hide the links
+    await toggle5MinutesLink.click()
+    await toggle10MinutesLink.click()
+
+    // Fast forward 5 minutes and 1 millisecond
+    await page.clock.fastForward(5 * 60 * 1000 + 1)
+
+    // Reveal the links again to trigger new prefetch tasks
+    await act(
+      async () => {
+        await toggle5MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-5-minutes"]')
+      },
+      // The page with a stale time of 5 minutes is requested again
+      // because its stale time elapsed.
+      {
+        includes: 'Content with stale time of 5 minutes',
+      }
+    )
+
+    await act(
+      async () => {
+        await toggle10MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-10-minutes"]')
+      },
+      // The page with a stale time of 10 minutes is *not* requested again
+      // because it's still fresh.
+      'no-requests'
+    )
+  })
+
   it('reuses dynamic data up to the staleTimes.dynamic threshold', async () => {
     let page: Playwright.Page
     const startDate = Date.now()

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -86,7 +86,7 @@ describe('next-link', () => {
     if (isNextDev) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Failed prop type: The prop \`prefetch\` expects a \`boolean | "auto"\` in \`<Link>\`, but got \`string\` instead.
+         "description": "Failed prop type: The prop \`prefetch\` expects a \`boolean | "auto" | "unstable_forceStale"\` in \`<Link>\`, but got \`string\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
          "label": "Runtime Error",


### PR DESCRIPTION
the split into `createPrerenderPathname` and `createRenderPathname` was making the code more complicated than it needed to be, i've inlined all the cases instead

---
🔄 **This is a mirror of [upstream PR #82197](https://github.com/vercel/next.js/pull/82197)**