### PR TITLE
[devtool] bump base-ui to 1.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,8 +307,7 @@
       "stacktrace-parser@0.1.10": "patches/stacktrace-parser@0.1.10.patch",
       "@ampproject/toolbox-optimizer@2.8.3": "patches/@ampproject__toolbox-optimizer@2.8.3.patch",
       "@types/node@20.17.6": "patches/@types__node@20.17.6.patch",
-      "taskr@1.1.0": "patches/taskr@1.1.0.patch",
-      "@base-ui-components/react@1.0.0-beta.1": "patches/@base-ui-components__react@1.0.0-beta.1.patch"
+      "taskr@1.1.0": "patches/taskr@1.1.0.patch"
     }
   }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -160,7 +160,7 @@
     "@babel/runtime": "7.27.0",
     "@babel/traverse": "7.27.0",
     "@babel/types": "7.27.0",
-    "@base-ui-components/react": "1.0.0-beta.1",
+    "@base-ui-components/react": "1.0.0-beta.2",
     "@capsizecss/metrics": "3.4.0",
     "@edge-runtime/cookies": "6.0.0",
     "@edge-runtime/ponyfill": "4.0.0",

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -37,7 +37,6 @@ export function SegmentBoundaryTrigger({
     const portalNode = ownerDocument.querySelector('nextjs-portal')!
     return portalNode.shadowRoot! as ShadowRoot
   })
-  const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const popupRef = useRef<HTMLDivElement>(null)
 
@@ -164,8 +163,7 @@ export function SegmentBoundaryTrigger({
         disabled={!hasBoundary}
       />
 
-      {/* @ts-expect-error remove this expect-error once shadowRoot is supported as container */}
-      <Menu.Portal container={shadowRootRef}>
+      <Menu.Portal container={shadowRoot}>
         <Menu.Positioner
           className="segment-boundary-dropdown-positioner"
           side="bottom"

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef, useState } from 'react'
+import { forwardRef, useState } from 'react'
 import { Tooltip as BaseTooltip } from '@base-ui-components/react/tooltip'
 import { cx } from '../../utils/cx'
 import './tooltip.css'
@@ -31,7 +31,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       const portalNode = ownerDocument.querySelector('nextjs-portal')!
       return portalNode.shadowRoot! as ShadowRoot
     })
-    const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
     if (!title) {
       return children
     }
@@ -45,9 +44,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
             }}
           />
 
-          {/* x-ref: https://github.com/mui/base-ui/issues/2224 */}
-          {/* @ts-expect-error remove this expect-error once shadowRoot is supported as container */}
-          <BaseTooltip.Portal container={shadowRootRef}>
+          <BaseTooltip.Portal container={shadowRoot}>
             <BaseTooltip.Positioner
               side={direction}
               sideOffset={offset + arrowSize}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ patchedDependencies:
   '@ampproject/toolbox-optimizer@2.8.3':
     hash: baeiwbdq3sqmjnnh2lznmpb5bu
     path: patches/@ampproject__toolbox-optimizer@2.8.3.patch
-  '@base-ui-components/react@1.0.0-beta.1':
-    hash: husdbmnwfarofaw5whjzcd7l2a
-    path: patches/@base-ui-components__react@1.0.0-beta.1.patch
   '@types/node@20.17.6':
     hash: rvl3vkomen3tospgr67bzubfyu
     path: patches/@types__node@20.17.6.patch
@@ -1019,8 +1016,8 @@ importers:
         specifier: 7.27.0
         version: 7.27.0
       '@base-ui-components/react':
-        specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(patch_hash=husdbmnwfarofaw5whjzcd7l2a)(@types/react@19.1.8)(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2(@types/react@19.1.8)(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)
       '@capsizecss/metrics':
         specifier: 3.4.0
         version: 3.4.0
@@ -2754,9 +2751,19 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui-components/react@1.0.0-beta.1':
-    resolution: {integrity: sha512-7zmGiz4/+HKnv99lWftItoSMqnj2PdSvt2krh0/GP+Rj0xK0NMnFI/gIVvP7CB2G+k0JPUrRWXjXa3y08oiakg==}
+  '@base-ui-components/react@1.0.0-beta.2':
+    resolution: {integrity: sha512-jfAUfSgXvsfr8mQi7r/6gLG8U1Ybr77NN8WK5IXXM0c/hBvFDBtvUfwDJACV0gXiYbSKpA+dRzZz01V1tULobA==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': 19.1.8
+      react: 19.2.0-canary-9be531cd-20250729
+      react-dom: 19.2.0-canary-9be531cd-20250729
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui-components/utils@0.1.0':
+    resolution: {integrity: sha512-9+uaWyF1o/PgXqHLJnC81IIG0HlV3o9eFCQ5hWZDMx5NHrFk0rrwqEFGQOB8lti/rnbxNPi+kYYw1D4e8xSn/Q==}
     peerDependencies:
       '@types/react': 19.1.8
       react: 19.2.0-canary-9be531cd-20250729
@@ -3647,14 +3654,14 @@ packages:
   '@floating-ui/core@1.6.2':
     resolution: {integrity: sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==}
 
-  '@floating-ui/core@1.7.2':
-    resolution: {integrity: sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==}
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
   '@floating-ui/dom@1.6.5':
     resolution: {integrity: sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==}
 
-  '@floating-ui/dom@1.7.2':
-    resolution: {integrity: sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==}
+  '@floating-ui/dom@1.7.3':
+    resolution: {integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==}
 
   '@floating-ui/react-dom@2.1.0':
     resolution: {integrity: sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==}
@@ -3662,8 +3669,8 @@ packages:
       react: 19.2.0-canary-9be531cd-20250729
       react-dom: 19.2.0-canary-9be531cd-20250729
 
-  '@floating-ui/react-dom@2.1.4':
-    resolution: {integrity: sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==}
+  '@floating-ui/react-dom@2.1.5':
+    resolution: {integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==}
     peerDependencies:
       react: 19.2.0-canary-9be531cd-20250729
       react-dom: 19.2.0-canary-9be531cd-20250729
@@ -18236,15 +18243,27 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@base-ui-components/react@1.0.0-beta.1(patch_hash=husdbmnwfarofaw5whjzcd7l2a)(@types/react@19.1.8)(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)':
+  '@base-ui-components/react@1.0.0-beta.2(@types/react@19.1.8)(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)':
     dependencies:
       '@babel/runtime': 7.27.6
-      '@floating-ui/react-dom': 2.1.4(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)
+      '@base-ui-components/utils': 0.1.0(@types/react@19.1.8)(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)
+      '@floating-ui/react-dom': 2.1.5(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)
       '@floating-ui/utils': 0.2.10
       react: 19.2.0-canary-9be531cd-20250729
       react-dom: 19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729)
       reselect: 5.1.1
       tabbable: 6.2.0
+      use-sync-external-store: 1.5.0(react@19.2.0-canary-9be531cd-20250729)
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@base-ui-components/utils@0.1.0(@types/react@19.1.8)(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.0-canary-9be531cd-20250729
+      react-dom: 19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729)
+      reselect: 5.1.1
       use-sync-external-store: 1.5.0(react@19.2.0-canary-9be531cd-20250729)
     optionalDependencies:
       '@types/react': 19.1.8
@@ -19112,7 +19131,7 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.2
 
-  '@floating-ui/core@1.7.2':
+  '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
 
@@ -19121,9 +19140,9 @@ snapshots:
       '@floating-ui/core': 1.6.2
       '@floating-ui/utils': 0.2.2
 
-  '@floating-ui/dom@1.7.2':
+  '@floating-ui/dom@1.7.3':
     dependencies:
-      '@floating-ui/core': 1.7.2
+      '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
   '@floating-ui/react-dom@2.1.0(react-dom@19.2.0-canary-eaee5308-20250728(react@19.2.0-canary-eaee5308-20250728))(react@19.2.0-canary-eaee5308-20250728)':
@@ -19132,9 +19151,9 @@ snapshots:
       react: 19.2.0-canary-eaee5308-20250728
       react-dom: 19.2.0-canary-eaee5308-20250728(react@19.2.0-canary-eaee5308-20250728)
 
-  '@floating-ui/react-dom@2.1.4(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)':
+  '@floating-ui/react-dom@2.1.5(react-dom@19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729))(react@19.2.0-canary-9be531cd-20250729)':
     dependencies:
-      '@floating-ui/dom': 1.7.2
+      '@floating-ui/dom': 1.7.3
       react: 19.2.0-canary-9be531cd-20250729
       react-dom: 19.2.0-canary-9be531cd-20250729(react@19.2.0-canary-9be531cd-20250729)
 


### PR DESCRIPTION
Bump base-ui to 1.0.0-beta.2 and removed our patch for edge browser on windows that introduced in #81474

Remove the shadow root ref hack we found before (https://github.com/mui/base-ui/issues/2224)

---
🔄 **This is a mirror of [upstream PR #82206](https://github.com/vercel/next.js/pull/82206)**