### PR TITLE
Turbopack: Remove unused `ignored_subpaths` feature from DiskWatcher

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -675,11 +675,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn project_fs(&self) -> Vc<DiskFileSystem> {
-        DiskFileSystem::new(
-            PROJECT_FILESYSTEM_NAME.into(),
-            self.root_path.clone(),
-            vec![],
-        )
+        DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.into(), self.root_path.clone())
     }
 
     #[turbo_tasks::function]
@@ -690,7 +686,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn output_fs(&self) -> Vc<DiskFileSystem> {
-        DiskFileSystem::new(rcstr!("output"), self.root_path.clone(), vec![])
+        DiskFileSystem::new(rcstr!("output"), self.root_path.clone())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -709,7 +709,6 @@ async fn get_mock_stylesheet(
             .to_str()
             .context("Must exist")?
             .into(),
-        vec![],
     ));
 
     let ExecutionContext {

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -127,7 +127,7 @@ async fn invalidation_does_not_invalidate() {
 }
 
 fn get_issue_context() -> Vc<FileSystemPath> {
-    DiskFileSystem::new(rcstr!("root"), rcstr!("/"), vec![]).root()
+    DiskFileSystem::new(rcstr!("root"), rcstr!("/")).root()
 }
 
 #[tokio::test]

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().into();
-            let disk_fs = DiskFileSystem::new("project".into(), root, vec![]);
+            let disk_fs = DiskFileSystem::new("project".into(), root);
             disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().into();
-            let disk_fs = DiskFileSystem::new("project".into(), root, vec![]);
+            let disk_fs = DiskFileSystem::new("project".into(), root);
             disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast

--- a/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -12,7 +12,7 @@ pub async fn directory_from_relative_path(
     name: RcStr,
     path: RcStr,
 ) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new(name, path, vec![]);
+    let disk_fs = DiskFileSystem::new(name, path);
     disk_fs.await?.start_watching(None).await?;
 
     Ok(Vc::upcast(disk_fs))

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -22,7 +22,6 @@ pub async fn content_from_relative_path(
     let disk_fs = DiskFileSystem::new(
         root_path.to_string_lossy().into(),
         root_path.to_string_lossy().into(),
-        vec![],
     );
     disk_fs.await?.start_watching(None).await?;
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -513,11 +513,8 @@ impl DiskFileSystem {
     /// * `name` - Name of the filesystem.
     /// * `root` - Path to the given filesystem's root. Should be
     ///   [canonicalized][std::fs::canonicalize].
-    /// * `ignored_subpaths` - A list of subpaths that should not trigger invalidation. This should
-    ///   be a full path, since it is possible that root & project dir is different and requires to
-    ///   ignore specific subpaths from each.
     #[turbo_tasks::function]
-    pub fn new(name: RcStr, root: RcStr, ignored_subpaths: Vec<RcStr>) -> Result<Vc<Self>> {
+    pub fn new(name: RcStr, root: RcStr) -> Result<Vc<Self>> {
         mark_stateful();
 
         let instance = DiskFileSystem {
@@ -529,9 +526,7 @@ impl DiskFileSystem {
                 invalidator_map: InvalidatorMap::new(),
                 dir_invalidator_map: InvalidatorMap::new(),
                 semaphore: create_semaphore(),
-                watcher: DiskWatcher::new(
-                    ignored_subpaths.into_iter().map(PathBuf::from).collect(),
-                ),
+                watcher: DiskWatcher::new(),
             }),
         };
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -224,11 +224,7 @@ pub mod tests {
         ));
         let path: RcStr = scratch.path().to_str().unwrap().into();
         tt.run_once(async {
-            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
-                "temp".into(),
-                path,
-                Vec::new(),
-            ));
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new("temp".into(), path));
             let read_dir = fs
                 .root()
                 .await?
@@ -298,11 +294,7 @@ pub mod tests {
         ));
         let path: RcStr = scratch.path().to_str().unwrap().into();
         tt.run_once(async {
-            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
-                "temp".into(),
-                path,
-                Vec::new(),
-            ));
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new("temp".into(), path));
             let read_dir = fs
                 .root()
                 .await?
@@ -383,11 +375,7 @@ pub mod tests {
         ));
         let path: RcStr = scratch.path().to_str().unwrap().into();
         tt.run_once(async {
-            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
-                "temp".into(),
-                path,
-                Vec::new(),
-            ));
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new("temp".into(), path));
             let dir = fs.root().await?.join("dir")?;
             let read_dir = track_star_star_glob(dir.clone())
                 .read_strongly_consistent()
@@ -457,11 +445,7 @@ pub mod tests {
         ));
         let path: RcStr = scratch.path().to_str().unwrap().into();
         tt.run_once(async {
-            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
-                "temp".into(),
-                path,
-                Vec::new(),
-            ));
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new("temp".into(), path));
             let err = fs
                 .root()
                 .await?
@@ -517,11 +501,7 @@ pub mod tests {
         ));
         let path: RcStr = scratch.path().to_str().unwrap().into();
         tt.run_once(async {
-            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
-                "temp".into(),
-                path,
-                Vec::new(),
-            ));
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new("temp".into(), path));
             let err = fs
                 .root()
                 .await?

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -159,7 +159,7 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
 
 #[turbo_tasks::function(operation)]
 fn disk_file_system_operation(fs_root: RcStr) -> Vc<DiskFileSystem> {
-    DiskFileSystem::new(rcstr!("project"), fs_root, Vec::new())
+    DiskFileSystem::new(rcstr!("project"), fs_root)
 }
 
 #[turbo_tasks::function(operation)]

--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -61,7 +61,7 @@ pub fn normalize_entries(entries: &Option<Vec<String>>) -> Vec<RcStr> {
 
 #[turbo_tasks::function]
 pub async fn project_fs(project_dir: RcStr, watch: bool) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new("project".into(), project_dir, vec![]);
+    let disk_fs = DiskFileSystem::new("project".into(), project_dir);
     if watch {
         disk_fs.await?.start_watching(None).await?;
     }
@@ -70,6 +70,6 @@ pub async fn project_fs(project_dir: RcStr, watch: bool) -> Result<Vc<Box<dyn Fi
 
 #[turbo_tasks::function]
 pub fn output_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new("output".into(), project_dir, vec![]);
+    let disk_fs = DiskFileSystem::new("output".into(), project_dir);
     Ok(Vc::upcast(disk_fs))
 }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -281,8 +281,8 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
         resource_path.to_str().unwrap()
     );
 
-    let root_fs = DiskFileSystem::new(rcstr!("workspace"), REPO_ROOT.clone(), vec![]);
-    let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
+    let root_fs = DiskFileSystem::new(rcstr!("workspace"), REPO_ROOT.clone());
+    let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone());
     let project_root = project_fs.root().owned().await?;
 
     let relative_path = resource_path.strip_prefix(&*REPO_ROOT).context(format!(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -260,7 +260,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Err(_) => SnapshotOptions::default(),
         Ok(options_str) => parse_json_with_source_context(&options_str).unwrap(),
     };
-    let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
+    let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone());
     let project_root = project_fs.root().owned().await?;
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -79,7 +79,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
         let input: RcStr = bench_input.input.clone().into();
         async move {
             let task = tt.spawn_once_task(async move {
-                let input_fs = DiskFileSystem::new("tests".into(), tests_root.clone(), vec![]);
+                let input_fs = DiskFileSystem::new("tests".into(), tests_root.clone());
                 let input = input_fs.root().await?.join(&input)?;
 
                 let input_dir = input.parent().parent();

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root: RcStr = current_dir().unwrap().to_str().unwrap().into();
-            let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.into(), root, vec![]);
+            let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.into(), root);
             disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -337,12 +337,11 @@ async fn node_file_trace_operation(
     let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
         rcstr!("workspace"),
         package_root.clone(),
-        vec![],
     ));
     let input_dir = workspace_fs.root().owned().await?;
     let input = input_dir.join(&format!("tests/{input}"))?;
 
-    let output_fs = DiskFileSystem::new(rcstr!("output"), directory.clone(), vec![]);
+    let output_fs = DiskFileSystem::new(rcstr!("output"), directory.clone());
     let output_dir = output_fs.root().owned().await?;
 
     let source = FileSource::new(input);


### PR DESCRIPTION
This feature is unused, but I think there are also significant problems with it, which would require work for it to be used:

- The `Vec` isn't very scalable. It should be an `auto_hash_map::AutoSet` or a `FxHashSet`.
- It's unclear that just ignoring watch events is sound. I understand that we don't want to allow source code to depend on outputs, but it seems like it would be better to prevent reads in the first place (e.g. pretend the file doesn't exist and generate a compiler diagnostic).
- There's no test coverage of this feature.

---
🔄 **This is a mirror of [upstream PR #82210](https://github.com/vercel/next.js/pull/82210)**