### PR TITLE
Turbopack: ensure max merge segments is respected accros families

### DIFF
--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -104,6 +104,7 @@ pub fn compute_metrics<T: Compactable>(
 }
 
 /// Configuration for the compaction algorithm.
+#[derive(Clone)]
 pub struct CompactConfig {
     /// The minimum number of files to merge at once.
     pub min_merge_count: usize,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -787,15 +787,27 @@ impl TurboPersistence {
             keys_written: u64,
         }
 
+        let mut compact_config = compact_config.clone();
+        let merge_jobs = sst_by_family
+            .iter()
+            .map(|ssts_with_ranges| {
+                if compact_config.max_merge_segment_count == 0 {
+                    return Vec::new();
+                }
+                let merge_jobs = get_merge_segments(&ssts_with_ranges, &compact_config);
+                compact_config.max_merge_segment_count -= merge_jobs.len();
+                merge_jobs
+            })
+            .collect::<Vec<_>>();
+
         let result = sst_by_family
             .into_par_iter()
+            .zip(merge_jobs.into_par_iter())
             .with_min_len(1)
             .enumerate()
-            .map(|(family, ssts_with_ranges)| {
+            .map(|(family, (ssts_with_ranges, merge_jobs))| {
                 let family = family as u32;
                 let _span = span.clone().entered();
-
-                let merge_jobs = get_merge_segments(&ssts_with_ranges, compact_config);
 
                 if merge_jobs.is_empty() {
                     return Ok(PartialResultPerFamily {

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -794,7 +794,7 @@ impl TurboPersistence {
                 if compact_config.max_merge_segment_count == 0 {
                     return Vec::new();
                 }
-                let merge_jobs = get_merge_segments(&ssts_with_ranges, &compact_config);
+                let merge_jobs = get_merge_segments(ssts_with_ranges, &compact_config);
                 compact_config.max_merge_segment_count -= merge_jobs.len();
                 merge_jobs
             })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82223](https://github.com/vercel/next.js/pull/82223)**