### PR TITLE
Turbopack: implement shutdown for backing storage correct

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -211,6 +211,10 @@ where
             }
         }
     }
+
+    fn shutdown(&self) -> Result<()> {
+        either::for_both!(self, this => this.shutdown())
+    }
 }
 
 // similar to `Either::unwrap_left`, but does not require `R: Debug`.


### PR DESCRIPTION
### What?

This ensures next.js correctly waits for the turbopack shutdown to complete

---
🔄 **This is a mirror of [upstream PR #82220](https://github.com/vercel/next.js/pull/82220)**