### PR TITLE
Fix: Don't bail out of prefetch if head is missing

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -109,6 +109,9 @@ type RouteCacheEntryShared = {
   // received a response from the server.
   couldBeIntercepted: boolean
 
+  // See comment in scheduler.ts for context
+  TODO_metadataStatus: EntryStatus.Empty | EntryStatus.Fulfilled
+
   // LRU-related fields
   keypath: null | Prefix<RouteCacheKeypath>
   next: null | RouteCacheEntry
@@ -554,6 +557,8 @@ export function readOrCreateRouteCacheEntry(
     // Similarly, we don't yet know if the route supports PPR.
     isPPREnabled: false,
     renderedSearch: null,
+
+    TODO_metadataStatus: EntryStatus.Empty,
 
     // LRU-related fields
     keypath: null,

--- a/packages/next/src/client/components/segment-cache-impl/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache-impl/scheduler.ts
@@ -586,7 +586,33 @@ function pingRootRouteTree(
             spawnedEntries,
             fetchStrategy
           )
-          const needsDynamicRequest = spawnedEntries.size > 0
+
+          let needsDynamicRequest = spawnedEntries.size > 0
+
+          if (
+            !needsDynamicRequest &&
+            route.isHeadPartial &&
+            route.TODO_metadataStatus === EntryStatus.Empty
+          ) {
+            // All the segment data is alreday cached, however, we need to issue
+            // a request anyway so we can prefetch the head. Update the status
+            // field to prevent additional requests from being spawned while
+            // this one is in progress.
+            // TODO: This is a temporary, targeted solution to fix a regression
+            // we found. It exists to prevent the scheduler from sending a
+            // redundant request if there's already one in progress.
+            // Essentially, it will attempt once at most, then give up until the
+            // route entry expires or is evicted by other means. But because
+            // this doesn't have its own stale time separate from the route
+            // itself, there will be edge cases where the metadata fails to be
+            // fully prefetched. Consider caching metadata using a separate
+            // entry type so we can model this more cleanly. The circumstances
+            // that lead to this branch running in the first place are
+            // relatively rare, so it's not critical.
+            route.TODO_metadataStatus = EntryStatus.Fulfilled
+            needsDynamicRequest = true
+          }
+
           if (needsDynamicRequest) {
             // Perform a dynamic prefetch request and populate the cache with
             // the result

--- a/test/e2e/app-dir/segment-cache/metadata/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata/app/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/link-accordion.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+  id,
+}: {
+  href: string
+  children: string
+  prefetch?: boolean | 'unstable_forceStale' | 'auto'
+  id?: string
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+        id={id}
+      />
+      {isVisible ? (
+        // @ts-expect-error - unstable_forceStale is not yet part of the types
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata/app/page-with-dynamic-head/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/page-with-dynamic-head/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next'
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export async function generateMetadata(): Promise<Metadata> {
+  await connection()
+  return {
+    title: 'Dynamic Title',
+  }
+}
+
+async function Content() {
+  await connection()
+  return <div id="target-page">Target page</div>
+}
+
+export default function PageWithDynamicTitle() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
@@ -1,0 +1,23 @@
+import { LinkAccordion } from './link-accordion'
+
+export default function Page() {
+  return (
+    <>
+      <ul>
+        <li>
+          <LinkAccordion prefetch={true} href="/page-with-dynamic-head">
+            Page with dynamic head (prefetch=true))
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            prefetch={true}
+            href="/rewrite-to-page-with-dynamic-head"
+          >
+            Rewrite to page with dynamic head (prefetch=true)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata/next.config.js
+++ b/test/e2e/app-dir/segment-cache/metadata/next.config.js
@@ -1,0 +1,19 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    cacheComponents: true,
+    clientSegmentCache: true,
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/rewrite-to-page-with-dynamic-head',
+        destination: '/page-with-dynamic-head',
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
+++ b/test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
@@ -1,0 +1,82 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from '../router-act'
+
+describe('segment cache (metadata)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    test('disabled in development', () => {})
+    return
+  }
+
+  it(
+    "regression: prefetch the head if it's missing even if all other data " +
+      'is cached',
+    async () => {
+      let act
+      const browser = await next.browser('/', {
+        beforePageLoad(p) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Fully prefetch a page
+      await act(
+        async () => {
+          const checkbox = await browser.elementByCss(
+            'input[data-link-accordion="/page-with-dynamic-head"]'
+          )
+          await checkbox.click()
+        },
+        // Because the link is prefetched with prefetch="unstable_forceStale",
+        // we should be able to prefetch the title, even though it's dynamic.
+        {
+          includes: 'Dynamic Title',
+        },
+        {
+          includes: 'Target page',
+        }
+      )
+
+      // Now prefetch a link that rewrites to the same underlying page.
+      await act(
+        async () => {
+          const checkbox = await browser.elementByCss(
+            'input[data-link-accordion="/rewrite-to-page-with-dynamic-head"]'
+          )
+          await checkbox.click()
+        },
+        // TODO: Ideally, this would not prefetch the dynamic title again,
+        // because it was already prefetched by the previous link, and both
+        // links resolve to the same underlying route. This is because, unlike
+        // segment data, we cache routes solely by their input URL, not by the
+        // path of the underlying route. Similarly, we don't cache metadata
+        // separately from the route tree. We should probably do one or both.
+        {
+          includes: 'Dynamic Title',
+        },
+        // It should not prefetch the page content again, because it was
+        // already cached.
+        {
+          includes: 'Target page',
+          block: 'reject',
+        }
+      )
+
+      // When we navigate to the page, it should not make any additional
+      // network requests, because both the segment data and the head were
+      // fully prefetched.
+      await act(async () => {
+        const link = await browser.elementByCss(
+          'a[href="/rewrite-to-page-with-dynamic-head"]'
+        )
+        await link.click()
+        const pageContent = await browser.elementById('target-page')
+        expect(await pageContent.text()).toBe('Target page')
+        const title = await browser.eval(() => document.title)
+        expect(title).toBe('Dynamic Title')
+      }, 'no-requests')
+    }
+  )
+})


### PR DESCRIPTION
This fixes an edge case where a Link is prefetched with prefetch={true}, and the target page has a dynamic head, but the head is not fully prefetched. If all the segment data for the target page was already cached, the prefetch scheduler would bail out and skip the request. However, we typically rely on the data prefetch to fetch the metadata, so by skipping the data prefetch we were effectively also skipping the metadata.

The fix in this PR is to check for this condition before bailing out of the request, and initiate a request anyway.

However, this illustrates that we're not modeling the caching of metadata in a complete way. Currently it's stored on the same cache entry as the route tree, but they are not always fetched simultaneously (as in this regression case), so their lifetimes are not always aligned. We should consider either always fetching the metadata as part of the route tree prefetch, or caching metadata on a separate entry type. This would allow us to dedupe entries between URLs that rewrite to the same route, like we already do for segments. The circumstances that lead to this scenario are relatively rare, though, hence the temporary solution in this PR.

---
🔄 **This is a mirror of [upstream PR #82216](https://github.com/vercel/next.js/pull/82216)**