### PR TITLE
[Pages] fix: use `asPath` for query-only navigation with `useRouter`

### DIFF
--- a/packages/next/src/client/resolve-href.ts
+++ b/packages/next/src/client/resolve-href.ts
@@ -56,8 +56,11 @@ export function resolveHref(
   }
 
   try {
+    const shouldUseAsPath =
+      urlAsString.startsWith('#') || urlAsString.startsWith('?')
+
     base = new URL(
-      urlAsString.startsWith('#') ? router.asPath : router.pathname,
+      shouldUseAsPath ? router.asPath : router.pathname,
       'http://n'
     )
   } catch (_) {

--- a/test/e2e/use-router-with-rewrites/next.config.js
+++ b/test/e2e/use-router-with-rewrites/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  rewrites: async () => {
+    return {
+      beforeFiles: [
+        {
+          source: '/',
+          destination: '/foo',
+        },
+      ],
+    }
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/use-router-with-rewrites/next.config.js
+++ b/test/e2e/use-router-with-rewrites/next.config.js
@@ -8,6 +8,22 @@ const nextConfig = {
           source: '/',
           destination: '/foo',
         },
+        {
+          source: '/rewrite-to-another-segment/:id',
+          destination: '/rewrite-to-another-segment/:id/foo',
+        },
+        {
+          source: '/rewrite-to-same-segment/1',
+          destination: '/rewrite-to-same-segment/001',
+        },
+        {
+          source: '/rewrite-to-same-segment/2',
+          destination: '/rewrite-to-same-segment/002',
+        },
+        {
+          source: '/rewrite-to-same-segment/3',
+          destination: '/rewrite-to-same-segment/003',
+        },
       ],
     }
   },

--- a/test/e2e/use-router-with-rewrites/pages/foo.tsx
+++ b/test/e2e/use-router-with-rewrites/pages/foo.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const router = useRouter()
+
+  function handlePush() {
+    router.push({
+      query: {
+        param: 1,
+      },
+    })
+  }
+
+  function handleReplace() {
+    router.replace({
+      query: {
+        param: 1,
+      },
+    })
+  }
+
+  return (
+    <>
+      <button id="router-push" onClick={handlePush}>
+        router.push
+      </button>
+      <button id="router-replace" onClick={handleReplace}>
+        router.replace
+      </button>
+    </>
+  )
+}

--- a/test/e2e/use-router-with-rewrites/pages/rewrite-to-another-segment/[id]/foo.tsx
+++ b/test/e2e/use-router-with-rewrites/pages/rewrite-to-another-segment/[id]/foo.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   function handlePush() {
     router.push({
       query: {
-        param: 1,
+        id: 1,
       },
     })
   }
@@ -15,20 +15,21 @@ export default function Page() {
   function handleReplace() {
     router.replace({
       query: {
-        param: 1,
+        id: 2,
       },
     })
   }
 
   return (
     <>
+      <p>{router.query.id}</p>
       <button id="router-push" onClick={handlePush}>
         router.push
       </button>
       <button id="router-replace" onClick={handleReplace}>
         router.replace
       </button>
-      <Link href="?param=1">Link</Link>
+      <Link href="?id=3">Link</Link>
     </>
   )
 }

--- a/test/e2e/use-router-with-rewrites/pages/rewrite-to-same-segment/[id]/index.tsx
+++ b/test/e2e/use-router-with-rewrites/pages/rewrite-to-same-segment/[id]/index.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   function handlePush() {
     router.push({
       query: {
-        param: 1,
+        id: 1,
       },
     })
   }
@@ -15,20 +15,21 @@ export default function Page() {
   function handleReplace() {
     router.replace({
       query: {
-        param: 1,
+        id: 2,
       },
     })
   }
 
   return (
     <>
+      <p>{router.query.id}</p>
       <button id="router-push" onClick={handlePush}>
         router.push
       </button>
       <button id="router-replace" onClick={handleReplace}>
         router.replace
       </button>
-      <Link href="?param=1">Link</Link>
+      <Link href="?id=3">Link</Link>
     </>
   )
 }

--- a/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+++ b/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('use-router-with-rewrites', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should preserve current pathname when using useRouter.push with rewrites', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('router-push').click()
+
+    expect(await browser.url()).toBe(
+      `http://localhost:${next.appPort}/?param=1`
+    )
+  })
+
+  it('should preserve current pathname when using useRouter.replace with rewrites', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('router-replace').click()
+
+    expect(await browser.url()).toBe(
+      `http://localhost:${next.appPort}/?param=1`
+    )
+  })
+})

--- a/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+++ b/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
@@ -22,4 +22,76 @@ describe('use-router-with-rewrites', () => {
       `http://localhost:${next.appPort}/?param=1`
     )
   })
+
+  it('should preserve current pathname when using Link with rewrites', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('a').click()
+    expect(await browser.url()).toBe(
+      `http://localhost:${next.appPort}/?param=1`
+    )
+  })
+
+  describe('rewrite to another segment', () => {
+    it('should preserve current pathname when using useRouter.push with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-another-segment/0')
+      await browser.elementById('router-push').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/1`
+      )
+    })
+
+    it('should preserve current pathname when using useRouter.replace with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-another-segment/0')
+      await browser.elementById('router-replace').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/2`
+      )
+    })
+
+    it('should preserve current pathname when using Link with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-another-segment/0')
+      await browser.elementByCss('a').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/3`
+      )
+    })
+  })
+
+  describe('rewrite to same segment', () => {
+    it('should preserve current pathname when using useRouter.push with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-same-segment/0')
+      await browser.elementById('router-push').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-same-segment/1`
+      )
+
+      expect(await browser.elementByCss('p').text()).toBe('001')
+    })
+
+    it('should preserve current pathname when using useRouter.replace with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-same-segment/0')
+      await browser.elementById('router-replace').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-same-segment/2`
+      )
+
+      expect(await browser.elementByCss('p').text()).toBe('002')
+    })
+
+    it('should preserve current pathname when using Link with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-same-segment/0')
+      await browser.elementByCss('a').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-same-segment/3`
+      )
+
+      expect(await browser.elementByCss('p').text()).toBe('003')
+    })
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/81476

---
🔄 **This is a mirror of [upstream PR #82236](https://github.com/vercel/next.js/pull/82236)**