### PR TITLE
feat: add imageRendering prop to Image component

### DIFF
--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -41,6 +41,8 @@ export type ImageProps = Omit<
   blurDataURL?: string
   unoptimized?: boolean
   overrideSrc?: string
+  imageRendering?: '-webkit-optimize-contrast' | 'auto' | 'crisp-edges' | 'pixelated' | 'smooth' | string
+
   /**
    * @deprecated Use `onLoad` instead.
    * @see https://nextjs.org/docs/app/api-reference/components/image#onload
@@ -280,6 +282,7 @@ export function getImgProps(
     objectPosition,
     lazyBoundary,
     lazyRoot,
+    imageRendering = "-webkit-optimize-contrast",
     ...rest
   }: ImageProps,
   _state: {
@@ -649,6 +652,7 @@ export function getImgProps(
         }
       : {},
     showAltText ? {} : { color: 'transparent' },
+    { imageRendering },
     style
   )
 


### PR DESCRIPTION
- Add imageRendering prop to ImageProps interface with default -webkit-optimize-contrast
- Update getImgProps to handle imageRendering prop
- Set default value to -webkit-optimize-contrast for better image quality

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82243](https://github.com/vercel/next.js/pull/82243)**