### PR TITLE
Make TypeScript understand MDX is compiled to React

### DIFF
--- a/packages/next-mdx/index.d.ts
+++ b/packages/next-mdx/index.d.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from 'next'
 import type { Options } from '@mdx-js/loader'
 import type { RuleSetConditionAbsolute } from 'webpack'
 
+declare module 'mdx/types.js' {
+  /** @internal This makes the MDX types understand React. */
+  namespace JSX {
+    type Element = React.JSX.Element
+    type ElementClass = React.JSX.ElementClass
+    type ElementType = React.JSX.ElementType
+    type IntrinsicElements = React.JSX.IntrinsicElements
+  }
+}
+
 type WithMDX = (config: NextConfig) => NextConfig
 
 declare namespace nextMDX {


### PR DESCRIPTION
### What?

Augment `mdx/types.js` to make it understand React.

### Why?

`@types/mdx` depends on the JSX namespace. In older TypeScript versions, this was declared globally by JSX frameworks. Nowadays, this can be declared on a module or namespace level. Modern frameworks, including React 19, have caught up and no longer define the global JSX namespace.

To make `@types/mdx` understand the JSX framework, the JSX namespace must now be defined in `mdx/types.js` via module augmentation.

Since the use of `@next/mdx` implies MDX is compiled to React components, it might as well augment the types.

### How?

TypeScript magic. :sparkles: 

---
🔄 **This is a mirror of [upstream PR #82242](https://github.com/vercel/next.js/pull/82242)**