### PR TITLE
Fix unpack next for windows

### DIFF
--- a/scripts/unpack-next.ts
+++ b/scripts/unpack-next.ts
@@ -4,7 +4,10 @@ import { NEXT_DIR, exec } from './pack-util'
 import fs from 'fs'
 import path from 'path'
 
-const TARBALLS = `${NEXT_DIR}/tarballs`
+const TARBALLS =
+  process.platform === 'win32'
+    ? `${NEXT_DIR}\\tarballs`
+    : `${NEXT_DIR}/tarballs`
 
 const PROJECT_DIR = path.resolve(process.argv[2])
 
@@ -15,16 +18,35 @@ function realPathIfAny(path: fs.PathLike) {
     return null
   }
 }
-const packages = {
-  next: realPathIfAny(`${PROJECT_DIR}/node_modules/next`),
-  'next-swc': realPathIfAny(`${PROJECT_DIR}/node_modules/@next/swc`),
-  'next-mdx': realPathIfAny(`${PROJECT_DIR}/node_modules/@next/mdx`),
-  'next-bundle-analyzer': realPathIfAny(
-    `${PROJECT_DIR}/node_modules/@next/bundle-anlyzer`
-  ),
-}
+const packages =
+  process.platform === 'win32'
+    ? {
+        next: realPathIfAny(`${PROJECT_DIR}\\node_modules\\next`),
+        'next-swc': realPathIfAny(
+          `${PROJECT_DIR}\\node_modules\\@next\\swc-${process.platform}-${process.arch}-msvc`
+        ),
+        'next-mdx': realPathIfAny(`${PROJECT_DIR}\\node_modules\\@next\\mdx`),
+        'next-bundle-analyzer': realPathIfAny(
+          `${PROJECT_DIR}\\node_modules\\@next\\bundle-anlyzer`
+        ),
+      }
+    : {
+        next: realPathIfAny(`${PROJECT_DIR}/node_modules/next`),
+        'next-swc': realPathIfAny(`${PROJECT_DIR}/node_modules/@next/swc`),
+        'next-mdx': realPathIfAny(`${PROJECT_DIR}/node_modules/@next/mdx`),
+        'next-bundle-analyzer': realPathIfAny(
+          `${PROJECT_DIR}/node_modules/@next/bundle-anlyzer`
+        ),
+      }
 
-for (const [key, path] of Object.entries(packages)) {
-  if (!path) continue
-  exec(`Unpack ${key}`, `tar -xf '${TARBALLS}/${key}.tar' -C '${path}'`)
+if (process.platform === 'win32') {
+  for (const [key, path] of Object.entries(packages)) {
+    if (!path) continue
+    exec(`Unpack ${key}`, `tar -xf ${TARBALLS}\\${key}.tar -C ${path}`)
+  }
+} else {
+  for (const [key, path] of Object.entries(packages)) {
+    if (!path) continue
+    exec(`Unpack ${key}`, `tar -xf '${TARBALLS}/${key}.tar' -C '${path}'`)
+  }
 }


### PR DESCRIPTION

<!-- ## For Contributors

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md



## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change -->

### What?

Makes sure unpack-next.ts script works on Windows.

### Why?

It is one of the available methods for testing local version of next.js, specified in developing.md.

### How?

Since exec uses Command Prompt rather than Powershell, the code ensures backslashes are used on Windows and paths are not enclosed in quotation marks.
It also ensures the swc path is written like swc-win32-x64-msvc. 
Perhaps a better way would be to use exec in a way that it runs powershell rather than command prompt?

Closes NEXT-
Fixes #82233

---
🔄 **This is a mirror of [upstream PR #82246](https://github.com/vercel/next.js/pull/82246)**