### PR TITLE
chore(docs): add gt-next to i18n resources

### DIFF
--- a/docs/01-app/02-guides/internationalization.mdx
+++ b/docs/01-app/02-guides/internationalization.mdx
@@ -214,3 +214,4 @@ export default async function RootLayout({ children, params }) {
 - [`next-i18n-router`](https://github.com/i18nexus/next-i18n-router)
 - [`paraglide-next`](https://inlang.com/m/osslbuzt/paraglide-next-i18n)
 - [`lingui`](https://lingui.dev)
+- [`gt-next`](https://generaltranslation.com/docs/next)


### PR DESCRIPTION
## Add gt-next to i18n resources

`gt-next` is an AI-native i18n library recently launched as part of the [Vercel AI Accelerator](https://vercel.com/ai-accelerator). 

It's built for the Next.js App Router and already being used in production by developer-first companies like Cursor, Daytona, and Mastra. 

This is a Next.js only library, which the docs reflect: [generaltranslation.com/docs/next](https://generaltranslation.com/docs/next)

Uniquely, `gt-next` translates UI inline, rather than forcing developers to refactor formatted strings into dictionary files.

```tsx
import { T } from "gt-next";

export default function Page() {
  return (
    <T>
      <p>Any children of <b>the {`<T>`} component</b> will be translated inline.</p>
    </T> 
  );
}
```

---
🔄 **This is a mirror of [upstream PR #82250](https://github.com/vercel/next.js/pull/82250)**