### PR TITLE
[cna] Add `reactCompiler` option

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -40,6 +40,7 @@ export async function createApp({
   turbopack,
   rspack,
   disableGit,
+  reactCompiler,
 }: {
   appPath: string
   packageManager: PackageManager
@@ -57,6 +58,7 @@ export async function createApp({
   turbopack: boolean
   rspack: boolean
   disableGit?: boolean
+  reactCompiler: boolean
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined
   const mode: TemplateMode = typescript ? 'ts' : 'js'
@@ -240,6 +242,7 @@ export async function createApp({
       skipInstall,
       turbopack,
       rspack,
+      reactCompiler,
     })
   }
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -49,6 +49,7 @@ const program = new Command(packageJson.name)
   .option('--ts, --typescript', 'Initialize as a TypeScript project. (default)')
   .option('--js, --javascript', 'Initialize as a JavaScript project.')
   .option('--tailwind', 'Initialize with Tailwind CSS config. (default)')
+  .option('--react-compiler', 'Initialize with React Compiler enabled.')
   .option('--eslint', 'Initialize with ESLint config.')
   .option('--app', 'Initialize as an App Router project.')
   .option('--src-dir', "Initialize inside a 'src/' directory.")
@@ -237,6 +238,7 @@ async function run(): Promise<void> {
       empty: false,
       turbopack: true,
       disableGit: false,
+      reactCompiler: false,
     }
     const getPrefOrDefault = (field: string) =>
       preferences[field] ?? defaults[field]
@@ -293,6 +295,29 @@ async function run(): Promise<void> {
         })
         opts.eslint = Boolean(eslint)
         preferences.eslint = Boolean(eslint)
+      }
+    }
+
+    if (
+      !opts.reactCompiler &&
+      !args.includes('--no-react-compiler') &&
+      !opts.api
+    ) {
+      if (skipPrompt) {
+        opts.reactCompiler = getPrefOrDefault('reactCompiler')
+      } else {
+        const styledReactCompiler = blue('React Compiler')
+        const { reactCompiler } = await prompts({
+          onState: onPromptState,
+          type: 'toggle',
+          name: 'reactCompiler',
+          message: `Would you like to use ${styledReactCompiler} (Release Candidate)?`,
+          initial: getPrefOrDefault('reactCompiler'),
+          active: 'Yes',
+          inactive: 'No',
+        })
+        opts.reactCompiler = Boolean(reactCompiler)
+        preferences.reactCompiler = Boolean(reactCompiler)
       }
     }
 
@@ -435,6 +460,7 @@ async function run(): Promise<void> {
       turbopack: opts.turbopack,
       rspack: opts.rspack,
       disableGit: opts.disableGit,
+      reactCompiler: opts.reactCompiler,
     })
   } catch (reason) {
     if (!(reason instanceof DownloadError)) {
@@ -468,6 +494,7 @@ async function run(): Promise<void> {
       turbopack: opts.turbopack,
       rspack: opts.rspack,
       disableGit: opts.disableGit,
+      reactCompiler: opts.reactCompiler,
     })
   }
   conf.set('preferences', preferences)

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -45,6 +45,7 @@ export const installTemplate = async ({
   skipInstall,
   turbopack,
   rspack,
+  reactCompiler,
 }: InstallTemplateArgs) => {
   console.log(bold(`Using ${packageManager}.`));
 
@@ -91,6 +92,28 @@ export const installTemplate = async ({
           "export default withRspack(nextConfig);",
         ),
     );
+  }
+
+  if (reactCompiler) {
+    const nextConfigFile = path.join(
+      root,
+      mode === "js" ? "next.config.mjs" : "next.config.ts",
+    );
+    let configContent = await fs.readFile(nextConfigFile, "utf8");
+
+    if (mode === "ts") {
+      configContent = configContent.replace(
+        "const nextConfig: NextConfig = {\n  /* config options here */\n};",
+        `const nextConfig: NextConfig = {\n  experimental: {\n    reactCompiler: true,\n  },\n};`,
+      );
+    } else {
+      configContent = configContent.replace(
+        "const nextConfig = {};",
+        `const nextConfig = {\n  experimental: {\n    reactCompiler: true,\n  },\n};`,
+      );
+    }
+
+    await fs.writeFile(nextConfigFile, configContent);
   }
 
   const tsconfigFile = path.join(
@@ -217,6 +240,12 @@ export const installTemplate = async ({
     } else {
       packageJson.dependencies["next-rspack"] = version;
     }
+  }
+
+  if (reactCompiler) {
+    // Note: When the compiler is stable, the versioning scheme will change to be standalone rather
+    // than in lockstep with React.
+    packageJson.devDependencies["babel-plugin-react-compiler"] = "19.1.0-rc.2";
   }
 
   /**

--- a/packages/create-next-app/templates/types.ts
+++ b/packages/create-next-app/templates/types.ts
@@ -32,4 +32,5 @@ export interface InstallTemplateArgs {
   skipInstall: boolean;
   turbopack: boolean;
   rspack: boolean;
+  reactCompiler: boolean;
 }


### PR DESCRIPTION
This PR adds a new `reactCompiler` option to create-next-app. To provide more time for build perf measurements, this option defaults to "no" for now.

When React Compiler is enabled, create-next-app will:

1. Add the experimental config enabling the compiler to next.config
2. Install babel-plugin-react-compiler, pinned to the latest rc 19.1.0-rc.2

Test plan:

Double checked that the generated next.config.ts contains the flag and that babel-plugin-react-compiler was installed as a devDep.

**OFF**

```
$ pnpm build
$ dist/index.js

✔ What is your project named? … my-app
✔ Would you like to use TypeScript? … No / Yes
✔ Would you like to use ESLint? … No / Yes
✔ Would you like to use React Compiler (Release Candidate)? … No / Yes
✔ Would you like to use Tailwind CSS? … No / Yes
✔ Would you like your code inside a `src/` directory? … No / Yes
✔ Would you like to use App Router? (recommended) … No / Yes
✔ Would you like to use Turbopack for `next dev`? … No / Yes
✔ Would you like to customize the import alias (`@/*` by default)? … No / Yes
Creating a new Next.js app in /Users/laurentan/code/next.js/packages/create-next-app/my-app.

Using npm.

Initializing project with template: app-tw

Installing dependencies:
- react
- react-dom
- next

Installing devDependencies:
- typescript
- @types/node
- @types/react
- @types/react-dom
- @tailwindcss/postcss
- tailwindcss
- eslint
- eslint-config-next
- @eslint/eslintrc

<snip>

Success! Created my-app at my-app
```

**ON**
```
$ pnpm build
$ dist/index.js

✔ What is your project named? … my-app
✔ Would you like to use TypeScript? … No / Yes
✔ Would you like to use ESLint? … No / Yes
✔ Would you like to use React Compiler (Release Candidate)? … No / Yes
✔ Would you like to use Tailwind CSS? … No / Yes
✔ Would you like your code inside a `src/` directory? … No / Yes
✔ Would you like to use App Router? (recommended) … No / Yes
✔ Would you like to use Turbopack for `next dev`? … No / Yes
✔ Would you like to customize the import alias (`@/*` by default)? … No / Yes
Creating a new Next.js app in /Users/laurentan/code/next.js/packages/create-next-app/my-app.

Using npm.

Initializing project with template: app-tw

Installing dependencies:
- react
- react-dom
- next

Installing devDependencies:
- babel-plugin-react-compiler
- typescript
- @types/node
- @types/react
- @types/react-dom
- @tailwindcss/postcss
- tailwindcss
- eslint
- eslint-config-next
- @eslint/eslintrc

<snip>

Success! Created my-app at my-app
```

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82251](https://github.com/vercel/next.js/pull/82251)**