### PR TITLE
Update linter options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -118,5 +118,8 @@
     "${workspaceRoot}/.git-blame-ignore-revs"
   ],
   "astGrep.serverPath": "node_modules/@ast-grep/cli/ast-grep",
-  "rust-analyzer.imports.prefix": "crate"
+  "rust-analyzer.imports.prefix": "crate",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
+++ b/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
@@ -26,6 +26,8 @@ The following options are available:
 | `--js` or `--javascript`                | Initialize as a JavaScript project                              |
 | `--tailwind`                            | Initialize with Tailwind CSS config (default)                   |
 | `--eslint`                              | Initialize with ESLint config                                   |
+| `--biome`                               | Initialize with Biome config                                    |
+| `--no-linter`                           | Skip linter configuration                                       |
 | `--app`                                 | Initialize as an App Router project                             |
 | `--api`                                 | Initialize a project with only route handlers                   |
 | `--src-dir`                             | Initialize inside a `src/` directory                            |
@@ -58,13 +60,23 @@ You will then be asked the following prompts:
 ```txt filename="Terminal"
 What is your project named?  my-app
 Would you like to use TypeScript?  No / Yes
-Would you like to use ESLint?  No / Yes
+Which linter would you like to use?  ESLint / Biome / None
 Would you like to use Tailwind CSS?  No / Yes
 Would you like your code inside a `src/` directory?  No / Yes
 Would you like to use App Router? (recommended)  No / Yes
 Would you like to use Turbopack for `next dev`?  No / Yes
 Would you like to customize the import alias (`@/*` by default)?  No / Yes
 ```
+
+### Linter Options
+
+**ESLint**: The traditional and most popular JavaScript linter. Includes Next.js-specific rules via `eslint-config-next`.
+
+**Biome**: A fast, modern linter and formatter that combines the functionality of ESLint and Prettier. Includes built-in Next.js and React domain support for optimal performance.
+
+**None**: Skip linter configuration entirely. You can always add a linter later.
+
+> **Note**: `next lint` command will be deprecated in Next.js 16. New projects should use the chosen linter directly (e.g., `biome check .` or `eslint .`).
 
 Once you've answered the prompts, a new project will be created with your chosen configuration.
 

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -31,6 +31,7 @@ export async function createApp({
   typescript,
   tailwind,
   eslint,
+  biome,
   app,
   srcDir,
   importAlias,
@@ -48,6 +49,7 @@ export async function createApp({
   typescript: boolean
   tailwind: boolean
   eslint: boolean
+  biome: boolean
   app: boolean
   srcDir: boolean
   importAlias: string
@@ -235,6 +237,7 @@ export async function createApp({
       isOnline,
       tailwind,
       eslint,
+      biome,
       srcDir,
       importAlias,
       skipInstall,

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -50,6 +50,8 @@ const program = new Command(packageJson.name)
   .option('--js, --javascript', 'Initialize as a JavaScript project.')
   .option('--tailwind', 'Initialize with Tailwind CSS config. (default)')
   .option('--eslint', 'Initialize with ESLint config.')
+  .option('--biome', 'Initialize with Biome config.')
+  .option('--no-linter', 'Skip linter configuration.')
   .option('--app', 'Initialize as an App Router project.')
   .option('--src-dir', "Initialize inside a 'src/' directory.")
   .option('--turbopack', 'Enable Turbopack by default for development.')
@@ -229,6 +231,7 @@ async function run(): Promise<void> {
     const defaults: typeof preferences = {
       typescript: true,
       eslint: false,
+      linter: 'none',
       tailwind: true,
       app: true,
       srcDir: false,
@@ -277,23 +280,62 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!opts.eslint && !args.includes('--no-eslint') && !opts.api) {
+    // Determine linter choice if not specified via CLI flags
+    if (!opts.eslint && !opts.biome && !opts.noLinter && !opts.api) {
       if (skipPrompt) {
-        opts.eslint = getPrefOrDefault('eslint')
+        const preferredLinter = getPrefOrDefault('linter')
+        opts.eslint = preferredLinter === 'eslint'
+        opts.biome = preferredLinter === 'biome'
+        opts.noLinter = preferredLinter === 'none'
       } else {
-        const styledEslint = blue('ESLint')
-        const { eslint } = await prompts({
+        const { linter } = await prompts({
           onState: onPromptState,
-          type: 'toggle',
-          name: 'eslint',
-          message: `Would you like to use ${styledEslint}?`,
-          initial: getPrefOrDefault('eslint'),
-          active: 'Yes',
-          inactive: 'No',
+          type: 'select',
+          name: 'linter',
+          message: 'Which linter would you like to use?',
+          choices: [
+            {
+              title: 'ESLint',
+              value: 'eslint',
+              description: 'The most popular linter',
+            },
+            {
+              title: 'Biome',
+              value: 'biome',
+              description: 'Fast formatter and linter',
+            },
+            {
+              title: 'None',
+              value: 'none',
+              description: 'Skip linter configuration',
+            },
+          ],
+          initial: 0,
         })
-        opts.eslint = Boolean(eslint)
-        preferences.eslint = Boolean(eslint)
+
+        opts.eslint = linter === 'eslint'
+        opts.biome = linter === 'biome'
+        opts.noLinter = linter === 'none'
+        preferences.linter = linter
+
+        // Keep backwards compatibility with old eslint preference
+        preferences.eslint = linter === 'eslint'
       }
+    } else if (opts.eslint) {
+      opts.biome = false
+      opts.noLinter = false
+      preferences.linter = 'eslint'
+      preferences.eslint = true
+    } else if (opts.biome) {
+      opts.eslint = false
+      opts.noLinter = false
+      preferences.linter = 'biome'
+      preferences.eslint = false
+    } else if (opts.noLinter) {
+      opts.eslint = false
+      opts.biome = false
+      preferences.linter = 'none'
+      preferences.eslint = false
     }
 
     if (!opts.tailwind && !args.includes('--no-tailwind') && !opts.api) {
@@ -426,6 +468,7 @@ async function run(): Promise<void> {
       typescript: opts.typescript,
       tailwind: opts.tailwind,
       eslint: opts.eslint,
+      biome: opts.biome,
       app: opts.app,
       srcDir: opts.srcDir,
       importAlias: opts.importAlias,
@@ -459,6 +502,7 @@ async function run(): Promise<void> {
       packageManager,
       typescript: opts.typescript,
       eslint: opts.eslint,
+      biome: opts.biome,
       tailwind: opts.tailwind,
       app: opts.app,
       srcDir: opts.srcDir,

--- a/packages/create-next-app/templates/app-api/js/biome.json
+++ b/packages/create-next-app/templates/app-api/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-api/js/biome.json
+++ b/packages/create-next-app/templates/app-api/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-api/ts/biome.json
+++ b/packages/create-next-app/templates/app-api/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-api/ts/biome.json
+++ b/packages/create-next-app/templates/app-api/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-empty/js/biome.json
+++ b/packages/create-next-app/templates/app-empty/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-empty/js/biome.json
+++ b/packages/create-next-app/templates/app-empty/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-empty/ts/biome.json
+++ b/packages/create-next-app/templates/app-empty/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-empty/ts/biome.json
+++ b/packages/create-next-app/templates/app-empty/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-tw/js/biome.json
+++ b/packages/create-next-app/templates/app-tw/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-tw/js/biome.json
+++ b/packages/create-next-app/templates/app-tw/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app-tw/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app-tw/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app/js/biome.json
+++ b/packages/create-next-app/templates/app/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app/js/biome.json
+++ b/packages/create-next-app/templates/app/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/app/ts/biome.json
+++ b/packages/create-next-app/templates/app/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/app/ts/biome.json
+++ b/packages/create-next-app/templates/app/ts/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,7 +7,13 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default-empty/js/biome.json
+++ b/packages/create-next-app/templates/default-empty/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default-empty/js/biome.json
+++ b/packages/create-next-app/templates/default-empty/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default-empty/ts/biome.json
+++ b/packages/create-next-app/templates/default-empty/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default-empty/ts/biome.json
+++ b/packages/create-next-app/templates/default-empty/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default-tw/js/biome.json
+++ b/packages/create-next-app/templates/default-tw/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default-tw/js/biome.json
+++ b/packages/create-next-app/templates/default-tw/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default-tw/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default-tw/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default/js/biome.json
+++ b/packages/create-next-app/templates/default/js/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default/js/biome.json
+++ b/packages/create-next-app/templates/default/js/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/default/ts/biome.json
+++ b/packages/create-next-app/templates/default/ts/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["node_modules", ".next", "dist", "build"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "next": "recommended",
+      "react": "recommended"
+    },
+    "rules": {
+      "recommended": true
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/packages/create-next-app/templates/default/ts/biome.json
+++ b/packages/create-next-app/templates/default/ts/biome.json
@@ -1,13 +1,19 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["node_modules", ".next", "dist", "build"]
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -16,15 +22,19 @@
   },
   "linter": {
     "enabled": true,
+    "rules": {
+      "recommended": true
+    },
     "domains": {
       "next": "recommended",
       "react": "recommended"
-    },
-    "rules": {
-      "recommended": true
     }
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -40,6 +40,7 @@ export const installTemplate = async ({
   mode,
   tailwind,
   eslint,
+  biome,
   srcDir,
   importAlias,
   skipInstall,
@@ -56,6 +57,7 @@ export const installTemplate = async ({
   const templatePath = path.join(__dirname, template, mode);
   const copySource = ["**"];
   if (!eslint) copySource.push("!eslint.config.mjs");
+  if (!biome) copySource.push("!biome.json");
   if (!tailwind) copySource.push("!postcss.config.mjs");
 
   await copy(copySource, root, {
@@ -191,7 +193,8 @@ export const installTemplate = async ({
       dev: `next dev${turbopack ? " --turbopack" : ""}`,
       build: "next build",
       start: "next start",
-      lint: "next lint",
+      ...(eslint && { lint: "next lint" }),
+      ...(biome && { lint: "biome check .", format: "biome format --write ." }),
     },
     /**
      * Default dependencies.
@@ -252,6 +255,14 @@ export const installTemplate = async ({
     };
   }
 
+  /* Biome dependencies. */
+  if (biome) {
+    packageJson.devDependencies = {
+      ...packageJson.devDependencies,
+      "@biomejs/biome": "^2",
+    };
+  }
+
   if (isApi) {
     delete packageJson.dependencies.react;
     delete packageJson.dependencies["react-dom"];
@@ -263,7 +274,9 @@ export const installTemplate = async ({
     // if a type error was thrown at `distDir/types/app/page.ts`.
     delete packageJson.devDependencies["@types/react-dom"];
 
+    // Remove linting scripts for API-only templates
     delete packageJson.scripts.lint;
+    delete packageJson.scripts.format;
   }
 
   const devDeps = Object.keys(packageJson.devDependencies).length;

--- a/packages/create-next-app/templates/types.ts
+++ b/packages/create-next-app/templates/types.ts
@@ -26,6 +26,7 @@ export interface InstallTemplateArgs {
   template: TemplateType;
   mode: TemplateMode;
   eslint: boolean;
+  biome: boolean;
   tailwind: boolean;
   srcDir: boolean;
   importAlias: string;

--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -6,7 +6,7 @@ import { isAbsolute, join } from 'path'
 import loadConfig from '../server/config'
 import { printAndExit } from '../server/lib/utils'
 import { Telemetry } from '../telemetry/storage'
-import { green } from '../lib/picocolors'
+import { green, yellow, bold } from '../lib/picocolors'
 import { ESLINT_DEFAULT_DIRS } from '../lib/constants'
 import { runLintCheck } from '../lib/eslint/runLintCheck'
 import { CompileError } from '../lib/compile-error'
@@ -64,6 +64,18 @@ const eslintOptions = (
 })
 
 const nextLint = async (options: NextLintOptions, directory?: string) => {
+  // Show deprecation warning
+  console.warn(
+    yellow(bold('⚠️  DEPRECATION WARNING: ')) +
+      yellow('`next lint` will be removed in Next.js 16.\n') +
+      'For new projects, use ' +
+      bold('create-next-app') +
+      ' to choose your preferred linter (ESLint or Biome).\n' +
+      'For existing projects, consider migrating to Biome for faster linting: ' +
+      bold('https://biomejs.dev') +
+      '\n'
+  )
+
   const baseDir = getProjectDir(directory)
 
   // Check if the provided directory exists


### PR DESCRIPTION
# Add Biome as a linter option in create-next-app

## What?
This PR adds Biome as a linter option in `create-next-app`, alongside ESLint and a new "None" option. It also adds a deprecation warning for `next lint` command, which will be removed in Next.js 16.

## Why?
Biome is a fast, modern linter and formatter that combines the functionality of ESLint and Prettier. It provides built-in Next.js and React domain support with optimal performance. This gives users more flexibility in choosing their preferred linting solution.

## How?
- Added a new `--biome` flag to `create-next-app` CLI
- Added a `--no-linter` flag to skip linter configuration entirely
- Updated the interactive prompt to offer three linter choices: ESLint, Biome, or None
- Added `biome.json` configuration files to all templates
- Updated documentation to explain the linter options
- Added a deprecation warning for the `next lint` command
- Updated package.json scripts based on the chosen linter

---
🔄 **This is a mirror of [upstream PR #82266](https://github.com/vercel/next.js/pull/82266)**