### PR TITLE
test: reduce artificial timeouts in runtime prefetch tests

### DIFF
--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/layout.tsx
@@ -25,7 +25,7 @@ export default async function Layout({ children }) {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value-layout">{`Cookie from layout: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/one/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/one/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/two/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/runtime-prefetchable-layout/two/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/layout.tsx
@@ -26,7 +26,7 @@ export default async function Layout({ children }) {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value-layout">{`Cookie from layout: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/one/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/one/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/two/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared-layout/two/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value-page">{`Cookie from page: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/shared.tsx
@@ -2,14 +2,13 @@ import { unstable_cacheLife } from 'next/cache'
 import { setTimeout } from 'timers/promises'
 
 export async function uncachedIO() {
-  await setTimeout(500)
+  await setTimeout(0)
 }
 
-export async function cachedDelay(time: number, cacheBuster?: any) {
+export async function cachedDelay(key: any) {
   'use cache'
   unstable_cacheLife('minutes')
-  console.log('cachedDelay', time, cacheBuster)
-  await setTimeout(time)
+  await setTimeout(1)
 }
 
 export function DebugRenderKind() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -25,7 +25,7 @@ async function CachedButShortLived() {
     // the rest of the settings don't matter for private caches,
     // because they are not persisted server-side
   })
-  await cachedDelay(500, [__filename])
+  await cachedDelay([__filename])
 
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -26,7 +26,7 @@ async function ShortLivedCache() {
     revalidate: 2 * 60,
     expire: 3 * 60, // < DYNAMIC_EXPIRE
   })
-  await cachedDelay(500, [__filename])
+  await cachedDelay([__filename])
 
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -26,7 +26,7 @@ async function ShortLivedCache() {
     revalidate: 2 * 60,
     expire: 3 * 60, // < DYNAMIC_EXPIRE
   })
-  await cachedDelay(500, [__filename])
+  await cachedDelay([__filename])
 
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -23,6 +23,6 @@ export default async function Page() {
 
 async function One(): Promise<never> {
   const cookieStore = await cookies()
-  await cachedDelay(500, ['/cookies', cookieStore.get('user-agent')?.value])
+  await cachedDelay(['/cookies', cookieStore.get('user-agent')?.value])
   throw new Error('Kaboom')
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-cookies/page.tsx
@@ -20,6 +20,6 @@ export default async function Page() {
 
 async function One() {
   const cookieStore = await cookies()
-  await cachedDelay(500, ['/cookies', cookieStore.get('user-agent')?.value])
+  await cachedDelay(['/cookies', cookieStore.get('user-agent')?.value])
   return <div id="timestamp">Timestamp: {Date.now()}</div>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -20,7 +20,7 @@ export default async function Page() {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -34,7 +34,7 @@ export default async function Page() {
 async function RuntimePrefetchable() {
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -21,7 +21,7 @@ export default async function Page({ params }: { params: Promise<Params> }) {
 
 async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
   const { id } = await params
-  await cachedDelay(500, [__filename, id])
+  await cachedDelay([__filename, id])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="param-value">{`Param: ${id}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -29,7 +29,7 @@ async function RuntimePrefetchable({
   searchParams: Promise<AnySearchParams>
 }) {
   const { searchParam } = await searchParams
-  await cachedDelay(500, [__filename, searchParam])
+  await cachedDelay([__filename, searchParam])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="search-param-value">{`Search param: ${searchParam}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -30,6 +30,6 @@ async function privateCache() {
   'use cache: private'
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return cookieValue
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -47,7 +47,7 @@ async function privateCache() {
   'use cache: private'
   const cookieStore = await cookies()
   const cookieValue = cookieStore.get('testCookie')?.value ?? null
-  await cachedDelay(500, [__filename, cookieValue])
+  await cachedDelay([__filename, cookieValue])
   return cookieValue
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -32,7 +32,7 @@ async function RuntimePrefetchable() {
 async function privateCache() {
   'use cache: private'
   const now = Date.now()
-  await cachedDelay(500, [__filename])
+  await cachedDelay([__filename])
   return now
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -34,7 +34,7 @@ async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
 async function privateCache(params: Promise<Params>) {
   'use cache: private'
   const { id } = await params
-  await cachedDelay(500, [__filename, id])
+  await cachedDelay([__filename, id])
   return id
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -42,7 +42,7 @@ async function RuntimePrefetchable({
 async function privateCache(searchParams: Promise<AnySearchParams>) {
   'use cache: private'
   const { searchParam } = await searchParams
-  await cachedDelay(500, [__filename, searchParam])
+  await cachedDelay([__filename, searchParam])
   return searchParam
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/shared.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/shared.tsx
@@ -2,14 +2,13 @@ import { unstable_cacheLife } from 'next/cache'
 import { setTimeout } from 'timers/promises'
 
 export async function uncachedIO() {
-  await setTimeout(500)
+  await setTimeout(0)
 }
 
-export async function cachedDelay(time: number, cacheBuster?: any) {
+export async function cachedDelay(key: any) {
   'use cache'
   unstable_cacheLife('minutes')
-  console.log('cachedDelay', time, cacheBuster)
-  await setTimeout(time)
+  await setTimeout(1)
 }
 
 export function DebugRenderKind() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -19,7 +19,7 @@ export default async function Page() {
 
 async function StaticallyPrefetchable() {
   const currentLang = await lang()
-  await cachedDelay(500, [__filename, currentLang])
+  await cachedDelay([__filename, currentLang])
   return (
     <div style={{ border: '1px solid blue', padding: '1em' }}>
       <div id="root-param-value">{`Lang: ${currentLang}`}</div>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -35,7 +35,7 @@ async function DynamicallyPrefetchable() {
 async function privateCache() {
   'use cache: private'
   const currentLang = await lang()
-  await cachedDelay(500, [__filename, currentLang])
+  await cachedDelay([__filename, currentLang])
   return currentLang
 }
 


### PR DESCRIPTION
the "wait for 500ms" thing was a leftover of me inspecting the test apps visually, we don't need it anymore and it slows the tests down unnecessarily

---
🔄 **This is a mirror of [upstream PR #82276](https://github.com/vercel/next.js/pull/82276)**