### PR TITLE
[devtools] Start animating issue count immediately

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
@@ -29,6 +29,7 @@ const Dialog: React.FC<DialogProps> = function Dialog({
   ...props
 }) {
   const dialogRef = React.useRef<HTMLDivElement | null>(null)
+  // TODO: Document is an external store. Either use useSyncExternalStore or always set the role.
   const [role, setRole] = React.useState<string | undefined>(
     typeof document !== 'undefined' && document.hasFocus()
       ? 'dialog'

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -4,6 +4,7 @@ import type {
   DevToolsScale,
 } from '../../../../shared'
 
+import { useDevOverlayContext } from '../../../../../dev-overlay.browser'
 import { css } from '../../../../utils/css'
 import EyeIcon from '../../../../icons/eye-icon'
 import { NEXT_DEV_TOOLS_SCALE } from '../../../../shared'
@@ -73,13 +74,10 @@ export function UserPreferencesBody({
   setScale: (value: DevToolsScale) => void
 }) {
   const { restartServer, isPending } = useRestartServer()
+  const { shadowRoot } = useDevOverlayContext()
 
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const portal = document.querySelector('nextjs-portal')
-    if (!portal) {
-      return
-    }
-
+    const portal = shadowRoot.host
     if (e.target.value === 'system') {
       portal.classList.remove('dark')
       portal.classList.remove('light')

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
@@ -1,10 +1,5 @@
 import { useEffect } from 'react'
 
-export const getShadowRoot = () => {
-  const portal = document.querySelector('nextjs-portal')
-  return portal?.shadowRoot
-}
-
 export function useFocusTrap(
   rootRef: React.RefObject<HTMLElement | null>,
   triggerRef: React.RefObject<HTMLButtonElement | null> | null,

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -1,6 +1,7 @@
 import './segment-boundary-trigger.css'
 import { useCallback, useState, useRef, useMemo } from 'react'
 import { Menu } from '@base-ui-components/react/menu'
+import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import type {
   SegmentBoundaryType,
   SegmentNodeState,
@@ -31,12 +32,7 @@ export function SegmentBoundaryTrigger({
   const { pagePath, boundaryType, setBoundaryType: onSelectBoundary } = currNode
 
   const [isOpen, setIsOpen] = useState(false)
-  // TODO: move this shadowRoot ref util to a shared hook or into context
-  const [shadowRoot] = useState<ShadowRoot>(() => {
-    const ownerDocument = document
-    const portalNode = ownerDocument.querySelector('nextjs-portal')!
-    return portalNode.shadowRoot! as ShadowRoot
-  })
+  const { shadowRoot } = useDevOverlayContext()
   const triggerRef = useRef<HTMLButtonElement>(null)
   const popupRef = useRef<HTMLDivElement>(null)
 

--- a/packages/next/src/next-devtools/dev-overlay/components/shadow-portal.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/shadow-portal.tsx
@@ -1,44 +1,8 @@
-import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useDevOverlayContext } from '../../dev-overlay.browser'
 
 export function ShadowPortal({ children }: { children: React.ReactNode }) {
-  const { state } = useDevOverlayContext()
-  let portalNode = React.useRef<HTMLElement | null>(null)
-  let shadowNode = React.useRef<ShadowRoot | null>(null)
-  let [, forceUpdate] = React.useState<{} | undefined>()
+  const { shadowRoot } = useDevOverlayContext()
 
-  // Don't use useLayoutEffect here, as it will cause warnings during SSR in React 18.
-  // Don't use useSyncExternalStore as an SSR gate unless you verified it doesn't
-  // downgrade a Transition of the initial root render to a sync render or
-  // we can assure the root render is not a Transition.
-  React.useEffect(() => {
-    const ownerDocument = document
-    portalNode.current = ownerDocument.querySelector('nextjs-portal')!
-
-    if (state.theme === 'dark') {
-      portalNode.current.classList.add('dark')
-      portalNode.current.classList.remove('light')
-    } else if (state.theme === 'light') {
-      portalNode.current.classList.add('light')
-      portalNode.current.classList.remove('dark')
-    } else {
-      portalNode.current.classList.remove('dark')
-      portalNode.current.classList.remove('light')
-    }
-
-    // We can only attach but never detach a shadow root.
-    // So if this is a remount, we don't need to attach a shadow root. Only
-    // on the very first, DOM-wide mount.
-    // This is mostly guarding against faulty _app implementations that
-    // create React Root in getInitialProps but don't clean it up like test/integration/app-tree/pages/_app.tsx
-    if (portalNode.current.shadowRoot === null) {
-      shadowNode.current = portalNode.current.attachShadow({ mode: 'open' })
-    }
-    forceUpdate({})
-  }, [state.theme])
-
-  // eslint-disable-next-line react-hooks/react-compiler -- TODO
-  const shadowRoot = shadowNode.current
-  return shadowRoot ? createPortal(children, shadowRoot as any) : null
+  return createPortal(children, shadowRoot)
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useState } from 'react'
+import { forwardRef } from 'react'
 import { Tooltip as BaseTooltip } from '@base-ui-components/react/tooltip'
+import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { cx } from '../../utils/cx'
 import './tooltip.css'
 
@@ -26,11 +27,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     },
     ref
   ) {
-    const [shadowRoot] = useState<ShadowRoot>(() => {
-      const ownerDocument = document
-      const portalNode = ownerDocument.querySelector('nextjs-portal')!
-      return portalNode.shadowRoot! as ShadowRoot
-    })
+    const { shadowRoot } = useDevOverlayContext()
     if (!title) {
       return children
     }

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -10,7 +10,6 @@ import { TurbopackInfoBody } from '../components/errors/dev-tools-indicator/dev-
 import { DevToolsHeader } from '../components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header'
 import { useDelayedRender } from '../hooks/use-delayed-render'
 import {
-  getShadowRoot,
   MENU_CURVE,
   MENU_DURATION_MS,
 } from '../components/errors/dev-tools-indicator/utils'
@@ -110,29 +109,27 @@ const MenuPanel = () => {
 
 // a little hacky but it does the trick
 const useToggleDevtoolsVisibility = () => {
-  const { state, dispatch } = useDevOverlayContext()
+  const { state, dispatch, shadowRoot } = useDevOverlayContext()
   return () => {
     dispatch({
       type: ACTION_DEV_INDICATOR_SET,
       disabled: !state.disableDevIndicator,
     })
-    const portal = getShadowRoot()
-    if (portal) {
-      const menuElement = portal.getElementById('panel-route') as HTMLElement
-      const indicatorElement = portal.getElementById(
-        'data-devtools-indicator'
-      ) as HTMLElement
 
-      if (menuElement && menuElement.firstElementChild) {
-        const firstChild = menuElement.firstElementChild as HTMLElement
-        const isCurrentlyHidden = firstChild.style.display === 'none'
-        firstChild.style.display = isCurrentlyHidden ? '' : 'none'
-      }
+    const menuElement = shadowRoot.getElementById('panel-route') as HTMLElement
+    const indicatorElement = shadowRoot.getElementById(
+      'data-devtools-indicator'
+    ) as HTMLElement
 
-      if (indicatorElement) {
-        const isCurrentlyHidden = indicatorElement.style.display === 'none'
-        indicatorElement.style.display = isCurrentlyHidden ? '' : 'none'
-      }
+    if (menuElement && menuElement.firstElementChild) {
+      const firstChild = menuElement.firstElementChild as HTMLElement
+      const isCurrentlyHidden = firstChild.style.display === 'none'
+      firstChild.style.display = isCurrentlyHidden ? '' : 'none'
+    }
+
+    if (indicatorElement) {
+      const isCurrentlyHidden = indicatorElement.style.display === 'none'
+      indicatorElement.style.display = isCurrentlyHidden ? '' : 'none'
     }
   }
 }


### PR DESCRIPTION
Removes a cascading update by replacing the state machine with a reducer.

Changes now behavior as far as I can tell. Though odd that the size is unstable considering we're using `tabular-nums`

Issues come in faster than animation duration:

https://github.com/user-attachments/assets/985d26d0-d0b3-40a1-a682-9c85252dedd0

Issues come in slower than animation duration:

https://github.com/user-attachments/assets/a5dccae4-b850-41fc-a185-5bc04373ffde



---
🔄 **This is a mirror of [upstream PR #82297](https://github.com/vercel/next.js/pull/82297)**