### PR TITLE
fix: next/root-params erroring when rerendering after action

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -771,5 +771,6 @@
   "770": "createParamsFromClient should not be called in a runtime prerender.",
   "771": "\\`%s\\` was called during a runtime prerender. Next.js should be preventing %s from being included in server components statically, but did not in this case.",
   "772": "FetchStrategy.PPRRuntime should never be used when `experimental.clientSegmentCache` is disabled",
-  "773": "Missing workStore in createPrerenderParamsForClientSegment"
+  "773": "Missing workStore in createPrerenderParamsForClientSegment",
+  "774": "Route %s used %s outside of a Server Component. This is not allowed."
 }

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/simple/app/[lang]/[locale]/rerender-after-server-action/page.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/simple/app/[lang]/[locale]/rerender-after-server-action/page.tsx
@@ -1,0 +1,37 @@
+import { lang, locale } from 'next/root-params'
+import { connection } from 'next/server'
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  const currentLang = await lang()
+  const currentLocale = await locale()
+  return (
+    <main>
+      <div>
+        Root params are{' '}
+        <span id="root-params">
+          {currentLang} {currentLocale}
+        </span>
+      </div>
+      <Suspense fallback="Loading...">
+        <Timestamp />
+      </Suspense>
+      <form
+        action={async () => {
+          'use server'
+          // rerender the page and return it alongside the action result
+          const cookieStore = await cookies()
+          cookieStore.set('my-cookie', Date.now() + '')
+        }}
+      >
+        <button type="submit">Submit form</button>
+      </form>
+    </main>
+  )
+}
+
+async function Timestamp() {
+  await connection()
+  return <div id="timestamp">{Date.now()}</div>
+}


### PR DESCRIPTION
When implementing the check that disallows using `next/root-params` in server actions, i forgot that when a page is rerendered after an action, the render is still wrapped with an `actionAsyncStorage` with `actionStore.isAction === true`. The fix is to also check that we're in the `'action'` phase, i.e. we haven't switched to rendering yet.

Closes #82302

---
🔄 **This is a mirror of [upstream PR #82326](https://github.com/vercel/next.js/pull/82326)**