### PR TITLE
[Cache Components] give the "seconds" profile a 30s staleTime

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1354,7 +1354,7 @@ export const defaultConfig = Object.freeze({
         expire: INFINITE_CACHE,
       },
       seconds: {
-        stale: undefined, // defaults to staleTimes.dynamic
+        stale: 30, // 30 seconds
         revalidate: 1, // 1 second
         expire: 60, // 1 minute
       },

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -942,18 +942,6 @@ function assignDefaults(
           result.expireTime ?? defaultDefault.expire
       }
     }
-    // This is the most dynamic cache life profile.
-    const secondsCacheLifeProfile = result.experimental.cacheLife['seconds']
-    if (
-      secondsCacheLifeProfile &&
-      secondsCacheLifeProfile.stale === undefined
-    ) {
-      // We default this to whatever stale time you had configured for dynamic content.
-      // Since this is basically a dynamic cache life profile.
-      const dynamicStaleTime = result.experimental.staleTimes?.dynamic
-      secondsCacheLifeProfile.stale =
-        dynamicStaleTime ?? defaultConfig.experimental?.staleTimes?.dynamic
-    }
   }
 
   if (result.experimental?.cacheHandlers) {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -7,8 +7,8 @@ export default async function Page() {
     <main>
       <DebugRenderKind />
       <p id="intro">
-        This page uses a short-lived public cache (expire &lt; DYNAMIC_EXPIRE,
-        5min), which should not be included in a static prefetch, but should be
+        This page uses a short-lived private cache (with cacheLife("seconds")),
+        which should not be included in a static prefetch, but should be
         included in a runtime prefetch, because it has a long enough stale time
         (&ge; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
       </p>
@@ -20,12 +20,8 @@ export default async function Page() {
 }
 
 async function ShortLivedCache() {
-  'use cache'
-  unstable_cacheLife({
-    stale: 60, // > RUNTIME_PREFETCH_DYNAMIC_STALE
-    revalidate: 2 * 60,
-    expire: 3 * 60, // < DYNAMIC_EXPIRE
-  })
+  'use cache: private'
+  unstable_cacheLife('seconds')
   await cachedDelay([__filename])
 
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -7,8 +7,8 @@ export default async function Page() {
     <main>
       <DebugRenderKind />
       <p id="intro">
-        This page uses a short-lived public cache (expire &lt; DYNAMIC_EXPIRE,
-        5min), which should not be included in a static prefetch, but should be
+        This page uses a short-lived public cache (with cacheLife("seconds")),
+        which should not be included in a static prefetch, but should be
         included in a runtime prefetch, because it has a long enough stale time
         (&ge; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
       </p>
@@ -21,11 +21,7 @@ export default async function Page() {
 
 async function ShortLivedCache() {
   'use cache'
-  unstable_cacheLife({
-    stale: 60, // > RUNTIME_PREFETCH_DYNAMIC_STALE
-    revalidate: 2 * 60,
-    expire: 3 * 60, // < DYNAMIC_EXPIRE
-  })
+  unstable_cacheLife('seconds')
   await cachedDelay([__filename])
 
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
@@ -189,6 +189,40 @@ export default async function Page() {
             </li>
           </ul>
         </li>
+        <li>
+          public, cacheLife("seconds")
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/public-seconds"
+                prefetch={'auto'}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/public-seconds"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          private, cacheLife("seconds")
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/private-seconds"
+                prefetch={'auto'}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/caches/private-seconds"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
       </ul>
 
       <h2>misc</h2>


### PR DESCRIPTION
Closes NAR-262

---
🔄 **This is a mirror of [upstream PR #82332](https://github.com/vercel/next.js/pull/82332)**