### PR TITLE
chore: fix eslint-typechecked-require with template

### DIFF
--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
@@ -34,12 +34,25 @@ module.exports = {
         node.callee.type !== 'Identifier' ||
         node.callee.name !== 'require' ||
         node.arguments.length !== 1 ||
-        node.arguments[0].type !== 'Literal'
+        !(
+          node.arguments[0].type === 'Literal' ||
+          node.arguments[0].type === 'TemplateLiteral'
+        )
       ) {
         return
       }
 
-      const requireSource = node.arguments[0].value
+      let requireSource = node.arguments[0].value
+      if (node.arguments[0].type === 'TemplateLiteral') {
+        if (node.arguments[0].quasis.length === 1) {
+          requireSource = node.arguments[0].quasis[0].value.cooked
+        } else {
+          // Ignore template literals with placeholders
+          return
+        }
+      } else {
+        requireSource = node.arguments[0].value
+      }
       const parent = node.parent
 
       // json is fine because we have resolveJsonModule disabled in our TS project

--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
@@ -42,7 +42,7 @@ module.exports = {
         return
       }
 
-      let requireSource = node.arguments[0].value
+      let requireSource
       if (node.arguments[0].type === 'TemplateLiteral') {
         if (node.arguments[0].quasis.length === 1) {
           requireSource = node.arguments[0].quasis[0].value.cooked

--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.test.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.test.js
@@ -228,7 +228,18 @@ describe('require-cast-to-import ESLint rule', () => {
         ],
         output: `const lodash = (require('underscore') as typeof import('underscore'))`,
       },
-
+      // ❌ Mismatched sources - template literal
+      {
+        code: `const lodash = require(\`lodash\`) as typeof import('underscore')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'mismatchedSource',
+            data: { requireSource: 'lodash', importSource: 'underscore' },
+          },
+        ],
+        output: `const lodash = (require('underscore') as typeof import('underscore'))`,
+      },
       // ❌ Scoped packages - missing cast
       {
         code: `const types = require('@types/node')`,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82328](https://github.com/vercel/next.js/pull/82328)**