### PR TITLE
fix(turbo-tasks-fs): change FS to_sys_path to be synchronous

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -541,7 +541,7 @@ async fn benchmark_file_io(
         ))?
         .await?;
 
-    let directory = fs.to_sys_path(directory).await?;
+    let directory = fs.to_sys_path(directory)?;
     let temp_path = directory.join(format!(
         "tmp_file_io_benchmark_{:x}",
         rand::random::<u128>()

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -152,8 +152,7 @@ pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<S
                 .to_sys_path(match path {
                     Some(path) => root.join(path)?,
                     None => root,
-                })
-                .await?
+                })?
                 .to_string_lossy()
         )
         .split('/')
@@ -171,12 +170,10 @@ pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<S
         .context("Expected root to have a DiskFileSystem")?
         .await?;
 
-    let sys_path = root_fs
-        .to_sys_path(match path {
-            Some(path) => root.join(path.into())?,
-            None => root,
-        })
-        .await?;
+    let sys_path = root_fs.to_sys_path(match path {
+        Some(path) => root.join(path.into())?,
+        None => root,
+    })?;
 
     let raw_path = sys_path.to_string_lossy().to_string();
     let normalized_path = raw_path.replace('\\', "/");


### PR DESCRIPTION
### What?
Just remove `async` of `DiskFileSystem::to_sys_path` 

---
🔄 **This is a mirror of [upstream PR #82341](https://github.com/vercel/next.js/pull/82341)**