### PR TITLE
wrap devtools stories in context providers

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CallStackFrame } from './call-stack-frame'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof CallStackFrame> = {
   component: CallStackFrame,
@@ -22,7 +23,7 @@ const meta: Meta<typeof CallStackFrame> = {
       },
     },
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack/call-stack.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack/call-stack.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CallStack } from './call-stack'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof CallStack> = {
   component: CallStack,
@@ -22,7 +23,7 @@ const meta: Meta<typeof CallStack> = {
       },
     },
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CodeFrame } from './code-frame'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof CodeFrame> = {
   component: CodeFrame,
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import type { OverlayState } from '../../shared'
 
 import { DevToolsIndicator } from './devtools-indicator'
-import { INITIAL_OVERLAY_STATE } from '../../shared'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof DevToolsIndicator> = {
   component: DevToolsIndicator,
@@ -13,6 +12,7 @@ const meta: Meta<typeof DevToolsIndicator> = {
   argTypes: {},
   decorators: [
     withShadowPortal,
+    withDevOverlayContexts(),
     // Test for high z-index
     (Story) => (
       <div
@@ -39,31 +39,22 @@ const meta: Meta<typeof DevToolsIndicator> = {
 export default meta
 type Story = StoryObj<typeof DevToolsIndicator>
 
-const state: OverlayState = {
-  ...INITIAL_OVERLAY_STATE,
-  routerType: 'app',
-  isErrorOverlayOpen: false,
-}
-
 export const Default: Story = {
-  args: {
-    state,
-    dispatch: () => {},
-  },
+  decorators: [withDevOverlayContexts()],
 }
 
 export const SingleError: Story = {
-  args: {
-    errorCount: 1,
-    state,
-    dispatch: () => {},
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 1,
+    }),
+  ],
 }
 
 export const MultipleErrors: Story = {
-  args: {
-    errorCount: 3,
-    state,
-    dispatch: () => {},
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 3,
+    }),
+  ],
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.stories.tsx
@@ -1,91 +1,114 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { NextLogo } from './next-logo'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
-// TODO: NEXT-4642
-const StoryBookNextLogo = (
-  _: {
-    issueCount: number
-    isDevBuilding: boolean
-    isDevRendering: boolean
-  } & Record<string, unknown>
-) => {
-  return <NextLogo onTriggerClick={() => {}} />
-}
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
-const meta: Meta<typeof StoryBookNextLogo> = {
-  component: StoryBookNextLogo,
+const meta: Meta<typeof NextLogo> = {
+  component: NextLogo,
   parameters: {
     layout: 'centered',
   },
   args: {
-    'aria-label': 'Open Next.js DevTools',
+    onTriggerClick: () => {},
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta
-type Story = StoryObj<typeof StoryBookNextLogo>
+type Story = StoryObj<typeof NextLogo>
 
 export const NoIssues: Story = {
-  args: {
-    issueCount: 0,
-    isDevBuilding: false,
-    isDevRendering: false,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 0,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: false,
+      },
+    }),
+  ],
 }
 
 export const SingleIssue: Story = {
-  args: {
-    issueCount: 1,
-    isDevBuilding: false,
-    isDevRendering: false,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 1,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: false,
+      },
+    }),
+  ],
 }
 
 export const MultipleIssues: Story = {
-  args: {
-    issueCount: 5,
-    isDevBuilding: false,
-    isDevRendering: false,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 5,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: false,
+      },
+    }),
+  ],
 }
 
 export const ManyIssues: Story = {
-  args: {
-    issueCount: 99,
-    isDevBuilding: false,
-    isDevRendering: false,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 99,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: false,
+      },
+    }),
+  ],
 }
 
 export const Building: Story = {
-  args: {
-    issueCount: 0,
-    isDevBuilding: true,
-    isDevRendering: false,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 0,
+      state: {
+        buildingIndicator: true,
+        renderingIndicator: false,
+      },
+    }),
+  ],
 }
 
 export const BuildingWithError: Story = {
-  args: {
-    issueCount: 1,
-    isDevBuilding: true,
-    isDevRendering: false,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 1,
+      state: {
+        buildingIndicator: true,
+        renderingIndicator: false,
+      },
+    }),
+  ],
 }
 
 export const Rendering: Story = {
-  args: {
-    issueCount: 0,
-    isDevBuilding: false,
-    isDevRendering: true,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 0,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: true,
+      },
+    }),
+  ],
 }
 
 export const RenderingWithError: Story = {
-  args: {
-    issueCount: 1,
-    isDevBuilding: false,
-    isDevRendering: true,
-  },
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 1,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: true,
+      },
+    }),
+  ],
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/environment-name-label/environment-name-label.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/environment-name-label/environment-name-label.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { EnvironmentNameLabel } from './environment-name-label'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof EnvironmentNameLabel> = {
   component: EnvironmentNameLabel,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorMessage } from './error-message'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof ErrorMessage> = {
   component: ErrorMessage,
@@ -22,7 +23,7 @@ const meta: Meta<typeof ErrorMessage> = {
       },
     },
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorOverlayCallStack } from './error-overlay-call-stack'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof ErrorOverlayCallStack> = {
   component: ErrorOverlayCallStack,
@@ -22,7 +23,7 @@ const meta: Meta<typeof ErrorOverlayCallStack> = {
       },
     },
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorOverlayLayout } from './error-overlay-layout'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof ErrorOverlayLayout> = {
   component: ErrorOverlayLayout,
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorOverlayNav } from './error-overlay-nav'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof ErrorOverlayNav> = {
   component: ErrorOverlayNav,
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorOverlayPagination } from './error-overlay-pagination'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 import { useState } from 'react'
 import type { ReadyRuntimeError } from '../../../utils/get-error-by-type'
 
@@ -9,7 +10,7 @@ const meta: Meta<typeof ErrorOverlayPagination> = {
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/copy-error-button.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/copy-error-button.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CopyErrorButton } from './copy-error-button'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof CopyErrorButton> = {
   component: CopyErrorButton,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/docs-link-button.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/docs-link-button.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { DocsLinkButton } from './docs-link-button'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof DocsLinkButton> = {
   component: DocsLinkButton,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorOverlayToolbar } from './error-overlay-toolbar'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof ErrorOverlayToolbar> = {
   component: ErrorOverlayToolbar,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/issue-feedback-button.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/issue-feedback-button.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { IssueFeedbackButton } from './issue-feedback-button'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof IssueFeedbackButton> = {
   component: IssueFeedbackButton,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/nodejs-inspector-button.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/nodejs-inspector-button.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { NodejsInspectorButton } from './nodejs-inspector-button'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof NodejsInspectorButton> = {
   component: NodejsInspectorButton,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-type-label/error-type-label.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-type-label/error-type-label.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorTypeLabel } from './error-type-label'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof ErrorTypeLabel> = {
   component: ErrorTypeLabel,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/terminal/terminal.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/terminal/terminal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Terminal } from './terminal'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof Terminal> = {
   component: Terminal,
@@ -19,7 +20,7 @@ const meta: Meta<typeof Terminal> = {
       },
     },
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { VersionStalenessInfo } from './version-staleness-info'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof VersionStalenessInfo> = {
   component: VersionStalenessInfo,
   parameters: {
     layout: 'centered',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/container/build-error.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/build-error.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { BuildError } from './build-error'
 import { withShadowPortal } from '../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof BuildError> = {
   component: BuildError,
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { Errors } from './errors'
 import { withShadowPortal } from '../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../storybook/with-dev-overlay-contexts'
 import { lorem } from '../utils/lorem'
 import { runtimeErrors } from '../storybook/errors'
 
@@ -10,7 +11,7 @@ const meta: Meta<typeof Errors> = {
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/container/runtime-error/component-stack-pseudo-html.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/runtime-error/component-stack-pseudo-html.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { PseudoHtmlDiff } from './component-stack-pseudo-html'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
+import { withDevOverlayContexts } from '../../storybook/with-dev-overlay-contexts'
 
 const meta: Meta<typeof PseudoHtmlDiff> = {
   component: PseudoHtmlDiff,
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [withShadowPortal],
+  decorators: [withShadowPortal, withDevOverlayContexts()],
 }
 
 export default meta

--- a/packages/next/src/next-devtools/dev-overlay/storybook/with-dev-overlay-contexts.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/storybook/with-dev-overlay-contexts.tsx
@@ -1,0 +1,67 @@
+import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { DevOverlayContext } from '../../dev-overlay.browser'
+import { RenderErrorContext } from '../dev-overlay'
+import { PanelRouterContext, type PanelStateKind } from '../menu/context'
+import { INITIAL_OVERLAY_STATE } from '../shared'
+import type { OverlayState, DispatcherEvent } from '../shared'
+import type { ReadyRuntimeError } from '../utils/get-error-by-type'
+
+interface WithDevOverlayContextsProps {
+  state?: Partial<OverlayState>
+  dispatch?: (action: DispatcherEvent) => void
+  runtimeErrors?: ReadyRuntimeError[]
+  totalErrorCount?: number
+  panel?: PanelStateKind | null
+  setPanel?: Dispatch<SetStateAction<PanelStateKind | null>>
+  selectedIndex?: number
+  setSelectedIndex?: Dispatch<SetStateAction<number>>
+}
+
+export const withDevOverlayContexts =
+  (props?: WithDevOverlayContextsProps) => (Story: any) => {
+    const [panel, setPanel] = useState<PanelStateKind | null>(
+      props?.panel ?? null
+    )
+    const [selectedIndex, setSelectedIndex] = useState(
+      props?.selectedIndex ?? -1
+    )
+    const triggerRef = useRef<HTMLButtonElement>(null)
+
+    const defaultState: OverlayState = {
+      ...INITIAL_OVERLAY_STATE,
+      routerType: 'app',
+      isErrorOverlayOpen: false,
+      ...props?.state,
+    }
+
+    const defaultDispatch = props?.dispatch || (() => {})
+
+    return (
+      <DevOverlayContext.Provider
+        value={{
+          state: defaultState,
+          dispatch: defaultDispatch,
+          getSquashedHydrationErrorDetails: () => null,
+        }}
+      >
+        <RenderErrorContext.Provider
+          value={{
+            runtimeErrors: props?.runtimeErrors ?? [],
+            totalErrorCount: props?.totalErrorCount ?? 0,
+          }}
+        >
+          <PanelRouterContext.Provider
+            value={{
+              panel,
+              setPanel: props?.setPanel ?? setPanel,
+              triggerRef,
+              selectedIndex,
+              setSelectedIndex: props?.setSelectedIndex ?? setSelectedIndex,
+            }}
+          >
+            <Story />
+          </PanelRouterContext.Provider>
+        </RenderErrorContext.Provider>
+      </DevOverlayContext.Provider>
+    )
+  }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3458,12 +3458,6 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/eslint-utils@4.5.1':
-    resolution: {integrity: sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8943,10 +8937,6 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.2.0:
-    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -14011,6 +14001,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.11.0:
@@ -15123,6 +15114,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -15487,7 +15479,7 @@ packages:
   superagent@3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superstruct@1.0.3:
     resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
@@ -18697,11 +18689,6 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.4.0(eslint@9.12.0)':
-    dependencies:
-      eslint: 9.12.0
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.5.1(eslint@9.12.0)':
     dependencies:
       eslint: 9.12.0
       eslint-visitor-keys: 3.4.3
@@ -22920,7 +22907,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.0
       cosmiconfig: 7.1.0
-      resolve: 1.22.8
+      resolve: 1.22.10
 
   babel-plugin-polyfill-corejs2@0.4.13(@babel/core@7.26.10):
     dependencies:
@@ -25748,8 +25735,6 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.0: {}
-
   eslint-visitor-keys@4.2.1: {}
 
   eslint@7.32.0:
@@ -25885,7 +25870,7 @@ snapshots:
 
   eslint@9.12.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.12.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.12.0)
       '@eslint-community/regexpp': 4.11.1
       '@eslint/config-array': 0.18.0
       '@eslint/core': 0.6.0
@@ -25903,7 +25888,7 @@ snapshots:
       debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.1.0
-      eslint-visitor-keys: 4.2.0
+      eslint-visitor-keys: 4.2.1
       espree: 10.2.0
       esquery: 1.6.0
       esutils: 2.0.3
@@ -25927,7 +25912,7 @@ snapshots:
     dependencies:
       acorn: 8.14.0
       acorn-jsx: 5.3.2(acorn@8.14.0)
-      eslint-visitor-keys: 4.2.0
+      eslint-visitor-keys: 4.2.1
 
   espree@7.3.1:
     dependencies:


### PR DESCRIPTION
Wraps stories in context providers, and replaces any old arguments that were being passed before the props -> context refactor in devtools

Closes NEXT-4642

---
🔄 **This is a mirror of [upstream PR #82345](https://github.com/vercel/next.js/pull/82345)**