### PR TITLE
Update Rspack production test manifest

### DIFF
--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -847,6 +847,7 @@
       "app-root-param-getters - simple should allow reading root params in nested pages",
       "app-root-param-getters - simple should error when used in a route handler (until we implement it)",
       "app-root-param-getters - simple should error when used in a server action",
+      "app-root-param-getters - simple should not error when rerendering the page after a server action",
       "app-root-param-getters - simple should render the not found page without errors"
     ],
     "failed": [],
@@ -1690,6 +1691,28 @@
   },
   "test/e2e/app-dir/build-size/index.test.ts": {
     "passed": ["app-dir build size should have correct size in build output"],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/bun-externals/bun-externals.test.ts": {
+    "passed": [
+      "app-dir - bun externals should handle bun builtins as external modules",
+      "app-dir - bun externals should handle bun builtins in edge runtime",
+      "app-dir - bun externals should handle bun builtins in route handlers",
+      "app-dir - bun externals should handle bun builtins in server actions",
+      "app-dir - bun externals should not bundle bun builtins in server bundles"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts": {
+    "passed": [
+      "hello-world should not indicate there is an error when incidental math.random calls occur during component tree generation during build"
+    ],
     "failed": [],
     "pending": [],
     "flakey": [],
@@ -6257,6 +6280,17 @@
   },
   "test/e2e/app-dir/turbopack-reports/turbopack-reports.test.ts": {
     "passed": ["turbopack-reports should render page importing sqlite3"],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/typed-routes/typed-routes.test.ts": {
+    "passed": [
+      "typed-routes should correctly convert custom route patterns from path-to-regexp to bracket syntax",
+      "typed-routes should generate route types correctly",
+      "typed-routes should throw type errors"
+    ],
     "failed": [],
     "pending": [],
     "flakey": [],
@@ -18728,6 +18762,17 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/integration/webpack-bun-externals/test/index.test.js": {
+    "passed": [
+      "Webpack - Bun Externals should externalize Bun builtins in server bundles",
+      "Webpack - Bun Externals should not bundle Bun module implementations",
+      "Webpack - Bun Externals should successfully build with Bun module imports"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/integration/webpack-config-extensionalias/test/index.test.js": {
     "passed": [
       "webpack config with extensionAlias setting should run correctly with an tsx file import with .js extension"
@@ -20004,10 +20049,11 @@
   },
   "test/production/pnpm-support/index.test.ts": {
     "passed": [
-      "pnpm support should build with dependencies installed via pnpm",
+      "pnpm support should build with dependencies installed via pnpm"
+    ],
+    "failed": [
       "pnpm support should execute client-side JS on each page in output: \"standalone\""
     ],
-    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
This auto-generated PR updates the production integration test manifest used when testing Rspack.

---
🔄 **This is a mirror of [upstream PR #82354](https://github.com/vercel/next.js/pull/82354)**