### PR TITLE
[Cache Components] Only validate the shell on SSR render

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -572,31 +572,6 @@ async function generateDynamicFlightRenderResult(
     options
   )
 
-  if (
-    // We only want this behavior when running `next dev`
-    renderOpts.dev &&
-    // We only want this behavior when we have React's dev builds available
-    process.env.NODE_ENV === 'development' &&
-    // We only have a Prerender environment for projects opted into cacheComponents
-    renderOpts.experimental.cacheComponents
-  ) {
-    const [resolveValidation, validationOutlet] = createValidationOutlet()
-    RSCPayload._validation = validationOutlet
-
-    const devValidatingFallbackParams =
-      getRequestMeta(req, 'devValidatingFallbackParams') || null
-
-    spawnDynamicValidationInDev(
-      resolveValidation,
-      ctx.componentMod.tree,
-      ctx,
-      false,
-      ctx.clientReferenceManifest,
-      requestStore,
-      devValidatingFallbackParams
-    )
-  }
-
   // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
   // which contains the subset React.
   const flightReadableStream = workUnitAsyncStorage.run(

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -1,6 +1,11 @@
 import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
-import { assertNoRedbox, hasErrorToast, retry } from 'next-test-utils'
+import {
+  assertNoRedbox,
+  assertNoErrorToast,
+  hasErrorToast,
+  retry,
+} from 'next-test-utils'
 import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
@@ -32,7 +37,7 @@ describe('Cache Components Dev Errors', () => {
     `)
   })
 
-  it('should show a red box error on client navigations', async () => {
+  it('should not show a red box error on client navigations', async () => {
     const browser = await next.browser('/no-error')
 
     await retry(async () => {
@@ -40,6 +45,9 @@ describe('Cache Components Dev Errors', () => {
     })
 
     await browser.elementByCss("[href='/error']").click()
+    await assertNoErrorToast(browser)
+
+    await browser.loadPage(`${next.url}/error`)
 
     // TODO: React should not include the anon stack in the Owner Stack.
     await expect(browser).toDisplayCollapsedRedbox(`


### PR DESCRIPTION
Prior to this change on every navigation we would validate that the initial static shell satisified the rules of cache components. This offers more protection as you edit pages but it slows down navigations and we are already concerned with dev speed and the extra CPU contention can potenially hide or exacerbate other performance characteristics you might notice in dev.

So for now we will only validate a page on initial load. This means that if you are trying to debug a page's static shell suitability you will need to refresh the page not just navigate to and from it.

---
🔄 **This is a mirror of [upstream PR #82381](https://github.com/vercel/next.js/pull/82381)**