### PR TITLE
Turbopack: Share entrypoint template logic between Turbopack/webpack

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -31,8 +31,7 @@
       { "type": "user", "pattern": "valorkin" },
       { "type": "user", "pattern": "xc2" },
       { "type": "user", "pattern": "zackarychapple" },
-      { "type": "user", "pattern": "zoolsher" },
-      "packages/next/src/build/**"
+      { "type": "user", "pattern": "zoolsher" }
     ],
     "created-by: Chrome Aurora": [
       { "type": "user", "pattern": "atcastle" },

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,8 +52,10 @@ jobs:
       is-release: ${{ steps.is-release.outputs.IS_RELEASE == 'true' }}
       rspack: >-
         ${{
-          github.event_name == 'pull_request' &&
-          contains(github.event.pull_request.labels.*.name, 'Rspack')
+          steps.is-release.outputs.IS_RELEASE == 'true' || (
+            github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'Rspack')
+          )
         }}
 
   build-native:

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -32,6 +32,8 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vercel'
+    outputs:
+      next-version: ${{ steps.version.outputs.value }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -49,6 +51,19 @@ jobs:
         with:
           fetch-depth: 25
 
+      - id: nextPackageInfo
+        name: Get `next` package info
+        run: |
+          cd packages/next 
+          {
+            echo 'value<<EOF'
+            cat package.json
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - id: version
+        name: Extract `next` version
+        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+
       - name: Setup test project
         run: |
           pnpm install
@@ -56,7 +71,7 @@ jobs:
           node scripts/run-e2e-test-project-reset.mjs
 
   test-deploy:
-    name: test deploy
+    name: Run Deploy Tests
     needs: setup
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
@@ -77,7 +92,7 @@ jobs:
     if: ${{ always() }}
 
     runs-on: ubuntu-latest
-    name: report test results to datadog
+    name: Report test results to datadog
     steps:
       - name: Download test report artifacts
         id: download-test-reports
@@ -93,9 +108,79 @@ jobs:
             DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
           fi
 
-  sync-repositories:
-    needs: test-deploy
-    if: ${{ always() && github.repository_owner == 'vercel' && github.event_name == 'release' }}
+  create-draft-prs:
+    name: Immediately open draft prs
+    needs: setup
+    if: ${{ github.repository_owner == 'vercel' && github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: front
+            workflow_id: cron-update-next.yml
+          - repo: v0
+            workflow_id: update-next.yml
+    steps:
+      - name: Check token
+        run: gh auth status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+      - uses: actions/github-script@v7
+        name: Check if target workflow is enabled
+        id: check-workflow-enabled
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
+          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+          result-encoding: string
+          script: |
+            const response = await github.request(
+              "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
+              {
+                owner: "vercel",
+                repo: "${{ matrix.repo }}",
+                workflow_id: "${{ matrix.workflow_id }}",
+              }
+            );
+
+            const isEnabled = response.data.state === 'active';
+            console.info(`Target workflow state: ${response.data.state}`);
+            console.info(`Target workflow enabled: ${isEnabled}`);
+
+            return isEnabled ? 'true' : 'false';
+      - uses: actions/github-script@v7
+        name: Create draft PR for vercel/${{ matrix.repo }}
+        id: create-draft-pr
+        if: steps.check-workflow-enabled.outputs.result == 'true'
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,404
+          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+          result-encoding: string
+          script: |
+            const inputs = {
+              version: "${{ needs.setup.outputs.next-version }}"
+            };
+
+            await github.request(
+              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+              {
+                owner: "vercel",
+                repo: "${{ matrix.repo }}",
+                workflow_id: "${{ matrix.workflow_id }}",
+                ref: "main",
+                inputs: inputs,
+              }
+            );
+
+            console.info(`Draft PR creation triggered for ${{ matrix.repo }}`);
+            console.info(`Workflow will create draft PR by default`);
+
+  update-prs:
+    name: Update prs as ready for review
+    needs: [test-deploy, create-draft-prs]
+    if: ${{ needs.test-deploy.result == 'success' && github.repository_owner == 'vercel' && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -108,22 +193,6 @@ jobs:
             workflow_id: update-next.yml
             workflow_url: https://github.com/vercel/v0/actions/workflows/update-next.yml?query=event%3Aworkflow_dispatch
     steps:
-      - uses: actions/checkout@v4
-      - id: nextPackageInfo
-        name: Get `next` package info
-        run: |
-          cd packages/next 
-          {
-            echo 'value<<EOF'
-            cat package.json
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-      - id: version
-        name: Extract `next` version
-        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
-      - id: test-result
-        name: Set test result variable
-        run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
       - name: Check token
         run: gh auth status
         env:
@@ -157,8 +226,8 @@ jobs:
               return 'false';
             }
       - uses: actions/github-script@v7
-        name: Trigger vercel/${{ matrix.repo }} sync
-        id: trigger-sync
+        name: Mark PR ready for review in vercel/${{ matrix.repo }}
+        id: mark-pr-ready
         if: steps.check-workflow-enabled.outputs.result == 'true'
         with:
           retries: 3
@@ -169,14 +238,11 @@ jobs:
           # Note `workflow_id` and `inputs` are contract between vercel/${{ matrix.repo }},
           # if these need to be changed both side should be updated accordingly.
           script: |
-            const immediatelyClose = '${{ steps.test-result.outputs.immediately-close }}';
             const inputs = {
-              version: "${{ steps.version.outputs.value }}",
+              version: "${{ needs.setup.outputs.next-version }}",
+              'make-ready-for-review': 'true',
+              force: 'true'
             };
-
-            if (immediatelyClose === 'true') {
-              inputs['immediately-close'] = 'true';
-            }
 
             await github.request(
               "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
@@ -188,16 +254,8 @@ jobs:
                 inputs: inputs,
               }
             );
-            // Ideally we'd include a URL to this specific sync.
-            // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
+
+            console.info("Tests passed - PR will be marked ready for review");
             console.info(
-              "Sync started in ${{ matrix.workflow_url }}"
+              "PR ready-for-review triggered in ${{ matrix.workflow_url }}"
             );
-            console.info(
-              "This may not start a new sync if one is already in progress. Check the logs of the workflow run."
-            );
-            if (immediatelyClose === 'true') {
-              console.info(
-                "Sync triggered with immediately-close=true due to test failure."
-              );
-            }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,6 +4280,7 @@ dependencies = [
  "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-malloc",
+ "turbo-unix-path",
  "turbopack",
  "turbopack-browser",
  "turbopack-core",
@@ -4340,6 +4341,7 @@ dependencies = [
  "mime_guess",
  "modularize_imports",
  "next-custom-transforms",
+ "next-taskless",
  "once_cell",
  "percent-encoding",
  "qstring",
@@ -4431,6 +4433,7 @@ dependencies = [
  "next-build",
  "next-core",
  "next-custom-transforms",
+ "next-taskless",
  "once_cell",
  "owo-colors 3.5.0",
  "rand 0.9.0",
@@ -4450,6 +4453,7 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-malloc",
+ "turbo-unix-path",
  "turbopack-core",
  "turbopack-ecmascript-hmr-protocol",
  "turbopack-ecmascript-plugins",
@@ -4458,6 +4462,16 @@ dependencies = [
  "url",
  "urlencoding",
  "vergen-gitcl",
+]
+
+[[package]]
+name = "next-taskless"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "regex",
+ "serde_json",
+ "turbo-unix-path",
 ]
 
 [[package]]
@@ -9372,6 +9386,7 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-testing",
+ "turbo-unix-path",
  "urlencoding",
 ]
 
@@ -9453,6 +9468,13 @@ dependencies = [
  "rustc-hash 2.1.1",
  "tokio",
  "turbo-tasks",
+]
+
+[[package]]
+name = "turbo-unix-path"
+version = "0.0.1"
+dependencies = [
+ "rstest",
 ]
 
 [[package]]
@@ -9638,6 +9660,7 @@ dependencies = [
  "turbo-tasks-fs",
  "turbo-tasks-hash",
  "turbo-tasks-testing",
+ "turbo-unix-path",
  "urlencoding",
 ]
 
@@ -10011,6 +10034,7 @@ dependencies = [
  "turbo-tasks-bytes",
  "turbo-tasks-env",
  "turbo-tasks-fs",
+ "turbo-unix-path",
  "turbopack",
  "turbopack-browser",
  "turbopack-core",
@@ -10567,6 +10591,8 @@ dependencies = [
  "js-sys",
  "mdxjs",
  "next-custom-transforms",
+ "next-taskless",
+ "rustc-hash 2.1.1",
  "serde-wasm-bindgen 0.4.5",
  "serde_json",
  "swc_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/next-build",
   "crates/next-core",
   "crates/next-custom-transforms",
+  "crates/next-taskless",
   "turbopack/crates/*",
   "turbopack/crates/*/fuzz",
   "turbopack/xtask",
@@ -252,6 +253,7 @@ next-api = { path = "crates/next-api" }
 next-build = { path = "crates/next-build" }
 next-core = { path = "crates/next-core" }
 next-custom-transforms = { path = "crates/next-custom-transforms" }
+next-taskless = { path = "crates/next-taskless" }
 
 # Turbopack
 auto-hash-map = { path = "turbopack/crates/turbo-tasks-auto-hash-map" }
@@ -260,6 +262,7 @@ turbo-rcstr = { path = "turbopack/crates/turbo-rcstr" }
 turbo-dyn-eq-hash = { path = "turbopack/crates/turbo-dyn-eq-hash" }
 turbo-esregex = { path = "turbopack/crates/turbo-esregex" }
 turbo-persistence = { path = "turbopack/crates/turbo-persistence" }
+turbo-unix-path = { path = "turbopack/crates/turbo-unix-path" }
 turbo-tasks-malloc = { path = "turbopack/crates/turbo-tasks-malloc", default-features = false }
 turbo-tasks = { path = "turbopack/crates/turbo-tasks" }
 turbo-tasks-backend = { path = "turbopack/crates/turbo-tasks-backend" }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -64,6 +64,7 @@ owo-colors = { workspace = true }
 napi = { workspace = true }
 napi-derive = "2"
 next-custom-transforms = { workspace = true }
+next-taskless = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
 serde = "1"
@@ -105,6 +106,7 @@ turbo-rcstr = { workspace = true, features = ["napi"] }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 turbo-tasks-fs = { workspace = true }
+turbo-unix-path = { workspace = true }
 next-api = { workspace = true }
 next-build = { workspace = true }
 next-core = { workspace = true }

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -39,9 +39,9 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::{BackingStorage, db_invalidation::invalidation_reasons};
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, get_relative_path_to,
-    util::uri_from_file,
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, util::uri_from_file,
 };
+use turbo_unix_path::get_relative_path_to;
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
     diagnostics::PlainDiagnostic,

--- a/crates/napi/src/react_compiler.rs
+++ b/crates/napi/src/react_compiler.rs
@@ -23,7 +23,7 @@ impl Task for CheckTask {
         GLOBALS.set(&Default::default(), || {
             //
             let cm = Arc::new(SourceMap::default());
-            let Ok(fm) = cm.load_file(&self.filename.clone()) else {
+            let Ok(fm) = cm.load_file(&self.filename) else {
                 return Ok(false);
             };
             let mut errors = vec![];

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -33,6 +33,7 @@ turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true, features = ["non_operation_vc_strongly_consistent"] }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
+turbo-unix-path = { workspace = true }
 turbopack = { workspace = true }
 turbopack-browser = { workspace = true }
 turbopack-core = { workspace = true }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -36,10 +36,8 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
-use turbo_tasks_fs::{
-    DiskFileSystem, FileSystem, FileSystemPath, VirtualFileSystem, invalidation,
-    util::{join_path, unix_to_sys},
-};
+use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, VirtualFileSystem, invalidation};
+use turbo_unix_path::{join_path, unix_to_sys};
 use turbopack::{
     ModuleAssetContext, evaluate_context::node_build_environment,
     global_module_ids::get_global_module_id_strategy, transition::TransitionOptions,

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.21.0"
 either = { workspace = true }
-next-custom-transforms = { workspace = true }
 once_cell = { workspace = true }
 qstring = { workspace = true }
 regex = { workspace = true }
@@ -54,6 +53,9 @@ swc_core = { workspace = true, features = [
   "ecma_visit",
 ] }
 modularize_imports = { workspace = true }
+
+next-custom-transforms = { workspace = true }
+next-taskless = { workspace = true }
 
 turbo-rcstr = { workspace = true }
 turbo-esregex = { workspace = true }

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{context::AssetContext, module::Module, reference_type::ReferenceType};
 
@@ -27,23 +27,23 @@ pub async fn get_middleware_module(
     project_root: FileSystemPath,
     userland_module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<Box<dyn Module>>> {
-    let inner = rcstr!("INNER_MIDDLEWARE_MODULE");
+    const INNER: &str = "INNER_MIDDLEWARE_MODULE";
 
     // Load the file from the next.js codebase.
     let source = load_next_js_template(
         "middleware.js",
         project_root,
-        fxindexmap! {
-            "VAR_USERLAND" => inner.clone(),
-            "VAR_DEFINITION_PAGE" => rcstr!("/middleware"),
-        },
-        FxIndexMap::default(),
-        FxIndexMap::default(),
+        &[
+            ("VAR_USERLAND", INNER),
+            ("VAR_DEFINITION_PAGE", "/middleware"),
+        ],
+        &[],
+        &[],
     )
     .await?;
 
     let inner_assets = fxindexmap! {
-        inner => userland_module
+        rcstr!(INNER) => userland_module
     };
 
     let module = asset_context

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, fxindexmap};
 use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
 use turbopack::ModuleAssetContext;
@@ -86,22 +86,25 @@ pub async fn get_app_page_entry(
     let source = load_next_js_template(
         "app-page.js",
         project_root.clone(),
-        fxindexmap! {
-            "VAR_DEFINITION_PAGE" => page.to_string().into(),
-            "VAR_DEFINITION_PATHNAME" => pathname.clone(),
-            "VAR_MODULE_GLOBAL_ERROR" => if inner_assets.contains_key(GLOBAL_ERROR) {
-                GLOBAL_ERROR.into()
-             } else {
-                rcstr!("next/dist/client/components/builtin/global-error")
-            },
-        },
-        fxindexmap! {
-            "tree" => loader_tree_code,
-            "pages" => StringifyJs(&pages).to_string().into(),
-            "__next_app_require__" => TURBOPACK_REQUIRE.bound().into(),
-            "__next_app_load_chunk__" => TURBOPACK_LOAD.bound().into(),
-        },
-        fxindexmap! {},
+        &[
+            ("VAR_DEFINITION_PAGE", &*page.to_string()),
+            ("VAR_DEFINITION_PATHNAME", &pathname),
+            (
+                "VAR_MODULE_GLOBAL_ERROR",
+                if inner_assets.contains_key(GLOBAL_ERROR) {
+                    GLOBAL_ERROR
+                } else {
+                    "next/dist/client/components/builtin/global-error"
+                },
+            ),
+        ],
+        &[
+            ("tree", &*loader_tree_code),
+            ("pages", &StringifyJs(&pages).to_string()),
+            ("__next_app_require__", &TURBOPACK_REQUIRE.bound()),
+            ("__next_app_load_chunk__", &TURBOPACK_LOAD.bound()),
+        ],
+        &[],
     )
     .await?;
 
@@ -158,18 +161,13 @@ async fn wrap_edge_page(
     let source = load_next_js_template(
         "edge-ssr-app.js",
         project_root.clone(),
-        fxindexmap! {
-            "VAR_USERLAND" => INNER.into(),
-            "VAR_PAGE" => page.to_string().into(),
-        },
-        fxindexmap! {
+        &[("VAR_USERLAND", INNER), ("VAR_PAGE", &page.to_string())],
+        &[
             // TODO do we really need to pass the entire next config here?
             // This is bad for invalidation as any config change will invalidate this
-            "nextConfig" => serde_json::to_string(next_config_val)?.into(),
-        },
-        fxindexmap! {
-            "incrementalCacheHandler" => None,
-        },
+            ("nextConfig", &*serde_json::to_string(next_config_val)?),
+        ],
+        &[("incrementalCacheHandler", None)],
     )
     .await?;
 

--- a/crates/next-taskless/Cargo.toml
+++ b/crates/next-taskless/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "next-taskless"
+version = "0.0.1"
+description = "TBD"
+license = "MIT"
+edition = "2024"
+
+[lib]
+bench = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+turbo-unix-path = { workspace = true }

--- a/crates/next-taskless/README.md
+++ b/crates/next-taskless/README.md
@@ -1,0 +1,7 @@
+Utilities for Next.js written without a dependency on turbo-tasks, allowing them to be shared with
+webpack and/or rspack codepaths. This crate must be compilable to WASM, so that it works in
+environments where no native bindings are available.
+
+These utilities should not perform file IO directly, but instead accept files they depend on as
+arguments (preferred) or via async trait methods or callbacks (acceptable). Follow "sans-io"
+patterns where possible.

--- a/crates/next-taskless/src/lib.rs
+++ b/crates/next-taskless/src/lib.rs
@@ -1,0 +1,265 @@
+#![doc = include_str!("../README.md")]
+
+use std::sync::LazyLock;
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use turbo_unix_path::{get_parent_path, get_relative_path_to, join_path, normalize_path};
+
+/// Given a next.js template file's contents, replaces `replacements` and `injections` and makes
+/// sure there are none left over.
+///
+/// See `packages/next/src/build/templates/` for examples.
+///
+/// Paths should be unix or node.js-style paths where `/` is used as the path separator. They should
+/// not be windows-style paths.
+pub fn expand_next_js_template<'a>(
+    content: &str,
+    template_path: &str,
+    next_package_dir_path: &str,
+    replacements: impl IntoIterator<Item = (&'a str, &'a str)>,
+    injections: impl IntoIterator<Item = (&'a str, &'a str)>,
+    imports: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+) -> Result<String> {
+    let template_parent_path = normalize_path(get_parent_path(template_path))
+        .context("failed to normalize template path")?;
+    let next_package_dir_parent_path = normalize_path(get_parent_path(next_package_dir_path))
+        .context("failed to normalize package dir path")?;
+
+    /// See [regex::Regex::replace_all].
+    fn replace_all<E>(
+        re: &regex::Regex,
+        haystack: &str,
+        mut replacement: impl FnMut(&regex::Captures) -> Result<String, E>,
+    ) -> Result<String, E> {
+        let mut new = String::with_capacity(haystack.len());
+        let mut last_match = 0;
+        for caps in re.captures_iter(haystack) {
+            let m = caps.get(0).unwrap();
+            new.push_str(&haystack[last_match..m.start()]);
+            new.push_str(&replacement(&caps)?);
+            last_match = m.end();
+        }
+        new.push_str(&haystack[last_match..]);
+        Ok(new)
+    }
+
+    // Update the relative imports to be absolute. This will update any relative imports to be
+    // relative to the root of the `next` package.
+    static IMPORT_PATH_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("(?:from '(\\..*)'|import '(\\..*)')").unwrap());
+
+    let mut count = 0;
+    let mut content = replace_all(&IMPORT_PATH_RE, content, |caps| {
+        let from_request = caps.get(1).map_or("", |c| c.as_str());
+        count += 1;
+        let is_from_request = !from_request.is_empty();
+
+        let imported_path = join_path(
+            &template_parent_path,
+            if is_from_request {
+                from_request
+            } else {
+                caps.get(2).context("import path must exist")?.as_str()
+            },
+        )
+        .context("path should not leave the fs")?;
+
+        let relative = get_relative_path_to(&next_package_dir_parent_path, &imported_path);
+
+        if !relative.starts_with("./next/") {
+            bail!(
+                "Invariant: Expected relative import to start with \"./next/\", found \
+                 {relative:?}. Path computed from {next_package_dir_parent_path:?} to \
+                 {imported_path:?}.",
+            )
+        }
+
+        let relative = relative
+            .strip_prefix("./")
+            .context("should be able to strip the prefix")?;
+
+        Ok(if is_from_request {
+            format!("from {}", serde_json::to_string(relative).unwrap())
+        } else {
+            format!("import {}", serde_json::to_string(relative).unwrap())
+        })
+    })
+    .context("replacing imports failed")?;
+
+    // Verify that at least one import was replaced. It's the case today where every template file
+    // has at least one import to update, so this ensures that we don't accidentally remove the
+    // import replacement code or use the wrong template file.
+    if count == 0 {
+        bail!("Invariant: Expected to replace at least one import")
+    }
+
+    // Replace all the template variables with the actual values. If a template variable is missing,
+    // throw an error.
+    let mut missing_replacements = Vec::new();
+    for (key, replacement) in replacements {
+        let full = format!("'{key}'");
+
+        if content.contains(&full) {
+            content = content.replace(&full, &serde_json::to_string(&replacement).unwrap());
+        } else {
+            missing_replacements.push(key)
+        }
+    }
+
+    // Check to see if there's any remaining template variables.
+    static TEMPLATE_VAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("VAR_[A-Z_]+").unwrap());
+    let mut matches = TEMPLATE_VAR_RE.find_iter(&content).peekable();
+
+    if matches.peek().is_some() {
+        bail!(
+            "Invariant: Expected to replace all template variables, found {}",
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
+        )
+    }
+
+    // Check to see if any template variable was provided but not used.
+    if !missing_replacements.is_empty() {
+        bail!(
+            "Invariant: Expected to replace all template variables, missing {} in template",
+            missing_replacements.join(", "),
+        )
+    }
+
+    // Replace the injections.
+    let mut missing_injections = Vec::new();
+    for (key, injection) in injections {
+        let full = format!("// INJECT:{key}");
+
+        if content.contains(&full) {
+            content = content.replace(&full, &format!("const {key} = {injection}"));
+        } else {
+            missing_injections.push(key);
+        }
+    }
+
+    // Check to see if there's any remaining injections.
+    static INJECT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("// INJECT:[A-Za-z0-9_]+").unwrap());
+    let mut matches = INJECT_RE.find_iter(&content).peekable();
+
+    if matches.peek().is_some() {
+        bail!(
+            "Invariant: Expected to inject all injections, found {}",
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
+        )
+    }
+
+    // Check to see if any injection was provided but not used.
+    if !missing_injections.is_empty() {
+        bail!(
+            "Invariant: Expected to inject all injections, missing {} in template",
+            missing_injections.join(", "),
+        )
+    }
+
+    // Replace the optional imports.
+    let mut missing_imports = Vec::new();
+    for (key, import_path) in imports {
+        let mut full = format!("// OPTIONAL_IMPORT:{key}");
+        let namespace = if !content.contains(&full) {
+            full = format!("// OPTIONAL_IMPORT:* as {key}");
+            if content.contains(&full) {
+                true
+            } else {
+                missing_imports.push(key);
+                continue;
+            }
+        } else {
+            false
+        };
+
+        if let Some(path) = import_path {
+            content = content.replace(
+                &full,
+                &format!(
+                    "import {}{} from {}",
+                    if namespace { "* as " } else { "" },
+                    key,
+                    serde_json::to_string(&path).unwrap(),
+                ),
+            );
+        } else {
+            content = content.replace(&full, &format!("const {key} = null"));
+        }
+    }
+
+    // Check to see if there's any remaining imports.
+    static OPTIONAL_IMPORT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("// OPTIONAL_IMPORT:(\\* as )?[A-Za-z0-9_]+").unwrap());
+    let mut matches = OPTIONAL_IMPORT_RE.find_iter(&content).peekable();
+
+    if matches.peek().is_some() {
+        bail!(
+            "Invariant: Expected to inject all imports, found {}",
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
+        )
+    }
+
+    // Check to see if any import was provided but not used.
+    if !missing_imports.is_empty() {
+        bail!(
+            "Invariant: Expected to inject all imports, missing {} in template",
+            missing_imports.join(", "),
+        )
+    }
+
+    // Ensure that the last line is a newline.
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_next_js_template() {
+        let input = r#"
+            import '../../foo/bar';
+            import * as userlandPage from 'VAR_USERLAND'
+            // OPTIONAL_IMPORT:* as userland500Page
+            // OPTIONAL_IMPORT:incrementalCacheHandler
+
+            // INJECT:nextConfig
+            const srcPage = 'VAR_PAGE'
+        "#;
+
+        let expected = r#"
+            import "next/src/foo/bar";
+            import * as userlandPage from "INNER_PAGE_ENTRY"
+            import * as userland500Page from "INNER_ERROR_500"
+            const incrementalCacheHandler = null
+
+            const nextConfig = {}
+            const srcPage = "./some/path.js"
+        "#;
+
+        let output = expand_next_js_template(
+            input,
+            "project/node_modules/next/src/build/templates/test-case.js",
+            "project/node_modules/next",
+            [
+                ("VAR_USERLAND", "INNER_PAGE_ENTRY"),
+                ("VAR_PAGE", "./some/path.js"),
+            ],
+            [("nextConfig", "{}")],
+            [
+                ("incrementalCacheHandler", None),
+                ("userland500Page", Some("INNER_ERROR_500")),
+            ],
+        )
+        .unwrap();
+        println!("{output}");
+
+        assert_eq!(output.trim_end(), expected.trim_end());
+    }
+}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -17,15 +17,17 @@ plugin = ["swc_core/plugin_transform_host_js"]
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 console_error_panic_hook = "0.1.6"
+getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] }
+js-sys = "0.3.59"
 next-custom-transforms = { workspace = true }
+next-taskless = { workspace = true }
+rustc-hash = { workspace = true }
+serde-wasm-bindgen = "0.4.3"
 serde_json = "1"
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.8"
-getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] }
-js-sys = "0.3.59"
-serde-wasm-bindgen = "0.4.3"
 
 swc_core = { workspace = true, features = [
   "common",

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
       "registry": "https://registry.npmjs.org/"
     }
   },
-  "version": "15.4.2-canary.32"
+  "version": "15.4.2-canary.33"
 }

--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-app",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "keywords": [
     "react",
     "next",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-next",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "ESLint configuration used by Next.js.",
   "main": "index.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "homepage": "https://nextjs.org/docs/app/api-reference/config/eslint",
   "dependencies": {
-    "@next/eslint-plugin-next": "15.4.2-canary.32",
+    "@next/eslint-plugin-next": "15.4.2-canary.33",
     "@rushstack/eslint-patch": "^1.10.3",
     "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",

--- a/packages/eslint-plugin-internal/package.json
+++ b/packages/eslint-plugin-internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@next/eslint-plugin-internal",
   "private": true,
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "ESLint plugin for working on Next.js.",
   "exports": {
     ".": "./src/eslint-plugin-internal.js"

--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/eslint-plugin-next",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "ESLint plugin for Next.js.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@next/font",
   "private": true,
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/font"

--- a/packages/next-bundle-analyzer/package.json
+++ b/packages/next-bundle-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/bundle-analyzer",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/codemod",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/env",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "keywords": [
     "react",
     "next",

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/mdx",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/packages/next-plugin-storybook/package.json
+++ b/packages/next-plugin-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/plugin-storybook",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/next-plugin-storybook"

--- a/packages/next-polyfill-module/package.json
+++ b/packages/next-polyfill-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/polyfill-module",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "A standard library polyfill for ES Modules supporting browsers (Edge 16+, Firefox 60+, Chrome 61+, Safari 10.1+)",
   "main": "dist/polyfill-module.js",
   "license": "MIT",

--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/polyfill-nomodule",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "A polyfill for non-dead, nomodule browsers.",
   "main": "dist/polyfill-nomodule.js",
   "license": "MIT",

--- a/packages/next-rspack/package.json
+++ b/packages/next-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-rspack",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/next-rspack"

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/swc",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "private": true,
   "files": [
     "native/"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "The React Framework",
   "main": "./dist/server/next.js",
   "license": "MIT",
@@ -102,7 +102,7 @@
     ]
   },
   "dependencies": {
-    "@next/env": "15.4.2-canary.32",
+    "@next/env": "15.4.2-canary.33",
     "@swc/helpers": "0.5.15",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.4.31",
@@ -166,11 +166,11 @@
     "@jest/types": "29.5.0",
     "@mswjs/interceptors": "0.23.0",
     "@napi-rs/triples": "1.2.0",
-    "@next/font": "15.4.2-canary.32",
-    "@next/polyfill-module": "15.4.2-canary.32",
-    "@next/polyfill-nomodule": "15.4.2-canary.32",
-    "@next/react-refresh-utils": "15.4.2-canary.32",
-    "@next/swc": "15.4.2-canary.32",
+    "@next/font": "15.4.2-canary.33",
+    "@next/polyfill-module": "15.4.2-canary.33",
+    "@next/polyfill-nomodule": "15.4.2-canary.33",
+    "@next/react-refresh-utils": "15.4.2-canary.33",
+    "@next/swc": "15.4.2-canary.33",
     "@opentelemetry/api": "1.6.0",
     "@playwright/test": "1.51.1",
     "@rspack/core": "1.4.5",

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -76,8 +76,8 @@ import {
   MIDDLEWARE_REACT_LOADABLE_MANIFEST,
   SERVER_REFERENCE_MANIFEST,
   FUNCTIONS_CONFIG_MANIFEST,
-  UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   UNDERSCORE_NOT_FOUND_ROUTE,
+  UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   DYNAMIC_CSS_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
 } from '../shared/lib/constants'
@@ -3090,12 +3090,6 @@ export default async function build(
             ]
 
             for (const prerenderedRoute of prerenderedRoutes) {
-              // TODO: check if still needed?
-              // Exclude the /_not-found route.
-              if (prerenderedRoute.pathname === UNDERSCORE_NOT_FOUND_ROUTE) {
-                continue
-              }
-
               if (
                 isRoutePPREnabled &&
                 prerenderedRoute.fallbackRouteParams &&
@@ -3114,7 +3108,6 @@ export default async function build(
             // Handle all the static routes.
             for (const route of staticPrerenderedRoutes) {
               if (isDynamicRoute(page) && route.pathname === page) continue
-              if (route.pathname === UNDERSCORE_NOT_FOUND_ROUTE) continue
 
               const {
                 metadata = {},
@@ -3164,9 +3157,13 @@ export default async function build(
                 }
 
                 const meta = collectMeta(metadata)
+                const status =
+                  route.pathname === UNDERSCORE_NOT_FOUND_ROUTE
+                    ? 404
+                    : meta.status
 
                 prerenderManifest.routes[route.pathname] = {
-                  initialStatus: meta.status,
+                  initialStatus: status,
                   initialHeaders: meta.headers,
                   renderingMode: isAppPPREnabled
                     ? isRoutePPREnabled

--- a/packages/next/src/build/load-entrypoint.ts
+++ b/packages/next/src/build/load-entrypoint.ts
@@ -1,9 +1,10 @@
 import fs from 'fs/promises'
 import path from 'path'
+import { loadBindings } from './swc'
 
 // NOTE: this should be updated if this loader file is moved.
-const PACKAGE_ROOT = path.normalize(path.join(__dirname, '../../..'))
-const TEMPLATE_FOLDER = path.join(__dirname, 'templates')
+const PACKAGE_ROOT = path.normalize(path.join(__dirname, '../..'))
+const TEMPLATE_SRC_FOLDER = path.normalize(path.join(__dirname, './templates'))
 const TEMPLATES_ESM_FOLDER = path.normalize(
   path.join(__dirname, '../../dist/esm/build/templates')
 )
@@ -38,195 +39,19 @@ export async function loadEntrypoint(
   injections?: Record<string, string>,
   imports?: Record<string, string | null>
 ): Promise<string> {
-  const filepath = path.resolve(
+  let bindings = await loadBindings()
+
+  const templatePath = path.resolve(
     path.join(TEMPLATES_ESM_FOLDER, `${entrypoint}.js`)
   )
+  let content = await fs.readFile(templatePath)
 
-  let file = await fs.readFile(filepath, 'utf8')
-
-  // Update the relative imports to be absolute. This will update any relative
-  // imports to be relative to the root of the `next` package.
-  let count = 0
-  file = file.replaceAll(
-    /from '(\..*)'|import '(\..*)'/g,
-    function (_, fromRequest, importRequest) {
-      count++
-
-      const relative = path
-        .relative(
-          PACKAGE_ROOT,
-          path.resolve(TEMPLATE_FOLDER, fromRequest ?? importRequest)
-        )
-        // Ensure that we use linux style path separators for node.
-        .replace(/\\/g, '/')
-
-      // Verify that the relative import is relative to the `next` package. This
-      // will catch cases where the constants at the top of the file were not
-      // updated after the file was moved.
-      if (!relative.startsWith('next/')) {
-        throw new Error(
-          `Invariant: Expected relative import to start with "next/", found "${relative}"`
-        )
-      }
-
-      return fromRequest
-        ? `from ${JSON.stringify(relative)}`
-        : `import ${JSON.stringify(relative)}`
-    }
+  return bindings.expandNextJsTemplate(
+    content,
+    path.join(TEMPLATE_SRC_FOLDER, `${entrypoint}.js`),
+    PACKAGE_ROOT,
+    replacements,
+    injections ?? {},
+    imports ?? {}
   )
-
-  // Verify that at least one import was replaced. It's the case today where
-  // every template file has at least one import to update, so this ensures that
-  // we don't accidentally remove the import replacement code or use the wrong
-  // template file.
-  if (count === 0) {
-    throw new Error('Invariant: Expected to replace at least one import')
-  }
-
-  const replaced = new Set<string>()
-
-  // Replace all the template variables with the actual values. If a template
-  // variable is missing, throw an error.
-  file = file.replaceAll(
-    new RegExp(
-      `${Object.keys(replacements)
-        .map((k) => `'${k}'`)
-        .join('|')}`,
-      'g'
-    ),
-    (match) => {
-      const key = JSON.parse(match.replace(/'/g, `"`))
-
-      if (!(key in replacements)) {
-        throw new Error(`Invariant: Unexpected template variable ${key}`)
-      }
-
-      replaced.add(key)
-
-      return JSON.stringify(replacements[key])
-    }
-  )
-
-  // Check to see if there's any remaining template variables.
-  let matches = file.match(/VAR_[A-Z_]+/g)
-  if (matches) {
-    throw new Error(
-      `Invariant: Expected to replace all template variables, found ${matches.join(
-        ', '
-      )}`
-    )
-  }
-
-  // Check to see if any template variable was provided but not used.
-  if (replaced.size !== Object.keys(replacements).length) {
-    // Find the difference between the provided replacements and the replaced
-    // template variables. This will let us notify the user of any template
-    // variables that were not used but were provided.
-    const difference = Object.keys(replacements).filter(
-      (key) => !replaced.has(key)
-    )
-
-    throw new Error(
-      `Invariant: Expected to replace all template variables, missing ${difference.join(
-        ', '
-      )} in template`
-    )
-  }
-
-  // Replace the injections.
-  const injected = new Set<string>()
-  if (injections) {
-    // Track all the injections to ensure that we're not missing any.
-    file = file.replaceAll(
-      new RegExp(`// INJECT:(${Object.keys(injections).join('|')})`, 'g'),
-      (_, key) => {
-        if (!(key in injections)) {
-          throw new Error(`Invariant: Unexpected injection ${key}`)
-        }
-
-        injected.add(key)
-
-        return `const ${key} = ${injections[key]}`
-      }
-    )
-  }
-
-  // Check to see if there's any remaining injections.
-  matches = file.match(/\/\/ INJECT:[A-Za-z0-9_]+/g)
-  if (matches) {
-    throw new Error(
-      `Invariant: Expected to inject all injections, found ${matches.join(
-        ', '
-      )}`
-    )
-  }
-
-  // Check to see if any injection was provided but not used.
-  if (injected.size !== Object.keys(injections ?? {}).length) {
-    // Find the difference between the provided injections and the injected
-    // injections. This will let us notify the user of any injections that were
-    // not used but were provided.
-    const difference = Object.keys(injections ?? {}).filter(
-      (key) => !injected.has(key)
-    )
-
-    throw new Error(
-      `Invariant: Expected to inject all injections, missing ${difference.join(
-        ', '
-      )} in template`
-    )
-  }
-
-  // Replace the optional imports.
-  const importsAdded = new Set<string>()
-  if (imports) {
-    // Track all the imports to ensure that we're not missing any.
-    file = file.replaceAll(
-      new RegExp(
-        `// OPTIONAL_IMPORT:(\\* as )?(${Object.keys(imports).join('|')})`,
-        'g'
-      ),
-      (_, asNamespace = '', key) => {
-        if (!(key in imports)) {
-          throw new Error(`Invariant: Unexpected optional import ${key}`)
-        }
-
-        importsAdded.add(key)
-
-        if (imports[key]) {
-          return `import ${asNamespace}${key} from ${JSON.stringify(
-            imports[key]
-          )}`
-        } else {
-          return `const ${key} = null`
-        }
-      }
-    )
-  }
-
-  // Check to see if there's any remaining imports.
-  matches = file.match(/\/\/ OPTIONAL_IMPORT:(\* as )?[A-Za-z0-9_]+/g)
-  if (matches) {
-    throw new Error(
-      `Invariant: Expected to inject all imports, found ${matches.join(', ')}`
-    )
-  }
-
-  // Check to see if any import was provided but not used.
-  if (importsAdded.size !== Object.keys(imports ?? {}).length) {
-    // Find the difference between the provided imports and the injected
-    // imports. This will let us notify the user of any imports that were
-    // not used but were provided.
-    const difference = Object.keys(imports ?? {}).filter(
-      (key) => !importsAdded.has(key)
-    )
-
-    throw new Error(
-      `Invariant: Expected to inject all imports, missing ${difference.join(
-        ', '
-      )} in template`
-    )
-  }
-
-  return file
 }

--- a/packages/next/src/build/load-entrypoint.ts
+++ b/packages/next/src/build/load-entrypoint.ts
@@ -48,8 +48,9 @@ export async function loadEntrypoint(
 
   return bindings.expandNextJsTemplate(
     content,
-    path.join(TEMPLATE_SRC_FOLDER, `${entrypoint}.js`),
-    PACKAGE_ROOT,
+    // Ensure that we use unix-style path separators for the import paths
+    path.join(TEMPLATE_SRC_FOLDER, `${entrypoint}.js`).replace(/\\/g, '/'),
+    PACKAGE_ROOT.replace(/\\/g, '/'),
     replacements,
     injections ?? {},
     imports ?? {}

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -424,6 +424,14 @@ export interface NapiDiagnostic {
   name: string
   payload: Record<string, string>
 }
+export declare function expandNextJsTemplate(
+  content: Buffer,
+  templatePath: string,
+  nextPackageDirPath: string,
+  replacements: Record<string, string>,
+  injections: Record<string, string>,
+  imports: Record<string, string | null>
+): string
 export declare function parse(
   src: string,
   options: Buffer,

--- a/packages/next/src/build/swc/generated-wasm.d.ts
+++ b/packages/next/src/build/swc/generated-wasm.d.ts
@@ -11,3 +11,11 @@ export function transformSync(s: any, opts: any): any
 export function transform(s: any, opts: any): Promise<any>
 export function parseSync(s: string, opts: any): any
 export function parse(s: string, opts: any): Promise<any>
+export function expandNextJsTemplate(
+  content: Uint8Array,
+  template_path: string,
+  next_package_dir_path: string,
+  replacements: any,
+  injections: any,
+  imports: any
+): string

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1238,6 +1238,23 @@ async function loadWasm(importPath = '') {
         )
       },
     },
+    expandNextJsTemplate(
+      content: Buffer,
+      templatePath: string,
+      nextPackageDirPath: string,
+      replacements: Record<`VAR_${string}`, string>,
+      injections: Record<string, string>,
+      imports: Record<string, string | null>
+    ): string {
+      return rawBindings.expandNextJsTemplate(
+        content,
+        templatePath,
+        nextPackageDirPath,
+        replacements,
+        injections,
+        imports
+      )
+    },
   }
   return wasmBindings
 }
@@ -1419,6 +1436,23 @@ function loadNative(importPath?: string) {
         ): Promise<NapiSourceDiagnostic[]> {
           return bindings.warnForEdgeRuntime(source, isProduction)
         },
+      },
+      expandNextJsTemplate(
+        content: Buffer,
+        templatePath: string,
+        nextPackageDirPath: string,
+        replacements: Record<`VAR_${string}`, string>,
+        injections: Record<string, string>,
+        imports: Record<string, string | null>
+      ): string {
+        return bindings.expandNextJsTemplate(
+          content,
+          templatePath,
+          nextPackageDirPath,
+          replacements,
+          injections,
+          imports
+        )
       },
     }
     return nativeBindings

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -52,6 +52,14 @@ export interface Binding {
       isProduction: boolean
     ): Promise<NapiSourceDiagnostic[]>
   }
+  expandNextJsTemplate(
+    content: Buffer,
+    templatePath: string,
+    nextPackageDirPath: string,
+    replacements: Record<`VAR_${string}`, string>,
+    injections: Record<string, string>,
+    imports: Record<string, string | null>
+  ): string
 }
 
 export type StyledString =

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -763,6 +763,10 @@ async function exportAppImpl(
   if (!options.buildExport && prerenderManifest) {
     await Promise.all(
       Object.keys(prerenderManifest.routes).map(async (unnormalizedRoute) => {
+        // Skip handling /_not-found route, it will copy the 404.html file later
+        if (unnormalizedRoute === '/_not-found') {
+          return
+        }
         const { srcRoute } = prerenderManifest!.routes[unnormalizedRoute]
         const appPageName = mapAppRouteToPage.get(srcRoute || '')
         const pageName = appPageName || srcRoute || unnormalizedRoute

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -572,31 +572,6 @@ async function generateDynamicFlightRenderResult(
     options
   )
 
-  if (
-    // We only want this behavior when running `next dev`
-    renderOpts.dev &&
-    // We only want this behavior when we have React's dev builds available
-    process.env.NODE_ENV === 'development' &&
-    // We only have a Prerender environment for projects opted into cacheComponents
-    renderOpts.experimental.cacheComponents
-  ) {
-    const [resolveValidation, validationOutlet] = createValidationOutlet()
-    RSCPayload._validation = validationOutlet
-
-    const devValidatingFallbackParams =
-      getRequestMeta(req, 'devValidatingFallbackParams') || null
-
-    spawnDynamicValidationInDev(
-      resolveValidation,
-      ctx.componentMod.tree,
-      ctx,
-      false,
-      ctx.clientReferenceManifest,
-      requestStore,
-      devValidatingFallbackParams
-    )
-  }
-
   // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
   // which contains the subset React.
   const flightReadableStream = workUnitAsyncStorage.run(

--- a/packages/react-refresh-utils/package.json
+++ b/packages/react-refresh-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/react-refresh-utils",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "description": "An experimental package providing utilities for React Refresh.",
   "repository": {
     "url": "vercel/next.js",

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/third-parties",
-  "version": "15.4.2-canary.32",
+  "version": "15.4.2-canary.33",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/third-parties"
@@ -26,7 +26,7 @@
     "third-party-capital": "1.0.20"
   },
   "devDependencies": {
-    "next": "15.4.2-canary.32",
+    "next": "15.4.2-canary.33",
     "outdent": "0.8.0",
     "prettier": "2.5.1",
     "typescript": "5.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,7 +854,7 @@ importers:
   packages/eslint-config-next:
     dependencies:
       '@next/eslint-plugin-next':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../eslint-plugin-next
       '@rushstack/eslint-patch':
         specifier: ^1.10.3
@@ -924,7 +924,7 @@ importers:
   packages/next:
     dependencies:
       '@next/env':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../next-env
       '@swc/helpers':
         specifier: 0.5.15
@@ -1049,19 +1049,19 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       '@next/font':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../font
       '@next/polyfill-module':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../next-polyfill-module
       '@next/polyfill-nomodule':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../next-polyfill-nomodule
       '@next/react-refresh-utils':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../react-refresh-utils
       '@next/swc':
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../next-swc
       '@opentelemetry/api':
         specifier: 1.6.0
@@ -1764,7 +1764,7 @@ importers:
         version: 1.0.20
     devDependencies:
       next:
-        specifier: 15.4.2-canary.32
+        specifier: 15.4.2-canary.33
         version: link:../next
       outdent:
         specifier: 0.8.0

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -1,6 +1,11 @@
 import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
-import { assertNoRedbox, hasErrorToast, retry } from 'next-test-utils'
+import {
+  assertNoRedbox,
+  assertNoErrorToast,
+  hasErrorToast,
+  retry,
+} from 'next-test-utils'
 import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
@@ -32,7 +37,7 @@ describe('Cache Components Dev Errors', () => {
     `)
   })
 
-  it('should show a red box error on client navigations', async () => {
+  it('should not show a red box error on client navigations', async () => {
     const browser = await next.browser('/no-error')
 
     await retry(async () => {
@@ -40,6 +45,9 @@ describe('Cache Components Dev Errors', () => {
     })
 
     await browser.elementByCss("[href='/error']").click()
+    await assertNoErrorToast(browser)
+
+    await browser.loadPage(`${next.url}/error`)
 
     // TODO: React should not include the anon stack in the Owner Stack.
     await expect(browser).toDisplayCollapsedRedbox(`

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -987,6 +987,31 @@ describe('app-dir static/dynamic handling', () => {
            "initialRevalidateSeconds": false,
            "srcRoute": "/",
          },
+         "/_not-found": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/_not-found.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "next-action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialRevalidateSeconds": false,
+           "initialStatus": 404,
+           "srcRoute": "/_not-found",
+         },
          "/api/large-data": {
            "allowHeader": [
              "host",

--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -39,6 +39,7 @@ describe('async imports in cacheComponents', () => {
 
       expect(prerenderedRoutes).toMatchInlineSnapshot(`
        [
+         "/_not-found",
          "/inside-render/client/async-module",
          "/inside-render/client/sync-module",
          "/inside-render/route-handler/async-module",

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -24,6 +24,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         const staticRoutes = prerenderManifest.routes
         expect(Object.keys(staticRoutes).sort()).toEqual([
           '/',
+          '/_not-found',
           '/suspenseful/static',
         ])
       })

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -22,6 +22,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         const staticRoutes = prerenderManifest.routes
         expect(Object.keys(staticRoutes).sort()).toEqual([
           '/',
+          '/_not-found',
           '/slow/static',
           '/suspenseful/static',
         ])

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -473,6 +473,7 @@ describe('use-cache', () => {
 
       expect(prerenderedRouteKeys).toEqual(
         [
+          '/_not-found',
           // [id] route, first entry in generateStaticParams
           expect.stringMatching(/\/a\d/),
           withCacheComponents && '/api',

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -5828,6 +5828,7 @@
   },
   "test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts": {
     "passed": [
+      "segment cache (basic tests) does not cause infinite loop with cacheLife(\"seconds\")",
       "segment cache (basic tests) does not throw an error when navigating to a page with a server action",
       "segment cache (basic tests) navigate before any data has loaded into the prefetch cache",
       "segment cache (basic tests) navigate to page with lazily-generated (not at build time) static param",
@@ -5984,6 +5985,8 @@
   },
   "test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts": {
     "passed": [
+      "<Link prefetch={true}> (runtime prefetch) cache stale time handling includes private caches with cacheLife(\"seconds\")",
+      "<Link prefetch={true}> (runtime prefetch) cache stale time handling includes public caches with cacheLife(\"seconds\")",
       "<Link prefetch={true}> (runtime prefetch) cache stale time handling includes short-lived public caches with a long enough staleTime",
       "<Link prefetch={true}> (runtime prefetch) cache stale time handling omits private caches with a short enough staleTime",
       "<Link prefetch={true}> (runtime prefetch) cache stale time handling omits short-lived public caches with a short enough staleTime",

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -3142,10 +3142,10 @@
     "runtimeError": false
   },
   "test/development/basic/barrel-optimization/barrel-optimization-mui.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "Skipped in Turbopack optimizePackageImports - mui should support MUI"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false
@@ -4289,14 +4289,14 @@
   },
   "test/development/tsconfig-path-reloading/index.test.ts": {
     "passed": [
-      "tsconfig-path-reloading tsconfig should load with initial paths config correctly",
-      "tsconfig-path-reloading tsconfig should automatically fast refresh content when path is added without error"
+      "tsconfig-path-reloading tsconfig should automatically fast refresh content when path is added without error",
+      "tsconfig-path-reloading tsconfig should load with initial paths config correctly"
     ],
     "failed": [
-      "tsconfig-path-reloading tsconfig added after starting dev should recover from module not found when paths is updated",
-      "tsconfig-path-reloading tsconfig should recover from module not found when paths is updated",
+      "tsconfig-path-reloading tsconfig added after starting dev should automatically fast refresh content when path is added without error",
       "tsconfig-path-reloading tsconfig added after starting dev should load with initial paths config correctly",
-      "tsconfig-path-reloading tsconfig added after starting dev should automatically fast refresh content when path is added without error"
+      "tsconfig-path-reloading tsconfig added after starting dev should recover from module not found when paths is updated",
+      "tsconfig-path-reloading tsconfig should recover from module not found when paths is updated"
     ],
     "pending": [],
     "flakey": [],
@@ -5134,6 +5134,7 @@
       "app-root-param-getters - simple should allow reading root params in nested pages",
       "app-root-param-getters - simple should error when used in a route handler (until we implement it)",
       "app-root-param-getters - simple should error when used in a server action",
+      "app-root-param-getters - simple should not error when rerendering the page after a server action",
       "app-root-param-getters - simple should not generate getters for non-root params",
       "app-root-param-getters - simple should render the not found page without errors"
     ],
@@ -5632,6 +5633,7 @@
       "app dir - basic searchParams prop server component should have the correct search params on middleware rewrite",
       "app dir - basic searchParams prop server component should have the correct search params on rewrite",
       "app dir - basic server components Loading should render loading.js in browser for slow layout",
+      "app dir - basic server components Loading should render loading.js in browser for slow layout and page",
       "app dir - basic server components Loading should render loading.js in browser for slow page",
       "app dir - basic server components Loading should render loading.js in initial html for slow layout",
       "app dir - basic server components Loading should render loading.js in initial html for slow layout and page",
@@ -5646,7 +5648,6 @@
       "app dir - basic server components dynamic routes should only pass params that apply to the layout",
       "app dir - basic server components middleware should strip internal query parameters from requests to middleware for redirect",
       "app dir - basic server components middleware should strip internal query parameters from requests to middleware for rewrite",
-      "app dir - basic server components next/router should support router.back and router.forward",
       "app dir - basic server components should include client component layout with server component route should include it client-side",
       "app dir - basic server components should include client component layout with server component route should include it server-side",
       "app dir - basic server components should not serve .client.js as a path",
@@ -5690,7 +5691,7 @@
     ],
     "failed": [
       "app dir - basic <Link /> should navigate to pages dynamic route from pages page if it overlaps with an app page",
-      "app dir - basic server components Loading should render loading.js in browser for slow layout and page"
+      "app dir - basic server components next/router should support router.back and router.forward"
     ],
     "pending": [
       "app dir - basic HMR should HMR correctly when changing the component type",
@@ -5826,6 +5827,39 @@
   },
   "test/e2e/app-dir/build-size/index.test.ts": {
     "passed": ["app-dir build size should skip next dev for now"],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/bun-externals/bun-externals.test.ts": {
+    "passed": [
+      "app-dir - bun externals should handle bun builtins as external modules",
+      "app-dir - bun externals should handle bun builtins in edge runtime",
+      "app-dir - bun externals should handle bun builtins in route handlers",
+      "app-dir - bun externals should handle bun builtins in server actions"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts": {
+    "passed": [
+      "hello-world should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - with prerendering the page",
+      "hello-world should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - without prerendering the page",
+      "hello-world should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - with prerendering the page",
+      "hello-world should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - without prerendering the page"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts": {
+    "passed": [
+      "hello-world should not indicate there is an error when incidental math.random calls occur during component tree generation during dev"
+    ],
     "failed": [],
     "pending": [],
     "flakey": [],
@@ -7396,6 +7430,15 @@
       "app-dir - metadata-icons should re-insert the icons into head when icons are inserted in body during initial chunk",
       "app-dir - metadata-icons should render custom icons along with favicon in nested page",
       "app-dir - metadata-icons should render custom icons along with favicon in root page"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/metadata-image-files/metadata-image-files.test.ts": {
+    "passed": [
+      "app dir - metadata image files should handle imported metadata images"
     ],
     "failed": [],
     "pending": [],
@@ -10067,6 +10110,17 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/typed-routes/typed-routes.test.ts": {
+    "passed": [
+      "typed-routes should correctly convert custom route patterns from path-to-regexp to bracket syntax",
+      "typed-routes should generate route types correctly",
+      "typed-routes should update route types file when routes change"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/typeof-window/typeof-window.test.ts": {
     "passed": ["typeof-window should work using cheerio"],
     "failed": [],
@@ -10936,6 +10990,15 @@
       "edge-runtime uses edge-light import specifier for packages app-dir imports the correct module",
       "edge-runtime uses edge-light import specifier for packages pages import the correct module",
       "edge-runtime uses edge-light import specifier for packages pages/api endpoints import the correct module"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts": {
+    "passed": [
+      "error-handler-not-found-req-url should log the correct request url and asPath for not found _error page"
     ],
     "failed": [],
     "pending": [],
@@ -12482,6 +12545,7 @@
       "opentelemetry incoming context propagation app router should handle RSC with fetch",
       "opentelemetry incoming context propagation app router should handle RSC with fetch in RSC mode",
       "opentelemetry incoming context propagation app router should handle RSC with fetch on edge",
+      "opentelemetry incoming context propagation app router should handle error in RSC",
       "opentelemetry incoming context propagation app router should handle route handlers in app router",
       "opentelemetry incoming context propagation app router should handle route handlers in app router on edge",
       "opentelemetry incoming context propagation app router should propagate custom context without span",
@@ -12494,6 +12558,7 @@
       "opentelemetry root context app router should handle RSC with fetch",
       "opentelemetry root context app router should handle RSC with fetch in RSC mode",
       "opentelemetry root context app router should handle RSC with fetch on edge",
+      "opentelemetry root context app router should handle error in RSC",
       "opentelemetry root context app router should handle route handlers in app router",
       "opentelemetry root context app router should handle route handlers in app router on edge",
       "opentelemetry root context app router should propagate custom context without span",
@@ -12831,7 +12896,8 @@
       "styled-jsx should contain styled-jsx styles during SSR",
       "styled-jsx should render styles during CSR",
       "styled-jsx should render styles during CSR (AMP)",
-      "styled-jsx should render styles during SSR (AMP)"
+      "styled-jsx should render styles during SSR (AMP)",
+      "styled-jsx should render styles inside TypeScript"
     ],
     "failed": [],
     "pending": [],
@@ -13150,6 +13216,23 @@
       "useLinkStatus should remove pending state when server action triggers a redirect",
       "useLinkStatus should show pending state for the last link clicked when clicking multiple links in a row",
       "useLinkStatus should show pending state when navigating to the same path"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts": {
+    "passed": [
+      "use-router-with-rewrites rewrite to another segment should preserve current pathname when using Link with rewrites on dynamic route",
+      "use-router-with-rewrites rewrite to another segment should preserve current pathname when using useRouter.push with rewrites on dynamic route",
+      "use-router-with-rewrites rewrite to another segment should preserve current pathname when using useRouter.replace with rewrites on dynamic route",
+      "use-router-with-rewrites rewrite to same segment should preserve current pathname when using Link with rewrites on dynamic route",
+      "use-router-with-rewrites rewrite to same segment should preserve current pathname when using useRouter.push with rewrites on dynamic route",
+      "use-router-with-rewrites rewrite to same segment should preserve current pathname when using useRouter.replace with rewrites on dynamic route",
+      "use-router-with-rewrites should preserve current pathname when using Link with rewrites",
+      "use-router-with-rewrites should preserve current pathname when using useRouter.push with rewrites",
+      "use-router-with-rewrites should preserve current pathname when using useRouter.replace with rewrites"
     ],
     "failed": [],
     "pending": [],
@@ -22509,6 +22592,17 @@
       "Handle new URL asset references in next dev should render the /static page",
       "Handle new URL asset references in next dev should respond on basename api",
       "Handle new URL asset references in next dev should respond on size api"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/webpack-bun-externals/test/index.test.js": {
+    "passed": [
+      "Webpack - Bun Externals should externalize Bun builtins in server bundles",
+      "Webpack - Bun Externals should not bundle Bun module implementations",
+      "Webpack - Bun Externals should successfully build with Bun module imports"
     ],
     "failed": [],
     "pending": [],

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -50,6 +50,7 @@ triomphe = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
+turbo-unix-path = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     io::{self, ErrorKind},
     path::Path,
 };
@@ -8,123 +7,6 @@ use anyhow::{Context, Result, anyhow};
 use turbo_tasks::Vc;
 
 use crate::{DiskFileSystem, FileSystemPath};
-
-/// Joins two /-separated paths into a normalized path.
-/// Paths are concatenated with /.
-///
-/// see also [normalize_path] for normalization.
-pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
-    // Paths that we join are written as source code (eg, `join_path(fs_path,
-    // "foo/bar.js")`) and it's expected that they will never contain a
-    // backslash.
-    debug_assert!(
-        !join.contains('\\'),
-        "joined path {join} must not contain a Windows directory '\\', it must be normalized to \
-         Unix '/'"
-    );
-
-    // TODO: figure out why this freezes the benchmarks.
-    // // an absolute path would leave the file system root
-    // if Path::new(join).is_absolute() {
-    //     return None;
-    // }
-
-    if fs_path.is_empty() {
-        normalize_path(join)
-    } else if join.is_empty() {
-        normalize_path(fs_path)
-    } else {
-        normalize_path(&[fs_path, "/", join].concat())
-    }
-}
-
-/// Converts System paths into Unix paths. This is a noop on Unix systems, and
-/// replaces backslash directory separators with forward slashes on Windows.
-#[inline]
-pub fn sys_to_unix(path: &str) -> Cow<'_, str> {
-    #[cfg(not(target_family = "windows"))]
-    {
-        Cow::from(path)
-    }
-    #[cfg(target_family = "windows")]
-    {
-        Cow::Owned(path.replace(std::path::MAIN_SEPARATOR_STR, "/"))
-    }
-}
-
-/// Converts Unix paths into System paths. This is a noop on Unix systems, and
-/// replaces forward slash directory separators with backslashes on Windows.
-#[inline]
-pub fn unix_to_sys(path: &str) -> Cow<'_, str> {
-    #[cfg(not(target_family = "windows"))]
-    {
-        Cow::from(path)
-    }
-    #[cfg(target_family = "windows")]
-    {
-        Cow::Owned(path.replace('/', std::path::MAIN_SEPARATOR_STR))
-    }
-}
-
-/// Normalizes a /-separated path into a form that contains no leading /, no
-/// double /, no "." segment, no ".." segment.
-///
-/// Returns None if the path would need to start with ".." to be equal.
-pub fn normalize_path(str: &str) -> Option<String> {
-    let mut segments = Vec::new();
-    for segment in str.split('/') {
-        match segment {
-            "." | "" => {}
-            ".." => {
-                segments.pop()?;
-            }
-            segment => {
-                segments.push(segment);
-            }
-        }
-    }
-    Some(segments.join("/"))
-}
-
-/// Normalizes a /-separated request into a form that contains no leading /, no
-/// double /, and no "." or ".." segments in the middle of the request.
-///
-/// A request might only start with a single "." segment and no ".." segments, or
-/// any positive number of ".." segments but no "." segment.
-pub fn normalize_request(str: &str) -> String {
-    let mut segments = vec!["."];
-    // Keeps track of our directory depth so that we can pop directories when
-    // encountering a "..". If this is positive, then we're inside a directory
-    // and we can pop that. If it's 0, then we can't pop the directory and we must
-    // keep the ".." in our segments. This is not the same as the segments.len(),
-    // because we cannot pop a kept ".." when encountering another "..".
-    let mut depth = 0;
-    let mut popped_dot = false;
-    for segment in str.split('/') {
-        match segment {
-            "." => {}
-            ".." => {
-                if depth > 0 {
-                    depth -= 1;
-                    segments.pop();
-                } else {
-                    // The first time we push a "..", we need to remove the "." we include by
-                    // default.
-                    if !popped_dot {
-                        popped_dot = true;
-                        segments.pop();
-                    }
-                    segments.push(segment);
-                }
-            }
-            segment => {
-                segments.push(segment);
-                depth += 1;
-            }
-        }
-    }
-    segments.join("/")
-}
 
 /// Converts a disk access Result<T> into a Result<Some<T>>, where a NotFound
 /// error results in a None value. This is purely to reduce boilerplate code
@@ -139,6 +21,8 @@ pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Optio
 
 #[cfg(not(target_os = "windows"))]
 pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
+    use turbo_unix_path::sys_to_unix;
+
     let root_fs = root.fs();
     let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
         .await?
@@ -189,35 +73,4 @@ pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<S
     let uri = format!("file:///{}", encoded_path);
 
     Ok(uri)
-}
-
-#[cfg(test)]
-mod tests {
-
-    use rstest::*;
-
-    use crate::util::normalize_path;
-
-    #[rstest]
-    #[case("file.js")]
-    #[case("a/b/c/d/e/file.js")]
-    fn test_normalize_path_no_op(#[case] path: &str) {
-        assert_eq!(path, normalize_path(path).unwrap());
-    }
-
-    #[rstest]
-    #[case("/file.js", "file.js")]
-    #[case("./file.js", "file.js")]
-    #[case("././file.js", "file.js")]
-    #[case("a/../c/../file.js", "file.js")]
-    fn test_normalize_path(#[case] path: &str, #[case] normalized: &str) {
-        assert_eq!(normalized, normalize_path(path).unwrap());
-    }
-
-    #[rstest]
-    #[case("../file.js")]
-    #[case("a/../../file.js")]
-    fn test_normalize_path_invalid(#[case] path: &str) {
-        assert_eq!(None, normalize_path(path));
-    }
 }

--- a/turbopack/crates/turbo-unix-path/Cargo.toml
+++ b/turbopack/crates/turbo-unix-path/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "turbo-unix-path"
+version = "0.0.1"
+description = "TBD"
+license = "MIT"
+edition = "2024"
+
+[lib]
+bench = false
+
+[lints]
+workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/turbopack/crates/turbo-unix-path/README.md
+++ b/turbopack/crates/turbo-unix-path/README.md
@@ -1,0 +1,8 @@
+Utilities for lexical manipulation of unix-style (`/`-separated) paths represented as unicode
+strings.
+
+These paths types are frequently used for JS imports, and are used within Turbopack to represent
+platform-agnostic relative paths.
+
+This crate does not perform any IO, and does not depend on turbo-tasks. Most users should prefer the
+`turbo-tasks-fs` crate.

--- a/turbopack/crates/turbo-unix-path/src/lib.rs
+++ b/turbopack/crates/turbo-unix-path/src/lib.rs
@@ -1,0 +1,188 @@
+#![doc = include_str!("../README.md")]
+
+use std::borrow::Cow;
+
+/// Converts system paths into Unix paths. This is a noop on Unix systems, and replaces backslash
+/// directory separators with forward slashes on Windows.
+#[inline]
+pub fn sys_to_unix(path: &str) -> Cow<'_, str> {
+    #[cfg(not(target_family = "windows"))]
+    {
+        Cow::from(path)
+    }
+    #[cfg(target_family = "windows")]
+    {
+        Cow::Owned(path.replace(std::path::MAIN_SEPARATOR_STR, "/"))
+    }
+}
+
+/// Converts Unix paths into system paths. This is a noop on Unix systems, and replaces forward
+/// slash directory separators with backslashes on Windows.
+#[inline]
+pub fn unix_to_sys(path: &str) -> Cow<'_, str> {
+    #[cfg(not(target_family = "windows"))]
+    {
+        Cow::from(path)
+    }
+    #[cfg(target_family = "windows")]
+    {
+        Cow::Owned(path.replace('/', std::path::MAIN_SEPARATOR_STR))
+    }
+}
+
+/// Joins two /-separated paths into a normalized path.
+/// Paths are concatenated with /.
+///
+/// see also [normalize_path] for normalization.
+pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
+    // Paths that we join are written as source code (eg, `join_path(fs_path, "foo/bar.js")`) and
+    // it's expected that they will never contain a backslash.
+    debug_assert!(
+        !join.contains('\\'),
+        "joined path {join} must not contain a Windows directory '\\', it must be normalized to \
+         Unix '/'"
+    );
+
+    // TODO: figure out why this freezes the benchmarks.
+    // // an absolute path would leave the file system root
+    // if Path::new(join).is_absolute() {
+    //     return None;
+    // }
+
+    if fs_path.is_empty() {
+        normalize_path(join)
+    } else if join.is_empty() {
+        normalize_path(fs_path)
+    } else {
+        normalize_path(&[fs_path, "/", join].concat())
+    }
+}
+
+/// Normalizes a /-separated path into a form that contains no leading /, no double /, no "."
+/// segment, no ".." segment.
+///
+/// Returns None if the path would need to start with ".." to be equal.
+pub fn normalize_path(str: &str) -> Option<String> {
+    let mut segments = Vec::new();
+    for segment in str.split('/') {
+        match segment {
+            "." | "" => {}
+            ".." => {
+                segments.pop()?;
+            }
+            segment => {
+                segments.push(segment);
+            }
+        }
+    }
+    Some(segments.join("/"))
+}
+
+/// Normalizes a /-separated request into a form that contains no leading /, no double /, and no "."
+/// or ".." segments in the middle of the request.
+///
+/// A request might only start with a single "." segment and no ".." segments, or any positive
+/// number of ".." segments but no "." segment.
+pub fn normalize_request(str: &str) -> String {
+    let mut segments = vec!["."];
+    // Keeps track of our directory depth so that we can pop directories when encountering a "..".
+    // If this is positive, then we're inside a directory and we can pop that. If it's 0, then we
+    // can't pop the directory and we must keep the ".." in our segments. This is not the same as
+    // the segments.len(), because we cannot pop a kept ".." when encountering another "..".
+    let mut depth = 0;
+    let mut popped_dot = false;
+    for segment in str.split('/') {
+        match segment {
+            "." => {}
+            ".." => {
+                if depth > 0 {
+                    depth -= 1;
+                    segments.pop();
+                } else {
+                    // The first time we push a "..", we need to remove the "." we include by
+                    // default.
+                    if !popped_dot {
+                        popped_dot = true;
+                        segments.pop();
+                    }
+                    segments.push(segment);
+                }
+            }
+            segment => {
+                segments.push(segment);
+                depth += 1;
+            }
+        }
+    }
+    segments.join("/")
+}
+
+pub fn get_relative_path_to(from: &str, target: &str) -> String {
+    fn split(s: &str) -> impl Iterator<Item = &str> {
+        let empty = s.is_empty();
+        let mut iterator = s.split('/');
+        if empty {
+            iterator.next();
+        }
+        iterator
+    }
+
+    let mut from_segments = split(from).peekable();
+    let mut target_segments = split(target).peekable();
+    while from_segments.peek() == target_segments.peek() {
+        from_segments.next();
+        if target_segments.next().is_none() {
+            return ".".to_string();
+        }
+    }
+    let mut result = Vec::new();
+    if from_segments.peek().is_none() {
+        result.push(".");
+    } else {
+        while from_segments.next().is_some() {
+            result.push("..");
+        }
+    }
+    for segment in target_segments {
+        result.push(segment);
+    }
+    result.join("/")
+}
+
+pub fn get_parent_path(path: &str) -> &str {
+    match str::rfind(path, '/') {
+        Some(index) => &path[..index],
+        None => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use rstest::*;
+
+    use super::*;
+
+    #[rstest]
+    #[case("file.js")]
+    #[case("a/b/c/d/e/file.js")]
+    fn test_normalize_path_no_op(#[case] path: &str) {
+        assert_eq!(path, normalize_path(path).unwrap());
+    }
+
+    #[rstest]
+    #[case("/file.js", "file.js")]
+    #[case("./file.js", "file.js")]
+    #[case("././file.js", "file.js")]
+    #[case("a/../c/../file.js", "file.js")]
+    fn test_normalize_path(#[case] path: &str, #[case] normalized: &str) {
+        assert_eq!(normalized, normalize_path(path).unwrap());
+    }
+
+    #[rstest]
+    #[case("../file.js")]
+    #[case("a/../../file.js")]
+    fn test_normalize_path_invalid(#[case] path: &str) {
+        assert_eq!(None, normalize_path(path));
+    }
+}

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -41,6 +41,7 @@ turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-hash = { workspace = true }
+turbo-unix-path = { workspace = true }
 urlencoding = { workspace = true }
 bytes-str = { workspace = true }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1392,7 +1392,7 @@ async fn find_package(
                     for name in names.iter() {
                         let fs_path = lookup_path.join(name)?;
                         if let Some(fs_path) = dir_exists(fs_path, &mut affecting_sources).await? {
-                            let fs_path = fs_path.join(&package_name.clone())?;
+                            let fs_path = fs_path.join(&package_name)?;
                             if let Some(fs_path) =
                                 dir_exists(fs_path.clone(), &mut affecting_sources).await?
                             {
@@ -1431,7 +1431,7 @@ async fn find_package(
                     if excluded_extensions.contains(extension) {
                         continue;
                     }
-                    let package_file = package_dir.append(&extension.clone())?;
+                    let package_file = package_dir.append(extension)?;
                     if let Some(package_file) = exists(package_file, &mut affecting_sources).await?
                     {
                         packages.push(FindPackageItem::PackageFile(package_file));

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -15,9 +15,8 @@ use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap, TaskInput,
     TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{
-    FileSystemEntryType, FileSystemPath, RealPathResult, util::normalize_request,
-};
+use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath, RealPathResult};
+use turbo_unix_path::normalize_request;
 
 use self::{
     options::{
@@ -2108,7 +2107,7 @@ async fn resolve_into_folder(
                         .await?
                     && let Some(field_value) = package_json[name.as_str()].as_str()
                 {
-                    let normalized_request: RcStr = normalize_request(field_value).into();
+                    let normalized_request = RcStr::from(normalize_request(field_value));
                     if normalized_request.is_empty()
                         || &*normalized_request == "."
                         || &*normalized_request == "./"

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -16,8 +16,8 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{
     FileSystemPath, LinkContent, LinkType, RawDirectoryContent, RawDirectoryEntry,
-    util::normalize_path,
 };
+use turbo_unix_path::normalize_path;
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, Default)]
@@ -460,7 +460,7 @@ impl Pattern {
             match pattern {
                 Pattern::Constant(c) => {
                     let normalized = c.replace('\\', "/");
-                    *c = (*(normalize_path(normalized.as_str())?)).into();
+                    *c = RcStr::from(normalize_path(normalized.as_str())?);
                     Some(())
                 }
                 Pattern::Dynamic => Some(()),

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1631,7 +1631,7 @@ pub async fn read_matches(
                                     prefix.pop();
                                 }
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let fs_path = lookup_dir.join(&key.clone())?;
+                                    let fs_path = lookup_dir.join(key)?;
                                     if let LinkContent::Link { link_type, .. } =
                                         &*fs_path.read_link().await?
                                     {
@@ -1653,7 +1653,7 @@ pub async fn read_matches(
                                 }
                                 prefix.push('/');
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let fs_path = lookup_dir.join(&key.clone())?;
+                                    let fs_path = lookup_dir.join(key)?;
                                     if let LinkContent::Link { link_type, .. } =
                                         &*fs_path.read_link().await?
                                         && link_type.contains(LinkType::DIRECTORY)
@@ -1665,7 +1665,7 @@ pub async fn read_matches(
                                     }
                                 }
                                 if let Some(pos) = pat.could_match_position(&prefix) {
-                                    let fs_path = lookup_dir.join(&key.clone())?;
+                                    let fs_path = lookup_dir.join(key)?;
                                     if let LinkContent::Link { link_type, .. } =
                                         &*fs_path.read_link().await?
                                         && link_type.contains(LinkType::DIRECTORY)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
@@ -3399,8 +3399,7 @@ c#1018 = (arguments[2] | d[a])
 c#1019 = arguments[2]
 
 c#102 = (???*0* | "cssFloat")
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 c#1023 = arguments[2]
 
@@ -3471,8 +3470,7 @@ c#203 = (arguments[2] | b["tag"])
 c#207 = b["length"]
 
 c#212 = ???*0*
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 c#236 = (arguments[2] | new td("onChange", "change", null, c, d))
 
@@ -3504,9 +3502,10 @@ c#269 = arguments[2]
 
 c#270 = {}
 
-c#271 = ???*0*
+c#271 = (???*0* | ???*1*)
 - *0* c
   ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 c#274 = arguments[2]
 
@@ -3573,8 +3572,7 @@ c#364 = (b | undefined)
 c#370 = (a["data"] | undefined)
 
 c#381 = ???*0*
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 c#385 = arguments[2]
 
@@ -4656,8 +4654,7 @@ e#320 = (c["nextSibling"] | undefined)
 e#341 = {}
 
 e#345 = ???*0*
-- *0* e
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 e#354 = ???*0*
 - *0* e
@@ -4963,9 +4960,10 @@ f#308 = (e["stateNode"] | undefined | Kb(a, c) | Kb(a, b))
 
 f#311 = b["_reactName"]
 
-f#341 = ???*0*
+f#341 = (???*0* | ???*1*)
 - *0* f
   ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 f#357 = ((???*0* + e) | ???*1*["toString"](32))
 - *0* unsupported expression
@@ -5076,8 +5074,7 @@ f#647 = (
   | !(0)
   | c
 )
-- *0* f
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 f#673 = (d["focusNode"] | undefined)
 
@@ -5279,9 +5276,10 @@ g#609 = (
 
 g#614 = arguments[6]
 
-g#639 = ???*0*
+g#639 = (???*0* | ???*1*)
 - *0* g
   ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 g#647 = (
   | ???*0*
@@ -5292,8 +5290,7 @@ g#647 = (
   | Mh(a)
   | f["alternate"]
 )
-- *0* g
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 g#673 = (0 | undefined | (g + q["nodeValue"]["length"]))
 
@@ -5859,8 +5856,7 @@ l#601 = (
 )
 
 l#639 = (???*0* | f | undefined)
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 l#673 = (0 | undefined | ???*0*)
 - *0* updated with update expression

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
@@ -6695,8 +6695,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 0 -> 1004 member call = ???*0*["hasOwnProperty"]((???*1* | "cssFloat"))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* c
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 0 -> 1005 conditional = ???*0*
 - *0* ???*1*["hasOwnProperty"](c)
@@ -6705,28 +6704,24 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  function calls are not analysed yet
 
 1005 -> 1007 member call = (???*0* | "cssFloat")["indexOf"]("--")
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 1005 -> 1009 call = (...) => (((null == b) || ("boolean" === typeof(b)) || ("" === b)) ? "" : ((c || ("number" !== typeof(b)) || (0 === b) || (pb["hasOwnProperty"](a) && pb[a])) ? `${b}`["trim"]() : `${b}px`))((???*0* | "cssFloat"), ???*1*, ((0 === (???*3* | ???*5*)) | undefined))
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* ???*2*[c]
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
 - *3* ???*4*["indexOf"]("--")
   ⚠️  unknown callee object
-- *4* c
-  ⚠️  pattern without value
+- *4* for-in variable currently not analyzed
 - *5* "cssFloat"["indexOf"]("--")
   ⚠️  nested operation
 
 1005 -> 1010 conditional = ((0 === (???*0* | ???*2*)) | undefined)
 - *0* ???*1*["indexOf"]("--")
   ⚠️  unknown callee object
-- *1* c
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* "cssFloat"["indexOf"]("--")
   ⚠️  nested operation
 
@@ -6737,8 +6732,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
-- *3* c
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* (null == ???*5*)
   ⚠️  nested operation
 - *5* ???*6*[c]
@@ -6751,8 +6745,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  nested operation
 - *9* ???*10*["indexOf"]("--")
   ⚠️  unknown callee object
-- *10* c
-  ⚠️  pattern without value
+- *10* for-in variable currently not analyzed
 - *11* "cssFloat"["indexOf"]("--")
   ⚠️  nested operation
 - *12* (???*13* | ???*14*)((???*15* | "cssFloat"))
@@ -6762,8 +6755,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *14* unknown mutation
   ⚠️  This value might have side effects
-- *15* c
-  ⚠️  pattern without value
+- *15* for-in variable currently not analyzed
 - *16* node limit reached
   ⚠️  This value might have side effects
 - *17* ???*18*()
@@ -8037,7 +8029,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${190}`
   ⚠️  nested operation
 
-0 -> 1210 conditional = (3 !== (
+1166 -> 1210 conditional = (3 !== (
   | ???*0*
   | undefined["return"]["tag"]
   | undefined["alternate"]["tag"]
@@ -8062,7 +8054,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${188}`
   ⚠️  nested operation
 
-0 -> 1216 conditional = ((
+1166 -> 1216 conditional = ((
   | ???*0*
   | undefined["return"]["stateNode"]["current"]
   | undefined["alternate"]["stateNode"]["current"]
@@ -8106,7 +8098,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *13* b
   ⚠️  circular variable reference
 
-0 -> 1217 unreachable = ???*0*
+1166 -> 1217 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -8374,7 +8366,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 1231 unreachable = ???*0*
+1224 -> 1231 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -9651,7 +9643,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 1440 unreachable = ???*0*
+1417 -> 1440 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -11343,8 +11335,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 0 -> 1588 member call = ???*0*["hasOwnProperty"](???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* c
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 0 -> 1591 conditional = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -13127,7 +13118,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 1863 unreachable = ???*0*
+1852 -> 1863 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -14198,7 +14189,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* unreachable
   ⚠️  This value might have side effects
 
-2068 -> 2072 member call = ({} | ???*0*)["hasOwnProperty"](???*2*)
+2068 -> 2072 member call = ({} | ???*0*)["hasOwnProperty"]((???*2* | ???*3*))
 - *0* {}[???*1*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
@@ -14206,9 +14197,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  function calls are not analysed yet
 - *2* c
   ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 
-2068 -> 2073 conditional = (???*0* | ???*4* | ???*8*)
-- *0* (???*1* | ???*2*)(???*3*)
+2068 -> 2073 conditional = (???*0* | ???*5* | ???*10*)
+- *0* (???*1* | ???*2*)((???*3* | ???*4*))
   ⚠️  non-function callee
 - *1* FreeVar(undefined)
   ⚠️  unknown global
@@ -14217,24 +14209,26 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *3* c
   ⚠️  pattern without value
-- *4* ???*5*["hasOwnProperty"](???*7*)
+- *4* for-in variable currently not analyzed
+- *5* ???*6*["hasOwnProperty"]((???*8* | ???*9*))
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
-- *5* {}[???*6*]
+- *6* {}[???*7*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
-- *6* arguments[0]
+- *7* arguments[0]
   ⚠️  function calls are not analysed yet
-- *7* c
+- *8* c
   ⚠️  pattern without value
-- *8* unsupported expression
+- *9* for-in variable currently not analyzed
+- *10* unsupported expression
   ⚠️  This value might have side effects
 
 2073 -> 2076 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-2073 -> 2077 unreachable = ???*0*
+2068 -> 2077 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -18132,7 +18126,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 2496 unreachable = ???*0*
+2481 -> 2496 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -18346,8 +18340,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 2558 -> 2561 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(108, ???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* e
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 2558 -> 2562 call = ???*0*(???*1*)
 - *0* FreeVar(Error)
@@ -27087,7 +27080,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3680 -> 3682 unreachable = ???*0*
+3673 -> 3682 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
@@ -37772,8 +37765,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -37816,8 +37808,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* k
@@ -37908,8 +37899,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *14* arguments[0]
   ⚠️  function calls are not analysed yet
-- *15* l
-  ⚠️  pattern without value
+- *15* for-in variable currently not analyzed
 - *16* f
   ⚠️  circular variable reference
 
@@ -37955,8 +37945,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *15* arguments[0]
   ⚠️  function calls are not analysed yet
-- *16* l
-  ⚠️  pattern without value
+- *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
 
@@ -37965,8 +37954,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown callee object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*["hasOwnProperty"]((???*19* | null | undefined | [] | ???*20*))
@@ -38009,8 +37997,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* ???*22*["hasOwnProperty"]((???*24* | null | undefined | [] | ???*25*))
@@ -38019,8 +38006,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *23* arguments[0]
   ⚠️  function calls are not analysed yet
-- *24* l
-  ⚠️  pattern without value
+- *24* for-in variable currently not analyzed
 - *25* f
   ⚠️  circular variable reference
 - *26* ???*27*["hasOwnProperty"]((???*41* | null | undefined | [] | ???*42*))
@@ -38063,8 +38049,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *40* arguments[0]
   ⚠️  function calls are not analysed yet
-- *41* l
-  ⚠️  pattern without value
+- *41* for-in variable currently not analyzed
 - *42* f
   ⚠️  circular variable reference
 - *43* ???*44*[(???*46* | null | undefined | [] | ???*47*)]
@@ -38073,8 +38058,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *45* arguments[0]
   ⚠️  function calls are not analysed yet
-- *46* l
-  ⚠️  pattern without value
+- *46* for-in variable currently not analyzed
 - *47* f
   ⚠️  circular variable reference
 - *48* ???*49*[(???*63* | null | undefined | [] | ???*64*)]
@@ -38117,14 +38101,12 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *62* arguments[0]
   ⚠️  function calls are not analysed yet
-- *63* l
-  ⚠️  pattern without value
+- *63* for-in variable currently not analyzed
 - *64* f
   ⚠️  circular variable reference
 
 4968 -> 4969 conditional = ("style" === (???*0* | null | undefined | [] | ???*1*))
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 
@@ -38134,15 +38116,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   | undefined
   | (???*22* ? (???*39* | ???*44*) : ???*61*)
   | (???*62* ? ???*63* : ???*65*)
-)["hasOwnProperty"](???*66*)
+)["hasOwnProperty"]((???*66* | ???*67*))
 - *0* ???*1*[(???*3* | null | undefined | [] | ???*4*)]
   ⚠️  unknown object
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -38185,8 +38166,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* (null != (???*23* | ???*25*))
@@ -38238,8 +38218,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *41* arguments[0]
   ⚠️  function calls are not analysed yet
-- *42* l
-  ⚠️  pattern without value
+- *42* for-in variable currently not analyzed
 - *43* f
   ⚠️  circular variable reference
 - *44* ???*45*[(???*59* | null | undefined | [] | ???*60*)]
@@ -38282,8 +38261,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *58* arguments[0]
   ⚠️  function calls are not analysed yet
-- *59* l
-  ⚠️  pattern without value
+- *59* for-in variable currently not analyzed
 - *60* f
   ⚠️  circular variable reference
 - *61* unsupported expression
@@ -38298,10 +38276,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *66* g
   ⚠️  pattern without value
+- *67* for-in variable currently not analyzed
 
 4969 -> 4975 member call = {}["hasOwnProperty"]((???*0* | null | undefined | [] | ???*1*))
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 
@@ -38313,16 +38291,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *2* unknown mutation
   ⚠️  This value might have side effects
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 
 4976 -> 4978 member call = ???*0*["push"]((???*1* | null | undefined | [] | ???*2*), null)
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* l
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* f
   ⚠️  circular variable reference
 
@@ -38409,8 +38385,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *14* arguments[0]
   ⚠️  function calls are not analysed yet
-- *15* l
-  ⚠️  pattern without value
+- *15* for-in variable currently not analyzed
 - *16* f
   ⚠️  circular variable reference
 
@@ -38424,8 +38399,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown callee object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*["hasOwnProperty"]((???*19* | null | undefined | [] | ???*20*))
@@ -38468,16 +38442,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* ???*22*[(???*23* | null | undefined | [] | ???*24*)]
   ⚠️  unknown object
 - *22* arguments[3]
   ⚠️  function calls are not analysed yet
-- *23* l
-  ⚠️  pattern without value
+- *23* for-in variable currently not analyzed
 - *24* f
   ⚠️  circular variable reference
 - *25* ???*26*[(???*40* | null | undefined | [] | ???*41*)]
@@ -38520,8 +38492,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *39* arguments[0]
   ⚠️  function calls are not analysed yet
-- *40* l
-  ⚠️  pattern without value
+- *40* for-in variable currently not analyzed
 - *41* f
   ⚠️  circular variable reference
 - *42* (???*43* ? ???*44* : ???*46*)
@@ -38540,8 +38511,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *49* arguments[0]
   ⚠️  function calls are not analysed yet
-- *50* l
-  ⚠️  pattern without value
+- *50* for-in variable currently not analyzed
 - *51* f
   ⚠️  circular variable reference
 - *52* ???*53*[(???*67* | null | undefined | [] | ???*68*)]
@@ -38584,8 +38554,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *66* arguments[0]
   ⚠️  function calls are not analysed yet
-- *67* l
-  ⚠️  pattern without value
+- *67* for-in variable currently not analyzed
 - *68* f
   ⚠️  circular variable reference
 - *69* (???*70* ? (???*85* | ???*90*) : ???*105*)
@@ -38635,8 +38604,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *87* arguments[0]
   ⚠️  function calls are not analysed yet
-- *88* l
-  ⚠️  pattern without value
+- *88* for-in variable currently not analyzed
 - *89* f
   ⚠️  circular variable reference
 - *90* ???*91*[(???*103* | null | undefined | [] | ???*104*)]
@@ -38675,8 +38643,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *102* ...[...]
   ⚠️  unknown object
-- *103* l
-  ⚠️  pattern without value
+- *103* for-in variable currently not analyzed
 - *104* f
   ⚠️  circular variable reference
 - *105* unsupported expression
@@ -38685,8 +38652,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *107* arguments[3]
   ⚠️  function calls are not analysed yet
-- *108* l
-  ⚠️  pattern without value
+- *108* for-in variable currently not analyzed
 - *109* f
   ⚠️  circular variable reference
 - *110* ???*111*[(???*125* | null | undefined | [] | ???*126*)]
@@ -38729,8 +38695,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *124* arguments[0]
   ⚠️  function calls are not analysed yet
-- *125* l
-  ⚠️  pattern without value
+- *125* for-in variable currently not analyzed
 - *126* f
   ⚠️  circular variable reference
 - *127* (???*128* ? ???*129* : ???*131*)
@@ -38745,8 +38710,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 
 4984 -> 4985 conditional = ("style" === (???*0* | null | undefined | [] | ???*1*))
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 
@@ -38763,8 +38727,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -38807,8 +38770,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* (null != (???*23* | ???*25*))
@@ -38860,8 +38822,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *41* arguments[0]
   ⚠️  function calls are not analysed yet
-- *42* l
-  ⚠️  pattern without value
+- *42* for-in variable currently not analyzed
 - *43* f
   ⚠️  circular variable reference
 - *44* ???*45*[(???*59* | null | undefined | [] | ???*60*)]
@@ -38904,8 +38865,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *58* arguments[0]
   ⚠️  function calls are not analysed yet
-- *59* l
-  ⚠️  pattern without value
+- *59* for-in variable currently not analyzed
 - *60* f
   ⚠️  circular variable reference
 - *61* unsupported expression
@@ -38925,15 +38885,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   | undefined
   | (???*22* ? (???*39* | ???*44*) : ???*61*)
   | (???*62* ? ???*63* : ???*65*)
-)["hasOwnProperty"](???*66*)
+)["hasOwnProperty"]((???*66* | ???*67*))
 - *0* ???*1*[(???*3* | null | undefined | [] | ???*4*)]
   ⚠️  unknown object
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -38976,8 +38935,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* (null != (???*23* | ???*25*))
@@ -39029,8 +38987,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *41* arguments[0]
   ⚠️  function calls are not analysed yet
-- *42* l
-  ⚠️  pattern without value
+- *42* for-in variable currently not analyzed
 - *43* f
   ⚠️  circular variable reference
 - *44* ???*45*[(???*59* | null | undefined | [] | ???*60*)]
@@ -39073,8 +39030,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *58* arguments[0]
   ⚠️  function calls are not analysed yet
-- *59* l
-  ⚠️  pattern without value
+- *59* for-in variable currently not analyzed
 - *60* f
   ⚠️  circular variable reference
 - *61* unsupported expression
@@ -39089,14 +39045,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *66* g
   ⚠️  pattern without value
+- *67* for-in variable currently not analyzed
 
-4986 -> 4990 member call = (???*0* | ???*4* | undefined | (???*21* ? ???*22* : ???*24*))["hasOwnProperty"](???*25*)
+4986 -> 4990 member call = (???*0* | ???*4* | undefined | (???*21* ? ???*22* : ???*24*))["hasOwnProperty"]((???*25* | ???*26*))
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*[(???*19* | null | undefined | [] | ???*20*)]
@@ -39139,8 +39095,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* k
@@ -39153,14 +39108,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *25* g
   ⚠️  pattern without value
+- *26* for-in variable currently not analyzed
 
-4986 -> 4993 member call = (???*0* | ???*4* | undefined | (???*21* ? ???*22* : ???*24*))["hasOwnProperty"](???*25*)
+4986 -> 4993 member call = (???*0* | ???*4* | undefined | (???*21* ? ???*22* : ???*24*))["hasOwnProperty"]((???*25* | ???*26*))
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*[(???*19* | null | undefined | [] | ???*20*)]
@@ -39203,8 +39158,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* k
@@ -39217,6 +39171,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *25* g
   ⚠️  pattern without value
+- *26* for-in variable currently not analyzed
 
 4986 -> 4999 member call = (null | undefined | [] | ???*0*)["push"](
     (???*1* | null | undefined | [] | ???*2*),
@@ -39224,8 +39179,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 )
 - *0* f
   ⚠️  circular variable reference
-- *1* l
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* f
   ⚠️  circular variable reference
 - *3* arguments[2]
@@ -39234,8 +39188,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *5* arguments[3]
   ⚠️  function calls are not analysed yet
-- *6* l
-  ⚠️  pattern without value
+- *6* for-in variable currently not analyzed
 - *7* f
   ⚠️  circular variable reference
 - *8* ???*9*[(???*23* | null | undefined | [] | ???*24*)]
@@ -39278,8 +39231,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *22* arguments[0]
   ⚠️  function calls are not analysed yet
-- *23* l
-  ⚠️  pattern without value
+- *23* for-in variable currently not analyzed
 - *24* f
   ⚠️  circular variable reference
 - *25* k
@@ -39292,8 +39244,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 
 4985 -> 5000 conditional = ("dangerouslySetInnerHTML" === (???*0* | null | undefined | [] | ???*1*))
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 
@@ -39302,8 +39253,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*[(???*19* | null | undefined | [] | ???*20*)]
@@ -39346,8 +39296,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* k
@@ -39372,8 +39321,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -39416,8 +39364,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* (null != (???*23* | ???*25*))
@@ -39469,8 +39416,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *41* arguments[0]
   ⚠️  function calls are not analysed yet
-- *42* l
-  ⚠️  pattern without value
+- *42* for-in variable currently not analyzed
 - *43* f
   ⚠️  circular variable reference
 - *44* ???*45*[(???*59* | null | undefined | [] | ???*60*)]
@@ -39513,8 +39459,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *58* arguments[0]
   ⚠️  function calls are not analysed yet
-- *59* l
-  ⚠️  pattern without value
+- *59* for-in variable currently not analyzed
 - *60* f
   ⚠️  circular variable reference
 - *61* unsupported expression
@@ -39534,16 +39479,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 )
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* l
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* f
   ⚠️  circular variable reference
 - *3* ???*4*[(???*5* | null | undefined | [] | ???*6*)]
   ⚠️  unknown object
 - *4* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* l
-  ⚠️  pattern without value
+- *5* for-in variable currently not analyzed
 - *6* f
   ⚠️  circular variable reference
 - *7* ???*8*[(???*22* | null | undefined | [] | ???*23*)]
@@ -39586,8 +39529,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *21* arguments[0]
   ⚠️  function calls are not analysed yet
-- *22* l
-  ⚠️  pattern without value
+- *22* for-in variable currently not analyzed
 - *23* f
   ⚠️  circular variable reference
 - *24* k
@@ -39600,8 +39542,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 
 5000 -> 5007 conditional = ("children" === (???*0* | null | undefined | [] | ???*1*))
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 
@@ -39610,8 +39551,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*[(???*19* | null | undefined | [] | ???*20*)]
@@ -39654,8 +39594,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* k
@@ -39672,8 +39611,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*[(???*19* | null | undefined | [] | ???*20*)]
@@ -39716,8 +39654,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* k
@@ -39735,16 +39672,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 )
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* l
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* f
   ⚠️  circular variable reference
 - *3* ???*4*[(???*5* | null | undefined | [] | ???*6*)]
   ⚠️  unknown object
 - *4* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* l
-  ⚠️  pattern without value
+- *5* for-in variable currently not analyzed
 - *6* f
   ⚠️  circular variable reference
 - *7* ???*8*[(???*22* | null | undefined | [] | ???*23*)]
@@ -39787,8 +39722,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *21* arguments[0]
   ⚠️  function calls are not analysed yet
-- *22* l
-  ⚠️  pattern without value
+- *22* for-in variable currently not analyzed
 - *23* f
   ⚠️  circular variable reference
 - *24* k
@@ -39801,8 +39735,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 
 5007 -> 5013 member call = {}["hasOwnProperty"]((???*0* | null | undefined | [] | ???*1*))
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 
@@ -39814,8 +39747,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *2* unknown mutation
   ⚠️  This value might have side effects
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 
@@ -39833,16 +39765,14 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 )
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* l
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* f
   ⚠️  circular variable reference
 - *3* ???*4*[(???*5* | null | undefined | [] | ???*6*)]
   ⚠️  unknown object
 - *4* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* l
-  ⚠️  pattern without value
+- *5* for-in variable currently not analyzed
 - *6* f
   ⚠️  circular variable reference
 - *7* ???*8*[(???*22* | null | undefined | [] | ???*23*)]
@@ -39885,8 +39815,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *21* arguments[0]
   ⚠️  function calls are not analysed yet
-- *22* l
-  ⚠️  pattern without value
+- *22* for-in variable currently not analyzed
 - *23* f
   ⚠️  circular variable reference
 - *24* k
@@ -39910,8 +39839,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *3* arguments[3]
   ⚠️  function calls are not analysed yet
-- *4* l
-  ⚠️  pattern without value
+- *4* for-in variable currently not analyzed
 - *5* f
   ⚠️  circular variable reference
 - *6* ???*7*[(???*21* | null | undefined | [] | ???*22*)]
@@ -39954,8 +39882,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  unknown object
 - *20* arguments[0]
   ⚠️  function calls are not analysed yet
-- *21* l
-  ⚠️  pattern without value
+- *21* for-in variable currently not analyzed
 - *22* f
   ⚠️  circular variable reference
 - *23* k

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
@@ -9879,8 +9879,7 @@ c#1019 = ???*0*
   ⚠️  function calls are not analysed yet
 
 c#102 = (???*0* | "cssFloat")
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 c#1023 = ???*0*
 - *0* arguments[2]
@@ -10147,8 +10146,7 @@ c#207 = (
   ⚠️  This value might have side effects
 
 c#212 = ???*0*
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 c#236 = (
   | ???*0*
@@ -10271,9 +10269,10 @@ c#269 = ???*0*
 
 c#270 = {}
 
-c#271 = ???*0*
+c#271 = (???*0* | ???*1*)
 - *0* c
   ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 c#274 = ???*0*
 - *0* arguments[2]
@@ -10475,8 +10474,7 @@ c#370 = (???*0* | (???*2* ? ???*4* : null)["data"] | undefined)
   ⚠️  circular variable reference
 
 c#381 = ???*0*
-- *0* c
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 c#385 = ???*0*
 - *0* arguments[2]
@@ -11747,8 +11745,7 @@ c#639 = (???*0* | null | {} | ???*1* | ???*5* | undefined | (???*22* ? ???*23* :
   ⚠️  unknown object
 - *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -11791,8 +11788,7 @@ c#639 = (???*0* | null | {} | ???*1* | ???*5* | undefined | (???*22* ? ???*23* :
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* k
@@ -12558,8 +12554,7 @@ d#1018 = ((null != (???*0* | ???*1*)) | ???*3* | null)
 d#102 = ((0 === (???*0* | ???*2*)) | undefined)
 - *0* ???*1*["indexOf"]("--")
   ⚠️  unknown callee object
-- *1* c
-  ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 - *2* "cssFloat"["indexOf"]("--")
   ⚠️  nested operation
 
@@ -15091,8 +15086,7 @@ e#102 = ((???*0* ? "" : ???*3*) | undefined)
   ⚠️  nested operation
 - *5* ???*6*["indexOf"]("--")
   ⚠️  unknown callee object
-- *6* c
-  ⚠️  pattern without value
+- *6* for-in variable currently not analyzed
 - *7* "cssFloat"["indexOf"]("--")
   ⚠️  nested operation
 - *8* (???*9* | ???*10*)((???*11* | "cssFloat"))
@@ -15102,8 +15096,7 @@ e#102 = ((???*0* ? "" : ???*3*) | undefined)
   ⚠️  This value might have side effects
 - *10* unknown mutation
   ⚠️  This value might have side effects
-- *11* c
-  ⚠️  pattern without value
+- *11* for-in variable currently not analyzed
 - *12* node limit reached
   ⚠️  This value might have side effects
 - *13* ???*14*()
@@ -15588,8 +15581,7 @@ e#320 = (???*0* | undefined)
 e#341 = {}
 
 e#345 = ???*0*
-- *0* e
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 e#354 = ???*0*
 - *0* e
@@ -17508,9 +17500,10 @@ f#311 = ???*0*
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-f#341 = ???*0*
+f#341 = (???*0* | ???*1*)
 - *0* f
   ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 f#357 = ((???*0* + (???*1* | ???*2*)) | ???*3*)
 - *0* unsupported expression
@@ -18998,9 +18991,10 @@ g#614 = ???*0*
 - *0* arguments[6]
   ⚠️  function calls are not analysed yet
 
-g#639 = ???*0*
+g#639 = (???*0* | ???*1*)
 - *0* g
   ⚠️  pattern without value
+- *1* for-in variable currently not analyzed
 
 g#647 = ???*0*
 - *0* max number of linking steps reached
@@ -19515,8 +19509,7 @@ h#639 = (
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *3* l
-  ⚠️  pattern without value
+- *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
 - *5* ???*6*[(???*20* | null | undefined | [] | ???*21*)]
@@ -19559,8 +19552,7 @@ h#639 = (
   ⚠️  unknown object
 - *19* arguments[0]
   ⚠️  function calls are not analysed yet
-- *20* l
-  ⚠️  pattern without value
+- *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
 - *22* (null != (???*23* | ???*25*))
@@ -19612,8 +19604,7 @@ h#639 = (
   ⚠️  unknown object
 - *41* arguments[0]
   ⚠️  function calls are not analysed yet
-- *42* l
-  ⚠️  pattern without value
+- *42* for-in variable currently not analyzed
 - *43* f
   ⚠️  circular variable reference
 - *44* ???*45*[(???*59* | null | undefined | [] | ???*60*)]
@@ -19656,8 +19647,7 @@ h#639 = (
   ⚠️  unknown object
 - *58* arguments[0]
   ⚠️  function calls are not analysed yet
-- *59* l
-  ⚠️  pattern without value
+- *59* for-in variable currently not analyzed
 - *60* f
   ⚠️  circular variable reference
 - *61* unsupported expression
@@ -20257,8 +20247,7 @@ k#639 = (???*0* | ???*4* | undefined | (???*21* ? ???*22* : ???*24*))
   ⚠️  unknown object
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
-- *2* l
-  ⚠️  pattern without value
+- *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
 - *4* ???*5*[(???*19* | null | undefined | [] | ???*20*)]
@@ -20301,8 +20290,7 @@ k#639 = (???*0* | ???*4* | undefined | (???*21* ? ???*22* : ???*24*))
   ⚠️  unknown object
 - *18* arguments[0]
   ⚠️  function calls are not analysed yet
-- *19* l
-  ⚠️  pattern without value
+- *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
 - *21* k
@@ -20647,8 +20635,7 @@ l#601 = ???*0*
   ⚠️  This value might have side effects
 
 l#639 = (???*0* | null | undefined | [] | ???*1*)
-- *0* l
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 - *1* f
   ⚠️  circular variable reference
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-effects.snapshot
@@ -1,0 +1,1042 @@
+[
+    ImportedBinding {
+        esm_reference_index: 1,
+        export: Some(
+            "calledA1",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    1,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 191..199,
+        in_try: false,
+    },
+    Call {
+        func: Member(
+            3,
+            Module(
+                ModuleValue {
+                    module: "foo",
+                    annotations: ImportAnnotations {
+                        map: {},
+                    },
+                },
+            ),
+            Constant(
+                Str(
+                    Atom(
+                        "calledA1",
+                    ),
+                ),
+            ),
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    1,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 191..201,
+        in_try: false,
+        new: false,
+    },
+    Unreachable {
+        start_ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    1,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                Return,
+            ),
+        ],
+    },
+    Unreachable {
+        start_ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    1,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+        ],
+    },
+    ImportedBinding {
+        esm_reference_index: 7,
+        export: Some(
+            "unreachableA3",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    1,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    2,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 286..299,
+        in_try: false,
+    },
+    Call {
+        func: Member(
+            3,
+            Module(
+                ModuleValue {
+                    module: "foo",
+                    annotations: ImportAnnotations {
+                        map: {},
+                    },
+                },
+            ),
+            Constant(
+                Str(
+                    Atom(
+                        "unreachableA3",
+                    ),
+                ),
+            ),
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    1,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    2,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 286..301,
+        in_try: false,
+        new: false,
+    },
+    ImportedBinding {
+        esm_reference_index: 8,
+        export: Some(
+            "unreachableB1",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 350..363,
+        in_try: false,
+    },
+    Call {
+        func: Member(
+            3,
+            Module(
+                ModuleValue {
+                    module: "foo",
+                    annotations: ImportAnnotations {
+                        map: {},
+                    },
+                },
+            ),
+            Constant(
+                Str(
+                    Atom(
+                        "unreachableB1",
+                    ),
+                ),
+            ),
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 350..365,
+        in_try: false,
+        new: false,
+    },
+    Unreachable {
+        start_ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    2,
+                ),
+            ),
+            Stmt(
+                Return,
+            ),
+        ],
+    },
+    Unreachable {
+        start_ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+        ],
+    },
+    ImportedBinding {
+        esm_reference_index: 2,
+        export: Some(
+            "calledB1",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 403..411,
+        in_try: false,
+    },
+    Call {
+        func: Member(
+            3,
+            Module(
+                ModuleValue {
+                    module: "foo",
+                    annotations: ImportAnnotations {
+                        map: {},
+                    },
+                },
+            ),
+            Constant(
+                Str(
+                    Atom(
+                        "calledB1",
+                    ),
+                ),
+            ),
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 403..413,
+        in_try: false,
+        new: false,
+    },
+    ImportedBinding {
+        esm_reference_index: 3,
+        export: Some(
+            "calledC1",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 484..492,
+        in_try: false,
+    },
+    Call {
+        func: Member(
+            3,
+            Module(
+                ModuleValue {
+                    module: "foo",
+                    annotations: ImportAnnotations {
+                        map: {},
+                    },
+                },
+            ),
+            Constant(
+                Str(
+                    Atom(
+                        "calledC1",
+                    ),
+                ),
+            ),
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 484..494,
+        in_try: false,
+        new: false,
+    },
+    Unreachable {
+        start_ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    2,
+                ),
+            ),
+            Stmt(
+                Return,
+            ),
+        ],
+    },
+    Unreachable {
+        start_ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                While,
+            ),
+            WhileStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+        ],
+    },
+    ImportedBinding {
+        esm_reference_index: 4,
+        export: Some(
+            "calledC2",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 532..540,
+        in_try: false,
+    },
+    Call {
+        func: Member(
+            3,
+            Module(
+                ModuleValue {
+                    module: "foo",
+                    annotations: ImportAnnotations {
+                        map: {},
+                    },
+                },
+            ),
+            Constant(
+                Str(
+                    Atom(
+                        "calledC2",
+                    ),
+                ),
+            ),
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 532..542,
+        in_try: false,
+        new: false,
+    },
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-explained.snapshot
@@ -1,0 +1,7 @@
+A = (...) => (undefined | FreeVar(undefined))
+
+B = (...) => (undefined | FreeVar(undefined))
+
+C = (...) => (undefined | FreeVar(undefined))
+
+v = arguments[0]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph.snapshot
@@ -1,0 +1,66 @@
+[
+    (
+        "A",
+        Function(
+            4,
+            174,
+            Alternatives {
+                total_nodes: 3,
+                values: [
+                    Constant(
+                        Undefined,
+                    ),
+                    FreeVar(
+                        "undefined",
+                    ),
+                ],
+                logical_property: None,
+            },
+        ),
+    ),
+    (
+        "B",
+        Function(
+            4,
+            304,
+            Alternatives {
+                total_nodes: 3,
+                values: [
+                    Constant(
+                        Undefined,
+                    ),
+                    FreeVar(
+                        "undefined",
+                    ),
+                ],
+                logical_property: None,
+            },
+        ),
+    ),
+    (
+        "C",
+        Function(
+            4,
+            416,
+            Alternatives {
+                total_nodes: 3,
+                values: [
+                    Constant(
+                        Undefined,
+                    ),
+                    FreeVar(
+                        "undefined",
+                    ),
+                ],
+                logical_property: None,
+            },
+        ),
+    ),
+    (
+        "v",
+        Argument(
+            416,
+            0,
+        ),
+    ),
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/input.js
@@ -1,0 +1,43 @@
+import {
+  calledA1,
+  calledB1,
+  calledC1,
+  calledC2,
+  unreachableA1,
+  unreachableA2,
+  unreachableA3,
+  unreachableB1,
+  unreachableB2,
+  unreachableC1,
+} from 'foo'
+
+function A() {
+  calledA1()
+  while (true) {
+    return
+    unreachableA1()
+    break
+    unreachableA2()
+  }
+  unreachableA3()
+}
+function B() {
+  while (true) {
+    break
+    unreachableB1()
+    return
+    unreachableB2()
+  }
+  calledB1()
+}
+function C(v) {
+  while (true) {
+    if (v) {
+      break
+    }
+    calledC1()
+    return
+    unreachableC1()
+  }
+  calledC2()
+}

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/resolved-effects.snapshot
@@ -1,0 +1,35 @@
+0 -> 2 call = module<foo, {}>["calledA1"]()
+
+0 -> 3 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 4 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 6 call = module<foo, {}>["unreachableA3"]()
+
+0 -> 8 call = module<foo, {}>["unreachableB1"]()
+
+0 -> 9 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 10 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 12 call = module<foo, {}>["calledB1"]()
+
+0 -> 14 call = module<foo, {}>["calledC1"]()
+
+0 -> 15 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 16 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 18 call = module<foo, {}>["calledC2"]()

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/resolved-explained.snapshot
@@ -1,0 +1,9 @@
+A = (...) => (undefined | FreeVar(undefined))
+
+B = (...) => (undefined | FreeVar(undefined))
+
+C = (...) => (undefined | FreeVar(undefined))
+
+v = ???*0*
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph-effects.snapshot
@@ -339,6 +339,103 @@
     },
     FreeVar {
         var: FreeVar(
+            "b3",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    1,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 116..118,
+        in_try: false,
+    },
+    Call {
+        func: FreeVar(
+            "b3",
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    1,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 116..120,
+        in_try: false,
+        new: false,
+    },
+    FreeVar {
+        var: FreeVar(
             "c1",
         ),
         ast_path: [
@@ -545,6 +642,103 @@
                 Block,
             ),
         ],
+    },
+    FreeVar {
+        var: FreeVar(
+            "c3",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    2,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 200..202,
+        in_try: false,
+    },
+    Call {
+        func: FreeVar(
+            "c3",
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    2,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 200..204,
+        in_try: false,
+        new: false,
     },
     FreeVar {
         var: FreeVar(
@@ -757,6 +951,103 @@
     },
     FreeVar {
         var: FreeVar(
+            "d3",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    3,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 275..277,
+        in_try: false,
+    },
+    Call {
+        func: FreeVar(
+            "d3",
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    3,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 275..279,
+        in_try: false,
+        new: false,
+    },
+    FreeVar {
+        var: FreeVar(
             "e1",
         ),
         ast_path: [
@@ -966,6 +1257,103 @@
     },
     FreeVar {
         var: FreeVar(
+            "e3",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    4,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 359..361,
+        in_try: false,
+    },
+    Call {
+        func: FreeVar(
+            "e3",
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    4,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 359..363,
+        in_try: false,
+        new: false,
+    },
+    FreeVar {
+        var: FreeVar(
             "f1",
         ),
         ast_path: [
@@ -1172,6 +1560,103 @@
                 Block,
             ),
         ],
+    },
+    FreeVar {
+        var: FreeVar(
+            "f3",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    5,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 443..445,
+        in_try: false,
+    },
+    Call {
+        func: FreeVar(
+            "f3",
+        ),
+        args: [],
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    5,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Fn,
+            ),
+            FnDecl(
+                Function,
+            ),
+            Function(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    1,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 443..447,
+        in_try: false,
+        new: false,
     },
     FreeVar {
         var: FreeVar(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph-explained.snapshot
@@ -21,8 +21,7 @@ g = (...) => (undefined | FreeVar(undefined))
 h = (...) => undefined
 
 x#10 = ???*0*
-- *0* x
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 x#17 = *arrow function 567*
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph.snapshot
@@ -179,15 +179,8 @@
     (
         "x#10",
         Unknown {
-            original_value: Some(
-                Variable(
-                    (
-                        "x",
-                        #10,
-                    ),
-                ),
-            ),
-            reason: "pattern without value",
+            original_value: None,
+            reason: "for-in variable currently not analyzed",
             has_side_effects: false,
         },
     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/resolved-effects.snapshot
@@ -24,40 +24,39 @@
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 8 free var = FreeVar(c1)
+0 -> 8 free var = FreeVar(b3)
 
 0 -> 9 call = ???*0*()
+- *0* FreeVar(b3)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 10 free var = FreeVar(c1)
+
+0 -> 11 call = ???*0*()
 - *0* FreeVar(c1)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-0 -> 10 unreachable = ???*0*
+0 -> 12 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 11 unreachable = ???*0*
+0 -> 13 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 12 free var = FreeVar(d1)
+0 -> 14 free var = FreeVar(c3)
 
-0 -> 13 call = ???*0*()
-- *0* FreeVar(d1)
+0 -> 15 call = ???*0*()
+- *0* FreeVar(c3)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-0 -> 14 unreachable = ???*0*
-- *0* unreachable
-  ⚠️  This value might have side effects
-
-0 -> 15 unreachable = ???*0*
-- *0* unreachable
-  ⚠️  This value might have side effects
-
-0 -> 16 free var = FreeVar(e1)
+0 -> 16 free var = FreeVar(d1)
 
 0 -> 17 call = ???*0*()
-- *0* FreeVar(e1)
+- *0* FreeVar(d1)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
@@ -69,53 +68,89 @@
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 20 free var = FreeVar(f1)
+0 -> 20 free var = FreeVar(d3)
 
 0 -> 21 call = ???*0*()
+- *0* FreeVar(d3)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 22 free var = FreeVar(e1)
+
+0 -> 23 call = ???*0*()
+- *0* FreeVar(e1)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 24 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 25 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 26 free var = FreeVar(e3)
+
+0 -> 27 call = ???*0*()
+- *0* FreeVar(e3)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 28 free var = FreeVar(f1)
+
+0 -> 29 call = ???*0*()
 - *0* FreeVar(f1)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-0 -> 22 unreachable = ???*0*
+0 -> 30 unreachable = ???*0*
 - *0* unreachable
-  ⚠️  This value might have side effects
-
-0 -> 23 unreachable = ???*0*
-- *0* unreachable
-  ⚠️  This value might have side effects
-
-0 -> 24 free var = FreeVar(g1)
-
-0 -> 25 call = ???*0*()
-- *0* FreeVar(g1)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-
-0 -> 26 unreachable = ???*0*
-- *0* unreachable
-  ⚠️  This value might have side effects
-
-0 -> 27 free var = FreeVar(g3)
-
-0 -> 28 call = ???*0*()
-- *0* FreeVar(g3)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-
-0 -> 29 free var = FreeVar(h1)
-
-0 -> 30 call = ???*0*()
-- *0* FreeVar(h1)
-  ⚠️  unknown global
   ⚠️  This value might have side effects
 
 0 -> 31 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 32 free var = FreeVar(h3)
+0 -> 32 free var = FreeVar(f3)
 
 0 -> 33 call = ???*0*()
+- *0* FreeVar(f3)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 34 free var = FreeVar(g1)
+
+0 -> 35 call = ???*0*()
+- *0* FreeVar(g1)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 36 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 37 free var = FreeVar(g3)
+
+0 -> 38 call = ???*0*()
+- *0* FreeVar(g3)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 39 free var = FreeVar(h1)
+
+0 -> 40 call = ???*0*()
+- *0* FreeVar(h1)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+0 -> 41 unreachable = ???*0*
+- *0* unreachable
+  ⚠️  This value might have side effects
+
+0 -> 42 free var = FreeVar(h3)
+
+0 -> 43 call = ???*0*()
 - *0* FreeVar(h3)
   ⚠️  unknown global
   ⚠️  This value might have side effects

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/resolved-explained.snapshot
@@ -21,8 +21,7 @@ g = (...) => (undefined | FreeVar(undefined))
 h = (...) => undefined
 
 x#10 = ???*0*
-- *0* x
-  ⚠️  pattern without value
+- *0* for-in variable currently not analyzed
 
 x#17 = (...) => (undefined | FreeVar(undefined))
 

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -127,7 +127,7 @@ impl GetContentSourceContent for NodeApiContentSource {
         Ok(ContentSourceContent::HttpProxy(render_proxy_operation(
             self.cwd.clone(),
             self.env,
-            self.server_root.join(&path.clone())?,
+            self.server_root.join(&path)?,
             ResolvedVc::upcast(entry.module),
             entry.runtime_entries,
             entry.chunking_context,

--- a/turbopack/crates/turbopack-tests/Cargo.toml
+++ b/turbopack/crates/turbopack-tests/Cargo.toml
@@ -31,6 +31,7 @@ turbo-tasks-bytes = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-backend = { workspace = true }
+turbo-unix-path = { workspace = true }
 turbopack-browser = { workspace = true, features = ["test"] }
 turbopack-core = { workspace = true, features = ["issue_path"] }
 turbopack-ecmascript-plugins = { workspace = true, features = [

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -291,8 +291,8 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
         resource_path.display()
     ))?;
     let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
-    let path = root_fs.root().await?.join(&relative_path.clone())?;
-    let project_path = project_root.join(&relative_path.clone())?;
+    let path = root_fs.root().await?.join(&relative_path)?;
+    let project_path = project_root.join(&relative_path)?;
     let tests_path = project_fs
         .root()
         .await?

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -21,8 +21,9 @@ use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::CommandLineProcessEnv;
 use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystem, FileSystemEntryType, FileSystemPath,
-    json::parse_json_with_source_context, util::sys_to_unix,
+    json::parse_json_with_source_context,
 };
+use turbo_unix_path::sys_to_unix;
 use turbopack::{
     ModuleAssetContext,
     css::chunk::CssChunkType,
@@ -290,7 +291,7 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
         &*REPO_ROOT,
         resource_path.display()
     ))?;
-    let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
+    let relative_path = RcStr::from(sys_to_unix(relative_path.to_str().unwrap()));
     let path = root_fs.root().await?.join(&relative_path)?;
     let project_path = project_root.join(&relative_path)?;
     let tests_path = project_fs

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/next-76802/input/assert.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/next-76802/input/assert.js
@@ -1,0 +1,6 @@
+// app/assert.js
+export function assert(a, b) {
+  if (a !== b) {
+    throw new Error(`Assertion failed: ${a} !== ${b}`)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/next-76802/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/next-76802/input/index.js
@@ -1,0 +1,18 @@
+// app/page.js
+import { assert } from './assert'
+
+function test(src) {
+  for (;;) {
+    if (src === '.') {
+      break
+    }
+
+    return -1
+  }
+
+  assert(1, 1)
+}
+
+it('should handle break label in loop', () => {
+  expect(test('.')).toBeUndefined()
+})

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -16,8 +16,8 @@ use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storag
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
     DiskFileSystem, FileSystem, FileSystemPath, json::parse_json_with_source_context,
-    util::sys_to_unix,
 };
+use turbo_unix_path::sys_to_unix;
 use turbopack::{
     ModuleAssetContext,
     ecmascript::{EcmascriptInputTransform, TreeShakingMode, chunk::EcmascriptChunkType},
@@ -264,7 +264,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let project_root = project_fs.root().owned().await?;
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;
-    let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
+    let relative_path = RcStr::from(sys_to_unix(relative_path.to_str().unwrap()));
     let project_path = project_root.join(&relative_path)?;
 
     let project_path_to_project_root = project_path


### PR DESCRIPTION
## Goal

With three different bundlers, we're often forced to duplicate next.js-specific logic and configuration across two or three different bundlers.

E.g. https://github.com/SyMind/next-rspack-binding/ would cause us to duplicate our current externals logic across all three.

To help, we'd like to have a shared crate that can be used in a few different ways:

- Via turbopack (which is itself called through native napi bindings)
- Via direct native napi bindings to JS for webpack
- Via wasm bindings to JS for webpack [*(note: ideally these would be replaced with napi's recent wasm support, but it doesn't make sense to do that until after the napi v3 migration is done)*](https://napi.rs/blog/announce-v3#webassembly)
- Via Rspack (we'd build a custom binary)

The wasm bindings (in their current state) and Rspack cannot (or should not) depend on `turbo-tasks`. However, all of the current `next-*` crates depend on `turbo-tasks`.

This introduces a `next-taskless` crate for code that can be isolated from performing IO and that does not need to depend on `turbo-tasks`. Code in this crate can be used from wasm or Rspack.

## This PR

As a proof-of-concept, this deduplicates our next.js entrypoint templating logic across webpack and Turbopack. It's a large function that doesn't need to directly depend on file IO.

Some path manipulation had to be moved out of `turbo-tasks-fs` to support this, so that code is in `turbo-unix-path`.

I'm happy to accept different bikeshedded crate names.

## Testing

Tested wasm with:

```
pnpm i
pnpm swc-build-wasm --target nodejs
pnpm build
NODE_TEST_MODE=start NEXT_TEST_WASM=true NEXT_SKIP_NATIVE_POSTINSTALL=1 NEXT_TEST_PREFER_OFFLINE=1 node run-tests.js test/production/pages-dir/production/test/index.test.ts
```

Tested turbopack with:

```
pnpm i
pnpm swc-build-native
pnpm build
pnpm test-start-turbo test/production/pages-dir/production/test/index.test.ts
```

Tested webpack with:

```
pnpm i
pnpm swc-build-native
pnpm build
pnpm test-start test/production/pages-dir/production/test/index.test.ts
```

---
🔄 **This is a mirror of [upstream PR #82385](https://github.com/vercel/next.js/pull/82385)**