### PR TITLE
Turbopack: Fix logic in HMR logging code that could emit a NaN build time

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
+++ b/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
@@ -23,9 +23,11 @@ export class TurbopackHmr {
   #startMsSinceEpoch: number | undefined
   #lastUpdateMsSinceEpoch: number | undefined
   #deferredReportHmrStartId: ReturnType<typeof setTimeout> | undefined
+  #reportedHmrStart: boolean
 
   constructor() {
     this.#updatedModules = new Set()
+    this.#reportedHmrStart = false
   }
 
   // HACK: Turbopack tends to generate a lot of irrelevant "BUILDING" actions,
@@ -39,6 +41,7 @@ export class TurbopackHmr {
   #runDeferredReportHmrStart() {
     if (this.#deferredReportHmrStartId != null) {
       console.log('[Fast Refresh] rebuilding')
+      this.#reportedHmrStart = true
       this.#cancelDeferredReportHmrStart()
     }
   }
@@ -102,7 +105,7 @@ export class TurbopackHmr {
     // which can happen during initial page load. Ignore that too!
     const hasUpdates =
       this.#lastUpdateMsSinceEpoch != null && this.#startMsSinceEpoch != null
-    if (!hasUpdates && this.#deferredReportHmrStartId != null) {
+    if (!hasUpdates && !this.#reportedHmrStart) {
       // suppress the update entirely
       this.#cancelDeferredReportHmrStart()
       return null
@@ -116,6 +119,7 @@ export class TurbopackHmr {
       endMsSinceEpoch: this.#lastUpdateMsSinceEpoch ?? Date.now(),
     }
     this.#updatedModules = new Set()
+    this.#reportedHmrStart = false
     return result
   }
 }


### PR DESCRIPTION
The goal of this module is to avoid logging no-op build events. Turbopack uses a bottom-up execution model which leads to a lot of really short no-op "building" events that we try to filter out.

If `onBuilding` isn't called before `onBuilt`, then `deferredReportHmrStartId` will be `undefined` here, causing us to report the end of a build. Since `onBuilding` wasn't called yet, the start time will be `undefined`, giving us a duration of `NaN`.

We were using `deferredReportHmrStartId` to try to determine when we'd already reported the start of a build, but it wasn't quite right. Instead, use a separate, more explicit, variable for that.

---

https://vercel.slack.com/archives/C046HAU4H7F/p1749456305992089?thread_ts=1749455727.004169&cid=C046HAU4H7F

> we fire the BUILDING event from the server, before a client is present, then the client attaches, and eventually  BUILT is sent and we trigger the NaN ms log

Thanks for the root-causing help, @icyJoseph

---

Tested by loading `pnpm next dev --turbopack examples/basic-css/` and modifying the source code to trigger HMRs.

![Screenshot 2025-08-05 at 6.09.47 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/6ee43248-af68-4478-ac9f-93ea6a3d3a51.png)

---
🔄 **This is a mirror of [upstream PR #82389](https://github.com/vercel/next.js/pull/82389)**