### PR TITLE
Fix a small issue in the analyzer where we wouldn't skip assignments to free vars that were just identifiers

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -2046,7 +2046,7 @@ impl JsValue {
     /// variable/was not reassigned.
     pub fn match_free_var_reference<'a, T>(
         &self,
-        var_graph: Option<&VarGraph>,
+        var_graph: &VarGraph,
         free_var_references: &'a FxIndexMap<
             DefinableNameSegment,
             FxIndexMap<Vec<DefinableNameSegment>, T>,
@@ -2063,9 +2063,7 @@ impl JsValue {
 
                 let name_rev_it = name.iter().map(Cow::Borrowed).rev();
                 if name_rev_it.eq(self.iter_definable_name_rev()) {
-                    if let Some(var_graph) = var_graph
-                        && let DefinableNameSegment::Name(first_str) = name.first().unwrap()
-                    {
+                    if let DefinableNameSegment::Name(first_str) = name.first().unwrap() {
                         let first_str: &str = first_str;
                         if var_graph
                             .free_var_ids

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -2042,7 +2042,7 @@ impl JsValue {
     /// Returns any matching defined replacement that matches this value (the replacement that
     /// matches `$self.$prop`).
     ///
-    /// Optionally when passed a VarGraph, verifies that the first segment is not a local
+    /// Uses the `VarGraph` to verify that the first segment is not a local
     /// variable/was not reassigned.
     pub fn match_free_var_reference<'a, T>(
         &self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -52,7 +52,9 @@ use swc_core::{
         utils::IsDirective,
         visit::{
             AstParentKind, AstParentNodeRef, VisitAstPath, VisitWithAstPath,
-            fields::{AssignExprField, AssignTargetField, SimpleAssignTargetField},
+            fields::{
+                AssignExprField, AssignTargetField, BindingIdentField, SimpleAssignTargetField,
+            },
         },
     },
 };
@@ -2499,7 +2501,7 @@ async fn handle_typeof(
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
     if let Some(value) = arg.match_free_var_reference(
-        Some(state.var_graph),
+        state.var_graph,
         &*state.free_var_references,
         &DefinableNameSegment::TypeOf,
     ) {
@@ -2547,11 +2549,20 @@ async fn handle_free_var_reference(
     // We don't want to replace assignments as this would lead to invalid code.
     if matches!(
         ast_path,
+        // Matches assignments to members
         [
             ..,
             AstParentKind::AssignExpr(AssignExprField::Left),
             AstParentKind::AssignTarget(AssignTargetField::Simple),
             AstParentKind::SimpleAssignTarget(SimpleAssignTargetField::Member),
+        ] |
+        // Matches assignments to identifiers
+        [
+            ..,
+            AstParentKind::AssignExpr(AssignExprField::Left),
+            AstParentKind::AssignTarget(AssignTargetField::Simple),
+            AstParentKind::SimpleAssignTarget(SimpleAssignTargetField::Ident),
+            AstParentKind::BindingIdent(BindingIdentField::Id),
         ]
     ) {
         return Ok(false);
@@ -2901,7 +2912,7 @@ async fn value_visitor_inner(
         let compile_time_info = compile_time_info.await?;
         if let JsValue::TypeOf(_, arg) = &v
             && let Some(value) = arg.match_free_var_reference(
-                Some(var_graph),
+                var_graph,
                 free_var_references,
                 &DefinableNameSegment::TypeOf,
             )


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82392](https://github.com/vercel/next.js/pull/82392)**