### PR TITLE
update rspack-dev-tests-manifest for failing tests

### DIFF
--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -4289,14 +4289,14 @@
   },
   "test/development/tsconfig-path-reloading/index.test.ts": {
     "passed": [
-      "tsconfig-path-reloading tsconfig added after starting dev should automatically fast refresh content when path is added without error",
-      "tsconfig-path-reloading tsconfig added after starting dev should load with initial paths config correctly",
-      "tsconfig-path-reloading tsconfig should automatically fast refresh content when path is added without error",
-      "tsconfig-path-reloading tsconfig should load with initial paths config correctly"
+      "tsconfig-path-reloading tsconfig should load with initial paths config correctly",
+      "tsconfig-path-reloading tsconfig should automatically fast refresh content when path is added without error"
     ],
     "failed": [
       "tsconfig-path-reloading tsconfig added after starting dev should recover from module not found when paths is updated",
-      "tsconfig-path-reloading tsconfig should recover from module not found when paths is updated"
+      "tsconfig-path-reloading tsconfig should recover from module not found when paths is updated",
+      "tsconfig-path-reloading tsconfig added after starting dev should load with initial paths config correctly",
+      "tsconfig-path-reloading tsconfig added after starting dev should automatically fast refresh content when path is added without error"
     ],
     "pending": [],
     "flakey": [],


### PR DESCRIPTION
Rspack `testing for test/development/tsconfig-path-reloading` is failing often these days.
Noticed `test/development/jsconfig-path-reloading` is already in the manifest of the "failed" section.

- [Failed CI](https://github.com/vercel/next.js/actions/runs/16671025870/job/47187245042?pr=81396#step:34:504)
- [DataDog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%28%22tsconfig-path-reloading%20tsconfig%20added%20after%20starting%20dev%20should%20automatically%20fast%20refresh%20content%20when%20path%20is%20added%20without%20error%22%20OR%20%22tsconfig-path-reloading%20tsconfig%20should%20automatically%20fast%20refresh%20content%20when%20path%20is%20added%20without%20error%22%29&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1753875198762&end=1754479998762&paused=false)

---
🔄 **This is a mirror of [upstream PR #82414](https://github.com/vercel/next.js/pull/82414)**