### PR TITLE
fix: prevent navigation to .txt URLs when RSC payload fetch fails in static export

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -268,7 +268,14 @@ export async function fetchServerResponse(
     // If fetch fails handle it like a mpa navigation
     // TODO-APP: Add a test for the case where a CORS request fails, e.g. external url redirect coming from the response.
     // See https://github.com/vercel/next.js/issues/43605#issuecomment-1451617521 for a reproduction.
-    return doMpaNavigation(url.toString());
+    return {
+      flightData: url.toString(),
+      canonicalUrl: undefined,
+      couldBeIntercepted: false,
+      prerendered: false,
+      postponed: false,
+      staleTime: -1,
+    }
   }
 }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -268,7 +268,7 @@ export async function fetchServerResponse(
     // If fetch fails handle it like a mpa navigation
     // TODO-APP: Add a test for the case where a CORS request fails, e.g. external url redirect coming from the response.
     // See https://github.com/vercel/next.js/issues/43605#issuecomment-1451617521 for a reproduction.
-    return doMpaNavigation(url.toString());
+    return doMpaNavigation(url.toString())
   }
 }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -268,14 +268,7 @@ export async function fetchServerResponse(
     // If fetch fails handle it like a mpa navigation
     // TODO-APP: Add a test for the case where a CORS request fails, e.g. external url redirect coming from the response.
     // See https://github.com/vercel/next.js/issues/43605#issuecomment-1451617521 for a reproduction.
-    return {
-      flightData: url.toString(),
-      canonicalUrl: undefined,
-      couldBeIntercepted: false,
-      prerendered: false,
-      postponed: false,
-      staleTime: -1,
-    }
+    return doMpaNavigation(url.toString());
   }
 }
 

--- a/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
+++ b/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
@@ -160,4 +160,44 @@ describe('segment cache (output: "export")', () => {
       }
     )
   })
+
+  it('fallback to HTML navigation when RSC payload fetch fails in output: "export" mode', async () => {
+    // This test verifies that when RSC payload fetching fails (e.g., .txt files are blocked),
+    // the navigation falls back to regular HTML navigation without .txt extension
+    const browser = await webdriver(port, '/')
+
+    // Use browser dev tools to block .txt requests
+    await browser.eval(`
+      // Override fetch to simulate .txt request failures
+      const originalFetch = window.fetch;
+      window.fetch = function(...args) {
+        const url = args[0];
+        if (url && url.toString().includes('.txt')) {
+          // Simulate network failure for .txt files
+          return Promise.reject(new Error('Simulated .txt fetch failure'));
+        }
+        return originalFetch.apply(this, args);
+      };
+    `)
+
+    // Navigate directly to target page to trigger RSC payload fetch
+    await browser.eval(`
+      window.next.router.push('/target-page');
+    `)
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'document.location.pathname.includes("target-page") && document.body.textContent.includes("Target page")',
+      5000
+    )
+
+    // Verify that we navigated to the correct HTML page, not .txt
+    const currentUrl = await browser.url()
+    expect(currentUrl).not.toContain('.txt')
+    expect(currentUrl).toContain('/target-page')
+
+    // Verify page content is displayed
+    const bodyText = await browser.eval('document.body.textContent')
+    expect(bodyText).toContain('Target page')
+  })
 })

--- a/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
+++ b/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
@@ -165,7 +165,6 @@ describe('segment cache (output: "export")', () => {
     // This test verifies that when RSC payload fetching fails (e.g., .txt files are blocked),
     // the navigation falls back to regular HTML navigation without .txt extension
     const browser = await webdriver(port, '/')
-
     // Use browser dev tools to block .txt requests
     await browser.eval(`
       // Override fetch to simulate .txt request failures
@@ -179,22 +178,24 @@ describe('segment cache (output: "export")', () => {
         return originalFetch.apply(this, args);
       };
     `)
-
-    // Navigate directly to target page to trigger RSC payload fetch
-    await browser.eval(`
-      window.next.router.push('/target-page');
-    `)
+    // Initiate a prefetch
+    const checkbox = await browser.elementByCss(
+      '[data-link-accordion="/target-page"]'
+    )
+    await checkbox.click()
+    // Navigate to the prefetched target page.
+    const link = await browser.elementByCss('a[href="/target-page"]')
+    await link.click()
 
     // Wait for navigation to complete
     await browser.waitForCondition(
       'document.location.pathname.includes("target-page") && document.body.textContent.includes("Target page")',
       5000
     )
-
     // Verify that we navigated to the correct HTML page, not .txt
     const currentUrl = await browser.url()
     expect(currentUrl).not.toContain('.txt')
-    expect(currentUrl).toContain('/target-page')
+    expect(new URL(currentUrl).pathname).toBe('/target-page')
 
     // Verify page content is displayed
     const bodyText = await browser.eval('document.body.textContent')


### PR DESCRIPTION
### Fixing a bug

- fixes #82417

### What?

Fixes navigation fallback to `.txt` URLs when RSC payload fetching fails in `output: "export"` mode.

### Why?

When using `output: 'export'` mode, a regression was introduced in #75671 where the URL mutation for RSC payload requests (adding `.txt` extension) was moved to affect the original `url` parameter. This caused the MPA navigation fallback (introduced in #46674) to navigate to incorrect URLs with `.txt` extensions when RSC payload fetching
fails.

This issue affects production deployments where:

- Static export is used (`output: 'export'`)
- RSC payload fetching fails (network issues, blocked requests, version skew issues etc.)
- Users would be incorrectly navigated to `/path/to/page.txt` instead of `/path/to/page`

### How?

The fix uses the existing `doMpaNavigation` helper function which properly strips the `.txt` extension before performing the navigation fallback. This ensures users are
redirected to the correct HTML page URL instead of the RSC payload URL.

**Changes:**
1. Modified `fetchServerResponse` catch block to use `doMpaNavigation(url.toString())` instead of returning the raw URL
2. Added e2e test to verify fallback behavior when RSC payload fetch fails

**Timeline of the issue:**
1. #46674 added MPA navigation fallback for failed RSC payload fetches
2. #75671 unintentionally moved the `.txt` extension logic, causing the URL mutation to affect the fallback URL
3. This PR fixes the regression by ensuring the `.txt` extension is stripped during fallback

**Reproduction:** https://github.com/azu/next-prefetch-txt-bug

Fixes #82417 #77359
Related to #43605, #46674, #75671

---
🔄 **This is a mirror of [upstream PR #82418](https://github.com/vercel/next.js/pull/82418)**