### PR TITLE
Update Rspack production test manifest

### DIFF
--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -5828,6 +5828,7 @@
   },
   "test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts": {
     "passed": [
+      "segment cache (basic tests) does not cause infinite loop with cacheLife(\"seconds\")",
       "segment cache (basic tests) does not throw an error when navigating to a page with a server action",
       "segment cache (basic tests) navigate before any data has loaded into the prefetch cache",
       "segment cache (basic tests) navigate to page with lazily-generated (not at build time) static param",
@@ -5984,6 +5985,8 @@
   },
   "test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts": {
     "passed": [
+      "<Link prefetch={true}> (runtime prefetch) cache stale time handling includes private caches with cacheLife(\"seconds\")",
+      "<Link prefetch={true}> (runtime prefetch) cache stale time handling includes public caches with cacheLife(\"seconds\")",
       "<Link prefetch={true}> (runtime prefetch) cache stale time handling includes short-lived public caches with a long enough staleTime",
       "<Link prefetch={true}> (runtime prefetch) cache stale time handling omits private caches with a short enough staleTime",
       "<Link prefetch={true}> (runtime prefetch) cache stale time handling omits short-lived public caches with a short enough staleTime",


### PR DESCRIPTION
This auto-generated PR updates the production integration test manifest used when testing Rspack.

---
🔄 **This is a mirror of [upstream PR #82432](https://github.com/vercel/next.js/pull/82432)**