### PR TITLE
Add env var to delay shutdown signal handling

### DIFF
--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -267,3 +267,19 @@ if (process.env.NEXT_MANUAL_SIG_HANDLE) {
 ```
 
 </PagesOnly>
+
+## Delay Graceful Shutdowns
+
+Next.js will listen for `SIGINT` and `SIGTERM` and perform a graceful shutdown. If you need to delay handling those signals - e.g. to let your Kubernetes readiness probe report “not ready” before the process exits - you can set `NEXT_DELAY_SIG_HANDLE` to a number of milliseconds.
+
+> **Good to know**: Delaying signal handling is not available in `next dev`.
+
+```json filename="package.json"
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "NEXT_DELAY_SIG_HANDLE=10000 next start"
+  }
+}
+```

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -37,6 +37,7 @@ import { isIPv6 } from './is-ipv6'
 import { AsyncCallbackSet } from './async-callback-set'
 import type { NextServer } from '../next'
 import type { ConfiguredExperimentalFeature } from '../config'
+import { wait } from '../../lib/wait'
 
 const debug = setupDebug('next:start-server')
 let startServerSpan: Span | undefined
@@ -396,6 +397,9 @@ export async function startServer(
           cleanupStarted = true
           ;(async () => {
             debug('start-server process cleanup')
+
+            const delay = Number(process.env.NEXT_DELAY_SIG_HANDLE) || 0
+            if (delay) await wait(delay)
 
             // first, stop accepting new connections and finish pending requests,
             // because they might affect `nextServer.close()` (e.g. by scheduling an `after`)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82449](https://github.com/vercel/next.js/pull/82449)**