### PR TITLE
Turbopack: side effects optimization cleanups

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::BTreeMap, ops::ControlFlow};
 
 use anyhow::{Result, bail};
+use indexmap::map::Entry;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use smallvec::{SmallVec, smallvec};
@@ -189,30 +190,44 @@ pub async fn follow_reexports(
         // Try to find the export in the star exports
         if !exports_ref.star_exports.is_empty() && &*export_name != "default" {
             let result = find_export_from_reexports(*module, export_name.clone()).await?;
-            if let Some(m) = result.esm_export {
-                module = m;
-                continue;
+            match &*result {
+                FindExportFromReexportsResult::NotFound => {
+                    return Ok(FollowExportsResult::cell(FollowExportsResult {
+                        module,
+                        export_name: Some(export_name),
+                        ty: FoundExportType::NotFound,
+                    }));
+                }
+                FindExportFromReexportsResult::EsmExport(esm_export) => {
+                    match handle_declared_export(module, export_name, esm_export).await? {
+                        ControlFlow::Continue((m, n)) => {
+                            module = m.to_resolved().await?;
+                            export_name = n;
+                            continue;
+                        }
+                        ControlFlow::Break(result) => {
+                            return Ok(result.cell());
+                        }
+                    }
+                }
+                FindExportFromReexportsResult::Dynamic(dynamic_exporting_modules) => {
+                    return match &dynamic_exporting_modules[..] {
+                        [] => unreachable!(),
+                        [module] => Ok(FollowExportsResult {
+                            module: *module,
+                            export_name: Some(export_name),
+                            ty: FoundExportType::Dynamic,
+                        }
+                        .cell()),
+                        _ => Ok(FollowExportsResult {
+                            module,
+                            export_name: Some(export_name),
+                            ty: FoundExportType::Dynamic,
+                        }
+                        .cell()),
+                    };
+                }
             }
-            return match &result.dynamic_exporting_modules[..] {
-                [] => Ok(FollowExportsResult {
-                    module,
-                    export_name: Some(export_name),
-                    ty: FoundExportType::NotFound,
-                }
-                .cell()),
-                [module] => Ok(FollowExportsResult {
-                    module: *module,
-                    export_name: Some(export_name),
-                    ty: FoundExportType::Dynamic,
-                }
-                .cell()),
-                _ => Ok(FollowExportsResult {
-                    module,
-                    export_name: Some(export_name),
-                    ty: FoundExportType::Dynamic,
-                }
-                .cell()),
-            };
         }
 
         return Ok(FollowExportsResult::cell(FollowExportsResult {
@@ -270,9 +285,10 @@ async fn handle_declared_export(
 }
 
 #[turbo_tasks::value]
-struct FindExportFromReexportsResult {
-    esm_export: Option<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
-    dynamic_exporting_modules: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
+enum FindExportFromReexportsResult {
+    NotFound,
+    EsmExport(EsmExport),
+    Dynamic(Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>),
 }
 
 #[turbo_tasks::function]
@@ -301,17 +317,25 @@ async fn find_export_from_reexports(
     }
 
     let all_export_names = get_all_export_names(*module).await?;
-    let esm_export = all_export_names.esm_exports.get(&export_name).copied();
-    Ok(FindExportFromReexportsResult {
-        esm_export,
-        dynamic_exporting_modules: all_export_names.dynamic_exporting_modules.clone(),
-    }
-    .cell())
+    Ok(
+        if let Some(esm_export) = all_export_names.esm_exports.get(&export_name) {
+            FindExportFromReexportsResult::EsmExport(esm_export.clone())
+        } else if all_export_names.dynamic_exporting_modules.is_empty() {
+            FindExportFromReexportsResult::NotFound
+        } else {
+            FindExportFromReexportsResult::Dynamic(
+                all_export_names.dynamic_exporting_modules.clone(),
+            )
+        }
+        .cell(),
+    )
 }
 
 #[turbo_tasks::value]
 struct AllExportNamesResult {
-    esm_exports: FxIndexMap<RcStr, ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
+    /// A map from export name to the immediate referenced module.
+    esm_exports: FxIndexMap<RcStr, EsmExport>,
+    /// A list of all direct or indirectly referenced modules that are dynamically exporting
     dynamic_exporting_modules: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 
@@ -331,7 +355,12 @@ async fn get_all_export_names(
     let exports = exports.await?;
     let mut esm_exports = FxIndexMap::default();
     let mut dynamic_exporting_modules = Vec::new();
-    esm_exports.extend(exports.exports.keys().cloned().map(|n| (n, module)));
+    esm_exports.extend(
+        exports
+            .exports
+            .iter()
+            .map(|(name, esm_export)| (name.clone(), esm_export.clone())),
+    );
     let star_export_names = exports
         .star_exports
         .iter()
@@ -340,7 +369,7 @@ async fn get_all_export_names(
                 if let ReferencedAsset::Some(m) =
                     *ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                 {
-                    Some(expand_star_exports(*m))
+                    Some(expand_star_exports(**esm_ref, *m))
                 } else {
                     None
                 },
@@ -354,7 +383,7 @@ async fn get_all_export_names(
             star_export_names
                 .esm_exports
                 .iter()
-                .map(|(k, &v)| (k.clone(), v)),
+                .map(|(k, v)| (k.clone(), v.clone())),
         );
         dynamic_exporting_modules
             .extend(star_export_names.dynamic_exporting_modules.iter().copied());
@@ -369,35 +398,45 @@ async fn get_all_export_names(
 
 #[turbo_tasks::value]
 pub struct ExpandStarResult {
-    pub esm_exports: FxIndexMap<RcStr, ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
+    pub esm_exports: FxIndexMap<RcStr, EsmExport>,
     pub dynamic_exporting_modules: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 
 #[turbo_tasks::function]
 pub async fn expand_star_exports(
+    root_reference: ResolvedVc<Box<dyn ModuleReference>>,
     root_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 ) -> Result<Vc<ExpandStarResult>> {
     let mut esm_exports = FxIndexMap::default();
     let mut dynamic_exporting_modules = Vec::new();
     let mut checked_modules = FxHashSet::default();
     checked_modules.insert(root_module);
-    let mut queue = vec![(root_module, root_module.get_exports())];
-    while let Some((asset, exports)) = queue.pop() {
+    let mut queue = vec![(root_reference, root_module, root_module.get_exports())];
+    while let Some((reference, asset, exports)) = queue.pop() {
         match &*exports.await? {
             EcmascriptExports::EsmExports(exports) => {
                 let exports = exports.await?;
-                for key in exports.exports.keys() {
+                for (key, esm_export) in exports.exports.iter() {
                     if key == "default" {
                         continue;
                     }
-                    esm_exports.entry(key.clone()).or_insert_with(|| asset);
+                    if let Entry::Vacant(entry) = esm_exports.entry(key.clone()) {
+                        entry.insert(match esm_export {
+                            &EsmExport::LocalBinding(_, mutable) => EsmExport::ImportedBinding(
+                                ResolvedVc::upcast(reference),
+                                key.clone(),
+                                mutable,
+                            ),
+                            _ => esm_export.clone(),
+                        });
+                    }
                 }
                 for esm_ref in exports.star_exports.iter() {
                     if let ReferencedAsset::Some(asset) =
                         &*ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                         && checked_modules.insert(*asset)
                     {
-                        queue.push((*asset, asset.get_exports()));
+                        queue.push((*esm_ref, *asset, asset.get_exports()));
                     }
                 }
             }
@@ -518,7 +557,7 @@ impl EsmExports {
                 continue;
             };
 
-            let export_info = expand_star_exports(**asset).await?;
+            let export_info = expand_star_exports(*esm_ref, **asset).await?;
 
             for export in export_info.esm_exports.keys() {
                 if export == "default" {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -434,7 +434,6 @@ struct AnalysisState<'a> {
     // There can be many references to import.meta, but only the first should hoist
     // the object allocation.
     first_import_meta: bool,
-    tree_shaking_mode: Option<TreeShakingMode>,
     import_externals: bool,
     ignore_dynamic_requests: bool,
     url_rewrite_behavior: Option<UrlRewriteBehavior>,
@@ -989,7 +988,6 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             fun_args_values: Default::default(),
             var_cache: Default::default(),
             first_import_meta: true,
-            tree_shaking_mode: options.tree_shaking_mode,
             import_externals: options.import_externals,
             ignore_dynamic_requests: options.ignore_dynamic_requests,
             url_rewrite_behavior: options.url_rewrite_behavior,
@@ -2601,12 +2599,7 @@ async fn handle_free_var_reference(
                             span.hi.to_u32(),
                         ),
                         Default::default(),
-                        match state.tree_shaking_mode {
-                            Some(
-                                TreeShakingMode::ModuleFragments | TreeShakingMode::ReexportsOnly,
-                            ) => export.clone().map(ModulePart::export),
-                            None => None,
-                        },
+                        export.clone().map(ModulePart::export),
                         state.import_externals,
                     )
                     .resolved_cell())

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -174,22 +174,18 @@ async fn apply_module_type(
                         ))
                     }
                     Some(TreeShakingMode::ReexportsOnly) => {
-                        if let Some(part) = part {
-                            match part {
-                                ModulePart::Evaluation => {
-                                    if *module.get_exports().split_locals_and_reexports().await? {
+                        if *module.get_exports().split_locals_and_reexports().await? {
+                            if let Some(part) = part {
+                                match part {
+                                    ModulePart::Evaluation => {
                                         Vc::upcast(EcmascriptModuleLocalsModule::new(*module))
-                                    } else {
-                                        Vc::upcast(*module)
                                     }
-                                }
-                                ModulePart::Export(_) => {
-                                    let side_effect_free_packages = module_asset_context
-                                        .side_effect_free_packages()
-                                        .resolve()
-                                        .await?;
+                                    ModulePart::Export(_) => {
+                                        let side_effect_free_packages = module_asset_context
+                                            .side_effect_free_packages()
+                                            .resolve()
+                                            .await?;
 
-                                    if *module.get_exports().split_locals_and_reexports().await? {
                                         apply_reexport_tree_shaking(
                                             Vc::upcast(
                                                 EcmascriptModuleFacadeModule::new(
@@ -202,25 +198,19 @@ async fn apply_module_type(
                                             part,
                                             side_effect_free_packages,
                                         )
-                                    } else {
-                                        apply_reexport_tree_shaking(
-                                            Vc::upcast(*module),
-                                            part,
-                                            side_effect_free_packages,
-                                        )
                                     }
+                                    _ => bail!(
+                                        "Invalid module part \"{}\" for reexports only tree \
+                                         shaking mode",
+                                        part
+                                    ),
                                 }
-                                _ => bail!(
-                                    "Invalid module part \"{}\" for reexports only tree shaking \
-                                     mode",
-                                    part
-                                ),
+                            } else {
+                                Vc::upcast(EcmascriptModuleFacadeModule::new(
+                                    Vc::upcast(*module),
+                                    ModulePart::facade(),
+                                ))
                             }
-                        } else if *module.get_exports().split_locals_and_reexports().await? {
-                            Vc::upcast(EcmascriptModuleFacadeModule::new(
-                                Vc::upcast(*module),
-                                ModulePart::facade(),
-                            ))
                         } else {
                             Vc::upcast(*module)
                         }


### PR DESCRIPTION
pass ModulePart correctly for FreeVarReference::EcmaScriptModule

code simplification

use EsmExport in FindExportFromReexportsResult

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---
🔄 **This is a mirror of [upstream PR #82467](https://github.com/vercel/next.js/pull/82467)**