### PR TITLE
[Runtime prefetch] resolve runtime APIs in a separate task

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -775,5 +775,6 @@
   "774": "Route %s used %s outside of a Server Component. This is not allowed.",
   "775": "Node.js instrumentation extensions should not be loaded in the Edge runtime.",
   "776": "`unstable_isUnrecognizedActionError` can only be used on the client.",
-  "777": "Invariant: failed to find source route %s for prerender %s"
+  "777": "Invariant: failed to find source route %s for prerender %s",
+  "778": "`prerenderAndAbortInSequentialTasksWithStages` should not be called in edge runtime."
 }

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -77,6 +77,7 @@ import {
   doesExportedHtmlMatchBuildId,
 } from '../../../shared/lib/segment-cache/output-export-prefetch-encoding'
 import { FetchStrategy } from '../segment-cache'
+import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 
 // A note on async/await when working in the prefetch cache:
 //
@@ -2058,17 +2059,6 @@ function addSegmentPathToUrlInOutputExportMode(
     return staticUrl
   }
   return url
-}
-
-function createPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
-  // Shim of Stage 4 Promise.withResolvers proposal
-  let resolve: (value: T | PromiseLike<T>) => void
-  let reject: (reason: any) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  return { resolve: resolve!, reject: reject!, promise }
 }
 
 /**

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -155,7 +155,10 @@ import { createMutableActionQueue } from '../../client/components/app-router-ins
 import { getRevalidateReason } from '../instrumentation/utils'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { FallbackRouteParams } from '../request/fallback-params'
-import { processPrelude } from './app-render-prerender-utils'
+import {
+  prerenderAndAbortInSequentialTasksWithStages,
+  processPrelude,
+} from './app-render-prerender-utils'
 import {
   type ReactServerPrerenderResult,
   ReactServerResult,
@@ -200,6 +203,7 @@ import { getRequestMeta } from '../request-meta'
 import { getDynamicParam } from '../../shared/lib/router/utils/get-dynamic-param'
 import type { ExperimentalConfig } from '../config-shared'
 import type { Params } from '../request/params'
+import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -713,6 +717,8 @@ async function prospectiveRuntimeServerPrerender(
     prerenderResumeDataCache,
     hmrRefreshHash: undefined,
     captureOwnerStack: undefined,
+    // We only need task sequencing in the final prerender.
+    runtimeStagePromise: null,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
     cookies,
     draftMode,
@@ -823,6 +829,9 @@ async function finalRuntimeServerPrerender(
     isDebugDynamicAccesses
   )
 
+  const { promise: runtimeStagePromise, resolve: resolveBlockedRuntimeAPIs } =
+    createPromiseWithResolvers<void>()
+
   const finalServerPrerenderStore: PrerenderStoreModernRuntime = {
     type: 'prerender-runtime',
     phase: 'render',
@@ -843,6 +852,8 @@ async function finalRuntimeServerPrerender(
     renderResumeDataCache,
     hmrRefreshHash: undefined,
     captureOwnerStack: undefined,
+    // Used to separate the "Static" stage from the "Runtime" stage.
+    runtimeStagePromise,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
     cookies,
     draftMode,
@@ -854,8 +865,9 @@ async function finalRuntimeServerPrerender(
   )
 
   let prerenderIsPending = true
-  const result = await prerenderAndAbortInSequentialTasks(
+  const result = await prerenderAndAbortInSequentialTasksWithStages(
     async () => {
+      // Static stage
       const prerenderResult = await workUnitAsyncStorage.run(
         finalServerPrerenderStore,
         ComponentMod.prerender,
@@ -871,6 +883,17 @@ async function finalRuntimeServerPrerender(
       return prerenderResult
     },
     () => {
+      // Advance to the runtime stage.
+      //
+      // We make runtime APIs hang during the first task (above), and unblock them in the following task (here).
+      // This makes sure that, at this point, we'll have finished all the static parts (what we'd prerender statically).
+      // We know that they don't contain any incorrect sync IO, because that'd have caused a build error.
+      // After we unblock Runtime APIs, if we encounter sync IO (e.g. `await cookies(); Date.now()`),
+      // we'll abort, but we'll produce at least as much output as a static prerender would.
+      resolveBlockedRuntimeAPIs()
+    },
+    () => {
+      // Abort.
       if (finalServerController.signal.aborted) {
         // If the server controller is already aborted we must have called something
         // that required aborting the prerender synchronously such as with new Date()

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -26,6 +26,7 @@ import type {
   RequestStore,
   PrerenderStoreLegacy,
   PrerenderStoreModern,
+  PrerenderStoreModernRuntime,
 } from '../app-render/work-unit-async-storage.external'
 
 // Once postpone is in stable we should switch to importing the postpone export directly
@@ -33,7 +34,10 @@ import React from 'react'
 
 import { DynamicServerError } from '../../client/components/hooks-server-context'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import {
+  getRuntimeStagePromise,
+  workUnitAsyncStorage,
+} from './work-unit-async-storage.external'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import {
@@ -547,12 +551,25 @@ export function createHangingInputAbortSignal(
         })
       } else {
         // Otherwise we're in the final render and we should already have all
-        // our caches filled. We might still be waiting on some microtasks so we
+        // our caches filled.
+        // If the prerender uses stages, we have wait until the runtime stage,
+        // at which point all runtime inputs will be resolved.
+        // (otherwise, a runtime prerender might consider `cookies()` hanging
+        //  even though they'd resolve in the next task.)
+        //
+        // We might still be waiting on some microtasks so we
         // wait one tick before giving up. When we give up, we still want to
         // render the content of this cache as deeply as we can so that we can
         // suspend as deeply as possible in the tree or not at all if we don't
         // end up waiting for the input.
-        scheduleOnNextTick(() => controller.abort())
+        const runtimeStagePromise = getRuntimeStagePromise(workUnitStore)
+        if (runtimeStagePromise) {
+          runtimeStagePromise.then(() =>
+            scheduleOnNextTick(() => controller.abort())
+          )
+        } else {
+          scheduleOnNextTick(() => controller.abort())
+        }
       }
 
       return controller.signal
@@ -798,4 +815,15 @@ export function throwIfDisallowedDynamic(
       throw new StaticGenBailoutError()
     }
   }
+}
+
+export function delayUntilRuntimeStage<T>(
+  prerenderStore: PrerenderStoreModernRuntime,
+  result: Promise<T>
+): Promise<T> {
+  if (prerenderStore.runtimeStagePromise) {
+    // TODO(runtime-ppr): does this break exotic promises?
+    return prerenderStore.runtimeStagePromise.then(() => result)
+  }
+  return result
 }

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -15,6 +15,7 @@ import {
   type PrerenderStoreModern,
 } from '../app-render/work-unit-async-storage.external'
 import {
+  delayUntilRuntimeStage,
   postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
@@ -118,6 +119,10 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
             workUnitStore
           )
         case 'prerender-runtime':
+          return delayUntilRuntimeStage(
+            workUnitStore,
+            makeUntrackedExoticCookies(workUnitStore.cookies)
+          )
         case 'private-cache':
           return makeUntrackedExoticCookies(workUnitStore.cookies)
         case 'request':

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -12,6 +12,7 @@ import {
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
+  delayUntilRuntimeStage,
   postponeWithTracking,
   trackDynamicDataInDynamicRender,
   trackSynchronousRequestDataAccessInDev,
@@ -56,6 +57,11 @@ export function draftMode(): Promise<DraftMode> {
 
   switch (workUnitStore.type) {
     case 'prerender-runtime':
+      // TODO(runtime-ppr): does it make sense to delay this? normally it's always microtasky
+      return delayUntilRuntimeStage(
+        workUnitStore,
+        createOrGetCachedDraftMode(workUnitStore.draftMode, workStore)
+      )
     case 'request':
       return createOrGetCachedDraftMode(workUnitStore.draftMode, workStore)
 

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -9,6 +9,7 @@ import {
   throwToInterruptStaticGeneration,
   postponeWithTracking,
   trackSynchronousRequestDataAccessInDev,
+  delayUntilRuntimeStage,
 } from '../app-render/dynamic-rendering'
 
 import {
@@ -114,6 +115,10 @@ export function createServerParamsForRoute(
           'createServerParamsForRoute should not be called in cache contexts.'
         )
       case 'prerender-runtime':
+        return delayUntilRuntimeStage(
+          workUnitStore,
+          createRenderParams(underlyingParams, workStore)
+        )
       case 'request':
         break
       default:
@@ -142,6 +147,10 @@ export function createServerParamsForServerSegment(
           'createServerParamsForServerSegment should not be called in cache contexts.'
         )
       case 'prerender-runtime':
+        return delayUntilRuntimeStage(
+          workUnitStore,
+          createRenderParams(underlyingParams, workStore)
+        )
       case 'request':
         break
       default:

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -1,6 +1,7 @@
 import type { WorkStore } from '../app-render/work-async-storage.external'
 
 import {
+  delayUntilRuntimeStage,
   postponeWithTracking,
   type DynamicTrackingState,
 } from '../app-render/dynamic-rendering'
@@ -37,6 +38,10 @@ export function createServerPathnameForMetadata(
         )
 
       case 'prerender-runtime':
+        return delayUntilRuntimeStage(
+          workUnitStore,
+          createRenderPathname(underlyingPathname)
+        )
       case 'request':
         break
       default:

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -7,6 +7,7 @@ import {
   trackDynamicDataInDynamicRender,
   annotateDynamicAccess,
   trackSynchronousRequestDataAccessInDev,
+  delayUntilRuntimeStage,
 } from '../app-render/dynamic-rendering'
 
 import {
@@ -114,6 +115,10 @@ export function createServerSearchParamsForServerPage(
           'createServerSearchParamsForServerPage should not be called in cache contexts.'
         )
       case 'prerender-runtime':
+        return delayUntilRuntimeStage(
+          workUnitStore,
+          createRenderSearchParams(underlyingSearchParams, workStore)
+        )
       case 'request':
         break
       default:

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -34,6 +34,7 @@ import {
   getCacheSignal,
   isHmrRefresh,
   getServerComponentsHmrCache,
+  getRuntimeStagePromise,
 } from '../app-render/work-unit-async-storage.external'
 
 import { makeHangingPromise } from '../dynamic-rendering-utils'
@@ -199,6 +200,7 @@ function createUseCacheStore(
         outerWorkUnitStore
       ),
       forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
+      runtimeStagePromise: getRuntimeStagePromise(outerWorkUnitStore),
       draftMode: getDraftModeProviderForCacheScope(
         workStore,
         outerWorkUnitStore
@@ -953,6 +955,17 @@ export function cache(
         ? createHangingInputAbortSignal(workUnitStore)
         : undefined
 
+      // In a runtime prerender, we have to make sure that APIs that would hang during a static prerender
+      // are resolved with a delay, in the runtime stage. Private caches are one of these.
+      if (cacheContext.kind === 'private') {
+        const runtimeStagePromise = getRuntimeStagePromise(
+          cacheContext.outerWorkUnitStore
+        )
+        if (runtimeStagePromise) {
+          await runtimeStagePromise
+        }
+      }
+
       let isPageOrLayout = false
 
       // For page and layout components, the cache function is overwritten,
@@ -1068,6 +1081,14 @@ export function cache(
 
       switch (workUnitStore?.type) {
         case 'prerender-runtime':
+        // We're currently only using `dynamicAccessAsyncStorage` for params,
+        // which are always available in a runtime prerender, so they will never hang,
+        // effectively making the tracking below a no-op.
+        // However, a runtime prerender shares a lot of the semantics with a static prerender,
+        // and might need to follow this codepath in the future
+        // if we start using `dynamicAccessAsyncStorage` for other APIs.
+        //
+        // fallthrough
         case 'prerender':
           if (!isPageOrLayout) {
             // If the "use cache" function is not a page or a layout, we need to
@@ -1156,7 +1177,14 @@ export function cache(
                     workStore.route,
                     'dynamic "use cache"'
                   )
-                case 'prerender-runtime':
+                case 'prerender-runtime': {
+                  // In a runtime prerender, we have to make sure that APIs that would hang during a static prerender
+                  // are resolved with a delay, in the runtime stage.
+                  if (workUnitStore.runtimeStagePromise) {
+                    await workUnitStore.runtimeStagePromise
+                  }
+                  break
+                }
                 case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'request':
@@ -1232,6 +1260,7 @@ export function cache(
                 // transformed with an async function, before being passed into
                 // the "use cache" function, which escapes the instrumentation.
                 if (workUnitStore.allowEmptyStaticShell) {
+                  // TODO(dynamic-ppr): do we need to wait for the runtime stage for this?
                   return makeHangingPromise(
                     workUnitStore.renderSignal,
                     workStore.route,
@@ -1338,6 +1367,12 @@ export function cache(
                 'dynamic "use cache"'
               )
             case 'prerender-runtime':
+              // In a runtime prerender, we have to make sure that APIs that would hang during a static prerender
+              // are resolved with a delay, in the runtime stage.
+              if (workUnitStore.runtimeStagePromise) {
+                await workUnitStore.runtimeStagePromise
+              }
+              break
             case 'prerender-ppr':
             case 'prerender-legacy':
             case 'request':

--- a/packages/next/src/shared/lib/promise-with-resolvers.ts
+++ b/packages/next/src/shared/lib/promise-with-resolvers.ts
@@ -1,0 +1,10 @@
+export function createPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  // Shim of Stage 4 Promise.withResolvers proposal
+  let resolve: (value: T | PromiseLike<T>) => void
+  let reject: (reason: any) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { resolve: resolve!, reject: reject!, promise }
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/page.tsx
@@ -1,0 +1,53 @@
+import { DebugLinkAccordion } from '../../../components/link-accordion'
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Errors</h1>
+
+      <h2>thrown errors</h2>
+      <ul>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/error-after-cookies"
+            prefetch={true}
+          />
+        </li>
+      </ul>
+
+      <h2>sync IO</h2>
+      <ul>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/cookies"
+            prefetch={true}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/dynamic-params/123"
+            prefetch={true}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/search-params?foo=bar"
+            prefetch={true}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/private-cache"
+            prefetch={true}
+          />
+        </li>
+        <li>
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/quickly-expiring-public-cache"
+            prefetch={true}
+          />
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
-import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { DebugRenderKind } from '../../../../shared'
 
 export default async function Page() {
   return (
@@ -8,18 +8,16 @@ export default async function Page() {
       <DebugRenderKind />
       <p id="intro">
         This page performs sync IO after a cookies() call, so we should only see
-        the error in a runtime prefetch or a navigation (and not during
-        prerendering / prefetching)
+        the error in a runtime prefetch
       </p>
       <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
-        <One />
+        <RuntimePrefetchable />
       </Suspense>
     </main>
   )
 }
 
-async function One() {
-  const cookieStore = await cookies()
-  await cachedDelay(['/cookies', cookieStore.get('user-agent')?.value])
+async function RuntimePrefetchable() {
+  await cookies()
   return <div id="timestamp">Timestamp: {Date.now()}</div>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { DebugRenderKind } from '../../../../../shared'
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
+
+type Params = { id: string }
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page performs sync IO after awaiting params, so we should only see
+        the error in a runtime prefetch
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
+  const res = await params
+  console.log(
+    'RuntimePrefetchable :: awaited params',
+    res,
+    workUnitAsyncStorage.getStore()
+  )
+  return <div id="timestamp">Timestamp: {Date.now()}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../../shared'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page performs sync IO after awaiting a private cache, so we should
+        only see the error in a runtime prefetch
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  await privateCache()
+  return <div id="timestamp">Timestamp: {Date.now()}</div>
+}
+
+async function privateCache() {
+  'use cache: private'
+  await cachedDelay([__dirname])
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../../shared'
+import { unstable_cacheLife } from 'next/cache'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page performs sync IO after awaiting a quickly-expiring public
+        cache, so we should only see the error in a runtime prefetch
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  await publicCache()
+  return <div id="timestamp">Timestamp: {Date.now()}</div>
+}
+
+async function publicCache() {
+  'use cache'
+  unstable_cacheLife('seconds')
+  await cachedDelay([__dirname])
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+import { DebugRenderKind } from '../../../../shared'
+
+type AnySearchParams = { [key: string]: string | string[] | undefined }
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p id="intro">
+        This page performs sync IO after awaiting searchParams, so we should
+        only see the error in a runtime prefetch
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  await searchParams
+  return <div id="timestamp">Timestamp: {Date.now()}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
@@ -136,6 +136,68 @@ export default async function Page() {
         </li>
       </ul>
 
+      <h2>
+        <code>runtime promise passed to public cache</code>
+      </h2>
+      <ul>
+        <li>
+          cookies() promise passed to public cache + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/cookies"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          dynamic params promise passed to public cache + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/dynamic-params/123"
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/dynamic-params/456"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          search params promise passed to public cache + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/search-params?searchParam=123"
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/search-params?searchParam=456"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          only cookies passed to public cache (no dynamic content)
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/cookies-only"
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
+
       <h2>short-lived caches</h2>
       <ul>
         <li>
@@ -229,22 +291,6 @@ export default async function Page() {
       <ul>
         <li>
           <DebugLinkAccordion href="/fully-static" prefetch={true} />
-        </li>
-      </ul>
-
-      <h2>errors</h2>
-      <ul>
-        <li>
-          <DebugLinkAccordion
-            href="/errors/error-after-cookies"
-            prefetch={true}
-          />
-        </li>
-        <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-cookies"
-            prefetch={true}
-          />
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses cookies (from a private cache) and no uncached IO, So it
+        should be completely prefetchable with a runtime prefetch.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  await cookies() // Guard from being statically prerendered, which would make the cache hang
+
+  // We've already awaited cookies, but we still want to make sure
+  // that the cache doesn't consider them a hanging promise
+  const cookieValue = await publicCache(
+    cookies().then(
+      (cookieStore) => cookieStore.get('testCookie')?.value ?? null
+    )
+  )
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+    </div>
+  )
+}
+
+async function publicCache(cookiePromise: Promise<string | null>) {
+  'use cache'
+  const cookieValue = await cookiePromise
+  await cachedDelay([__filename, cookieValue])
+  return cookieValue
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -1,0 +1,68 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { connection } from 'next/server'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page passes cookies to a public cache, and uses some uncached IO,
+        so parts of it should be prefetchable with a runtime prefetch.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+      <form
+        action={async (formData: FormData) => {
+          'use server'
+          const cookieStore = await cookies()
+          const cookieValue = formData.get('cookie') as string | null
+          if (cookieValue) {
+            cookieStore.set('testCookie', cookieValue)
+          }
+        }}
+      >
+        <input type="text" name="cookie" />
+        <button type="submit">Update cookie</button>
+      </form>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  await cookies() // Guard from being statically prerendered, which would make the cache hang
+
+  // We've already awaited cookies, but we still want to make sure
+  // that the cache doesn't consider them a hanging promise
+  const cookieValue = await publicCache(
+    cookies().then(
+      (cookieStore) => cookieStore.get('testCookie')?.value ?? null
+    )
+  )
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function publicCache(cookiePromise: Promise<string | null>) {
+  'use cache'
+  const cookieValue = await cookiePromise
+  await cachedDelay([__filename, cookieValue])
+  return cookieValue
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../../shared'
+import { connection } from 'next/server'
+import { cookies } from 'next/headers'
+
+type Params = { id: string }
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page passes dynamic params to a public cache, and uses some
+        uncached IO, so parts of it should be prefetchable with a runtime
+        prefetch.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
+  await cookies() // Guard from being statically prerendered, which would make the cache hang
+
+  const id = await publicCache(params)
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="param-value">{`Param: ${id}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function publicCache(params: Promise<Params>) {
+  'use cache'
+  const { id } = await params
+  await cachedDelay([__filename, id])
+  return id
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind } from '../../../shared'
+import { connection } from 'next/server'
+import { cookies } from 'next/headers'
+
+type AnySearchParams = { [key: string]: string | string[] | undefined }
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page passes search params to a public cache, and uses some uncached
+        IO, so parts of it should be prefetchable with a runtime prefetch.
+      </p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  await cookies() // Guard from being statically prerendered, which would make the cache hang
+
+  const searchParam = await publicCache(searchParams)
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="search-param-value">{`Search param: ${searchParam}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function publicCache(searchParams: Promise<AnySearchParams>) {
+  'use cache'
+  const { searchParam } = await searchParams
+  await cachedDelay([__filename, searchParam])
+  return searchParam
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/page.tsx
@@ -51,6 +51,29 @@ export default async function Page() {
           </ul>
         </li>
       </ul>
+
+      <h2>
+        <code>promise passed to public cache</code>
+      </h2>
+      <ul>
+        <li>
+          root params + dynamic content
+          <ul>
+            <li>
+              <DebugLinkAccordion
+                href={`/with-root-param/${currentLang}/passed-to-public-cache/root-params`}
+                prefetch={true}
+              />
+            </li>
+            <li>
+              <DebugLinkAccordion
+                href={`/with-root-param/${otherLang}/passed-to-public-cache/root-params`}
+                prefetch={true}
+              />
+            </li>
+          </ul>
+        </li>
+      </ul>
     </main>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -1,0 +1,50 @@
+import { Suspense } from 'react'
+import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
+import { connection } from 'next/server'
+import { lang } from 'next/root-params'
+
+export default async function Page() {
+  return (
+    <main>
+      <DebugRenderKind />
+      <p>
+        This page uses root params (passed to a private cache) and some uncached
+        IO. Root params should always be available in static prerenders, so a
+        runtime prefetch should have them too, and they should not be considered
+        a hanging input.
+      </p>
+      <Suspense fallback="Loading 1...">
+        <DynamicallyPrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function DynamicallyPrefetchable() {
+  const currentLang = await publicCache(lang())
+  return (
+    <div style={{ border: '1px solid blue', padding: '1em' }}>
+      <div id="root-param-value">{`Lang: ${currentLang}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+async function publicCache(currentLangPromise: Promise<string>) {
+  'use cache'
+  const currentLang = await currentLangPromise
+  await cachedDelay([__filename, currentLang])
+  return currentLang
+}
+
+async function Dynamic() {
+  await uncachedIO()
+  await connection()
+  return (
+    <div style={{ border: '1px solid tomato', padding: '1em' }}>
+      <div id="dynamic-content">Dynamic content</div>
+    </div>
+  )
+}


### PR DESCRIPTION


---
🔄 **This is a mirror of [upstream PR #82475](https://github.com/vercel/next.js/pull/82475)**