### PR TITLE
chore: Ignore `compiled` folder in ripgrep/ast-grep/ag/etc

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -3,3 +3,4 @@
 
 # Not valid text
 turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
+packages/next/src/compiled


### PR DESCRIPTION
These files need to be committed (why they're not in `.gitignore`), but I'm tired of `ripgrep` capturing these generated files.

---
🔄 **This is a mirror of [upstream PR #82482](https://github.com/vercel/next.js/pull/82482)**