### PR TITLE
fix(create-next-app): Add missing ESLint packages

### DIFF
--- a/examples/with-eslint/package.json
+++ b/examples/with-eslint/package.json
@@ -16,6 +16,8 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "eslint": "^9",
-    "eslint-config-next": "latest"
+    "eslint-config-next": "latest",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "@next/eslint-plugin-next": "^15.4.6"
   }
 }


### PR DESCRIPTION
### Fixing a bug

### What?
- This pull request (PR) fixes an issue where the ESLint configuration in new Next.js projects with TypeScript is configured to use specific plugins, but these plugins are not automatically installed. 
- As a result, linting analysis of `.tsx` files fails with "missing package" errors, even though the configuration is present. 
- The project template currently omits the packages required for a fully functioning ESLint configuration.

### Why?

When using the create-next-app command with the following options, the lint command fails with the following errors:

#### With these installation options.

<img width="933" height="987" alt="2025-08-08_12-46" src="https://github.com/user-attachments/assets/be12f577-7c00-4729-8780-23c43ee1e668" />

#### You get this error from ESLint

<img width="1397" height="1003" alt="error" src="https://github.com/user-attachments/assets/ee790bce-59dd-4c2e-89bc-e962e546a0d0" />

#### Errors
```*.sh-session
Error: Failed to load plugin 'react-hooks' declared in ' » eslint-config-next/core-web-vitals » /workspace/contribute/sites-test/test-eslint/node_modules/.pnpm/eslint-config-next@15.4.6_eslint@9.33.0_jiti@2.5.1__typescript@5.9.2/node_modules/eslint-config-next/index.js': Cannot find module 'eslint-plugin-react-hooks'

Error: Failed to load plugin '@next/next' declared in ' » eslint-config-next/core-web-vitals » /workspace/contribute/sites-test/test-eslint/node_modules/.pnpm/eslint-config-next@15.4.6_eslint@9.33.0_jiti@2.5.1__typescript@5.9.2/node_modules/eslint-config-next/index.js': Cannot find module '@next/eslint-plugin-next'
```

### How?

This PR modifies the devDependencies of the with-eslint template to include the following packages:

#### Adding the following packages

- `eslint-plugin-react-hooks`
- `@next/eslint-plugin-next`

ESLint configuration issue fixed

---
🔄 **This is a mirror of [upstream PR #82489](https://github.com/vercel/next.js/pull/82489)**