### PR TITLE
Update Rspack production test manifest

### DIFF
--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -1720,6 +1720,15 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/cache-components-bot-ua/cache-components-bot-ua.test.ts": {
+    "passed": [
+      "cache-components PPR bot static generation bypass should bypass static generation for DOM bot requests to avoid SSG_BAILOUT"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts": {
     "passed": [
       "hello-world should not indicate there is an error when incidental math.random calls occur during component tree generation during build"
@@ -18875,7 +18884,10 @@
     "runtimeError": false
   },
   "test/production/adapter-config/adapter-config.test.ts": {
-    "passed": ["adapter-config should apply modifyConfig from adapter"],
+    "passed": [
+      "adapter-config should apply modifyConfig from adapter",
+      "adapter-config should call onBuildComplete with correct context"
+    ],
     "failed": [],
     "pending": [],
     "flakey": [],


### PR DESCRIPTION
This auto-generated PR updates the production integration test manifest used when testing Rspack.

---
🔄 **This is a mirror of [upstream PR #82493](https://github.com/vercel/next.js/pull/82493)**