### PR TITLE
[Cache Components] Error for sync IO in prerender in Server Components

### DIFF
--- a/errors/next-prerender-crypto.mdx
+++ b/errors/next-prerender-crypto.mdx
@@ -1,14 +1,16 @@
 ---
-title: Cannot access `crypto.getRandomValue()`, `crypto.randomUUID()`, or another web or node crypto API that generates random values synchronously in a Server Component
+title: Cannot access `crypto.getRandomValue()`, `crypto.randomUUID()`, or another web or node crypto API that generates random values synchronously before other uncached data or Request data in a Server Component
 ---
 
 ## Why This Error Occurred
 
-An API that produces a random value synchronously from the Web Crypto API or from Node's `crypto` API was called outside of a `"use cache"` scope and without first calling `await connection()`. Random values that are produced synchronously must either be inside a `"use cache"` scope or be preceded with `await connection()` to explicitly communicate to Next.js whether the random values produced can be reused across many requests (cached) or if they must be unique per Request (`await connection()`).
-
-If the API used has an async version you can also switch to that instead of using `await connection()`.
+An API that produces a random value synchronously from the Web Crypto API or from Node's `crypto` package was used in a Server Component before accessing other uncached data through APIs like `fetch()` and native database drivers, or Request data through Next.js APIs like `cookies()`, `headers()`, `connection()` and `searchParams`. Accessing random values synchronously in this way interferes with the prerendering and prefetching capabilities of Next.js.
 
 ## Possible Ways to Fix It
+
+If the random crypto value is appropriate to be prerendered and prefetched consider moving it into a Cache Component or Cache Function with the `"use cache"` directive.
+
+If the random crypto value is intended to be generated on every user request consider whether an async API exists that achieves the same result. If not consider whether you can move the random crypto value generation later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the random crypto value generation with Request data access by using `await connection()`.
 
 ### Cache the token value
 

--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -1,14 +1,20 @@
 ---
-title: Cannot infer intended usage of current time with `Date.now()`, `Date()`, or `new Date()` in a Server Component
+title: Cannot access `Date.now()`, `Date()`, or `new Date()` before other uncached data or Request data in a Server Component
 ---
 
 ## Why This Error Occurred
 
-Reading the current time in a Server Component can be ambiguous. Sometimes you intend to capture the time when something was cached, other times you intend to capture the time of a user Request. You might also be trying to measure runtime performance to track elapsed time.
-
-Depending on your use case you might use alternative time APIs like `performance.now()`, you might cache the time read with `"use cache"`, or you might communicate that the time must be evaluated on each request by guarding it with `await connection()` or moving it into a Client Component.
+`Date.now()`, `Date()`, or `new Date()` was used in a Server Component before accessing other uncached data through APIs like `fetch()` and native database drivers, or Request data through built-in APIs like `cookies()`, `headers()`, `connection()` and `searchParams`. Accessing the current time in this way interferes with the prerendering and prefetching capabilities of Next.js.
 
 ## Possible Ways to Fix It
+
+If the current time is being used for diagnostic purposes such as logging or performance tracking consider using `performance.now()` instead.
+
+If the current time is appropriate to be prerendered and prefetched consider moving it into a Cache Component or Cache Function with the `"use cache"` directive.
+
+If the current time is intended to be accessed dynamically on every user request first consider whether it is more appropriate to access it in a Client Component, which can often be the case when reading the time for display purposes. If a Client Component isn't the right choice then consider whether you can move the current time access later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the current time access with Request data access by using `await connection()`.
+
+> **Note**: Sometimes the place that accesses the current time is inside 3rd party code. While you can't easily convert the time access to `performance.now()` the other strategies can be applied in your own project code regardless of how deeply the time is read.
 
 ### Performance use case
 
@@ -40,6 +46,7 @@ export default async function Page() {
 ```
 
 > **Note**: If you need report an absolute time to an observability tool you can also use `performance.timeOrigin + performance.now()`.
+> **Note**: It is essential that the values provided by `performance.now()` do not influence the rendered output of your Component and should never be passed into Cache Functions as arguments or props
 
 ### Cacheable use cases
 
@@ -213,6 +220,8 @@ async function DynamicBanner() {
   }
 }
 ```
+
+> **Note**: This example illustrates using `await connection()` but you could just as well used moved where a uncached fetch was happening or read cookies before as well.
 
 ## Useful Links
 

--- a/errors/next-prerender-random.mdx
+++ b/errors/next-prerender-random.mdx
@@ -1,10 +1,20 @@
 ---
-title: Cannot infer intended usage of `Math.random()` in a Server Component
+title: Cannot access `Math.random()` before other uncached data or Request data in a Server Component
 ---
 
 ## Why This Error Occurred
 
-A Server Component is calling `Math.random()` without specifying whether it should be cached or whether it should be evaluated on each user Request. If you want this random value to be included in the prerendered HTML for this page you must cache it using `"use cache"`. If you want this random value to be unique per Request you must precede it with `await connection()` so Next.js knows to exclude it from the prerendered HTML.
+`Math.random()` was called in a Server Component before accessing other uncached data through APIs like `fetch()` and native database drivers, or Request data through built-in APIs like `cookies()`, `headers()`, `connection()` and `searchParams`. Accessing random values in this way interferes with the prerendering and prefetching capabilities of Next.js.
+
+## Possible Ways to Fix It
+
+If the random value is appropriate to be prerendered and prefetched consider moving it into a Cache Component or Cache Function with the `"use cache"` directive.
+
+If the random value is intended to be generated on every user request consider whether you can move the random value generation later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the random value generation with Request data access by using `await connection()`.
+
+If the random value is being used as a unique identifier for diagnostic purposes such as logging or tracking consider using an alternate method of id generation that does not rely on random number generation such as incrementing an integer.
+
+> **Note**: Sometimes the place that generates a random value synchronously is inside 3rd party code. While you can't easily replace the `Math.random()` call directly, the other strategies can be applied in your own project code regardless of how deep random generation is.
 
 ## Possible Ways to Fix It
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1759,6 +1759,8 @@ async function renderToHTMLOrFlightImpl(
       renderOpts.renderResumeDataCache ?? postponedState?.renderResumeDataCache
 
     const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
+    const devValidatingFallbackParams =
+      getRequestMeta(req, 'devValidatingFallbackParams') || null
     const requestStore = createRequestStoreForRender(
       req,
       res,
@@ -1769,7 +1771,8 @@ async function renderToHTMLOrFlightImpl(
       renderOpts.previewProps,
       isHmrRefresh,
       serverComponentsHmrCache,
-      renderResumeDataCache
+      renderResumeDataCache,
+      devValidatingFallbackParams
     )
 
     if (
@@ -1841,7 +1844,8 @@ async function renderToHTMLOrFlightImpl(
             notFoundLoaderTree,
             formState,
             postponedState,
-            metadata
+            metadata,
+            devValidatingFallbackParams
           )
 
           return new RenderResult(stream, {
@@ -1872,7 +1876,8 @@ async function renderToHTMLOrFlightImpl(
       loaderTree,
       formState,
       postponedState,
-      metadata
+      metadata,
+      devValidatingFallbackParams
     )
 
     // Invalid dynamic usages should only error the request in development.
@@ -2058,7 +2063,8 @@ async function renderToStream(
   tree: LoaderTree,
   formState: any,
   postponedState: PostponedState | null,
-  metadata: AppPageRenderResultMetadata
+  metadata: AppPageRenderResultMetadata,
+  devValidatingFallbackParams: FallbackRouteParams | null
 ): Promise<ReadableStream<Uint8Array>> {
   const { assetPrefix, nonce, pagePath, renderOpts } = ctx
 
@@ -2204,9 +2210,6 @@ async function renderToStream(
           requestStore.prerenderPhase = false
         }
       )
-
-      const devValidatingFallbackParams =
-        getRequestMeta(req, 'devValidatingFallbackParams') || null
 
       spawnDynamicValidationInDev(
         resolveValidation,

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -736,23 +736,20 @@ export function throwIfDisallowedDynamic(
   dynamicValidation: DynamicValidationState,
   serverDynamic: DynamicTrackingState
 ): void {
+  if (serverDynamic.syncDynamicErrorWithStack) {
+    logDisallowedDynamicError(
+      workStore,
+      serverDynamic.syncDynamicErrorWithStack
+    )
+    throw new StaticGenBailoutError()
+  }
+
   if (prelude !== PreludeState.Full) {
     if (dynamicValidation.hasSuspenseAboveBody) {
       // This route has opted into allowing fully dynamic rendering
       // by including a Suspense boundary above the body. In this case
       // a lack of a shell is not considered disallowed so we simply return
       return
-    }
-
-    if (serverDynamic.syncDynamicErrorWithStack) {
-      // There is no shell and the server did something sync dynamic likely
-      // leading to an early termination of the prerender before the shell
-      // could be completed. We terminate the build/validating render.
-      logDisallowedDynamicError(
-        workStore,
-        serverDynamic.syncDynamicErrorWithStack
-      )
-      throw new StaticGenBailoutError()
     }
 
     // We didn't have any sync bailouts but there may be user code which

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -18,6 +18,7 @@ import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
 import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../client/components/app-router-headers'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 export type WorkUnitPhase = 'action' | 'render' | 'after'
 
@@ -67,6 +68,7 @@ export interface RequestStore extends CommonWorkUnitStore {
   // DEV-only
   usedDynamic?: boolean
   prerenderPhase?: boolean
+  devFallbackParams?: FallbackRouteParams | null
 }
 
 /**
@@ -309,6 +311,10 @@ export function throwForMissingRequestStore(callingExpression: string): never {
   throw new Error(
     `\`${callingExpression}\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
   )
+}
+
+export function throwInvariantForMissingStore(): never {
+  throw new InvariantError('Expected workUnitAsyncStorage to have a store.')
 }
 
 export function getPrerenderResumeDataCache(

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -24,6 +24,7 @@ import type { ServerComponentsHmrCache } from '../response-cache'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
+import type { FallbackRouteParams } from '../request/fallback-params'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
@@ -114,7 +115,8 @@ export function createRequestStoreForRender(
   previewProps: WrapperRenderOpts['previewProps'],
   isHmrRefresh: RequestContext['isHmrRefresh'],
   serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
-  renderResumeDataCache: RenderResumeDataCache | undefined
+  renderResumeDataCache: RenderResumeDataCache | undefined,
+  devFallbackParams: FallbackRouteParams | null
 ): RequestStore {
   return createRequestStoreImpl(
     // Pages start in render phase by default
@@ -128,7 +130,8 @@ export function createRequestStoreForRender(
     renderResumeDataCache,
     previewProps,
     isHmrRefresh,
-    serverComponentsHmrCache
+    serverComponentsHmrCache,
+    devFallbackParams
   )
 }
 
@@ -151,7 +154,8 @@ export function createRequestStoreForAPI(
     undefined,
     previewProps,
     false,
-    undefined
+    undefined,
+    null
   )
 }
 
@@ -166,7 +170,8 @@ function createRequestStoreImpl(
   renderResumeDataCache: RenderResumeDataCache | undefined,
   previewProps: WrapperRenderOpts['previewProps'],
   isHmrRefresh: RequestContext['isHmrRefresh'],
-  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache']
+  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
+  devFallbackParams: FallbackRouteParams | null | undefined
 ): RequestStore {
   function defaultOnUpdateCookies(cookies: string[]) {
     if (res) {
@@ -258,6 +263,7 @@ function createRequestStoreImpl(
     serverComponentsHmrCache:
       serverComponentsHmrCache ||
       (globalThis as any).__serverComponentsHmrCache,
+    devFallbackParams,
   }
 }
 

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -72,3 +72,14 @@ export function makeHangingPromise<T>(
 }
 
 function ignoreReject() {}
+
+export function makeDevtoolsIOAwarePromise<T>(underlying: T): Promise<T> {
+  // in React DevTools if we resolve in a setTimeout we will observe
+  // the promise resolution as something that can suspend a boundary or root.
+  return new Promise<T>((resolve) => {
+    // Must use setTimeout to be considered IO React DevTools. setImmediate will not work.
+    setTimeout(() => {
+      resolve(underlying)
+    }, 0)
+  })
+}

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -30,13 +30,13 @@ export function io(expression: string, type: ApiType) {
         let message: string
         switch (type) {
           case 'time':
-            message = `Route "${workStore.route}" used ${expression} instead of using \`performance\` or without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time`
+            message = `Route "${workStore.route}" used ${expression} before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time`
             break
           case 'random':
-            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random`
+            message = `Route "${workStore.route}" used ${expression} before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random`
             break
           case 'crypto':
-            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto`
+            message = `Route "${workStore.route}" used ${expression} before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random cryptographic values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto`
             break
           default:
             throw new InvariantError(

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -21,9 +21,11 @@ import {
   trackSynchronousRequestDataAccessInDev,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { scheduleImmediate } from '../../lib/scheduler'
 import { isRequestAPICallableInsideAfter } from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
@@ -134,10 +136,10 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
             underlyingCookies = workUnitStore.cookies
           }
 
-          if (
-            process.env.NODE_ENV === 'development' &&
-            !workStore?.isPrefetchRequest
-          ) {
+          if (process.env.NODE_ENV === 'development') {
+            // Semantically we only need the dev tracking when running in `next dev`
+            // but since you would never use next dev with production NODE_ENV we use this
+            // as a proxy so we can statically exclude this code from production builds.
             if (process.env.__NEXT_CACHE_COMPONENTS) {
               return makeUntrackedCookiesWithDevWarnings(
                 underlyingCookies,
@@ -263,9 +265,7 @@ function makeUntrackedExoticCookiesWithDevWarnings(
     return cachedCookies
   }
 
-  const promise = new Promise<ReadonlyRequestCookies>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingCookies))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingCookies)
   CachedCookies.set(underlyingCookies, promise)
 
   Object.defineProperties(promise, {
@@ -416,9 +416,7 @@ function makeUntrackedCookiesWithDevWarnings(
     return cachedCookies
   }
 
-  const promise = new Promise<ReadonlyRequestCookies>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingCookies))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingCookies)
 
   const proxiedPromise = new Proxy(promise, {
     get(target, prop, receiver) {

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -6,8 +6,8 @@ import {
   workAsyncStorage,
   type WorkStore,
 } from '../app-render/work-async-storage.external'
-import { throwForMissingRequestStore } from '../app-render/work-unit-async-storage.external'
 import {
+  throwForMissingRequestStore,
   workUnitAsyncStorage,
   type PrerenderStoreModern,
 } from '../app-render/work-unit-async-storage.external'
@@ -18,9 +18,11 @@ import {
   trackSynchronousRequestDataAccessInDev,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { scheduleImmediate } from '../../lib/scheduler'
 import { isRequestAPICallableInsideAfter } from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
@@ -153,10 +155,10 @@ export function headers(): Promise<ReadonlyHeaders> {
         case 'request':
           trackDynamicDataInDynamicRender(workUnitStore)
 
-          if (
-            process.env.NODE_ENV === 'development' &&
-            !workStore?.isPrefetchRequest
-          ) {
+          if (process.env.NODE_ENV === 'development') {
+            // Semantically we only need the dev tracking when running in `next dev`
+            // but since you would never use next dev with production NODE_ENV we use this
+            // as a proxy so we can statically exclude this code from production builds.
             if (process.env.__NEXT_CACHE_COMPONENTS) {
               return makeUntrackedHeadersWithDevWarnings(
                 workUnitStore.headers,
@@ -263,9 +265,7 @@ function makeUntrackedExoticHeadersWithDevWarnings(
     return cachedHeaders
   }
 
-  const promise = new Promise<ReadonlyHeaders>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingHeaders))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingHeaders)
 
   CachedHeaders.set(underlyingHeaders, promise)
 
@@ -384,9 +384,7 @@ function makeUntrackedHeadersWithDevWarnings(
     return cachedHeaders
   }
 
-  const promise = new Promise<ReadonlyHeaders>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingHeaders))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingHeaders)
 
   const proxiedPromise = new Proxy(promise, {
     get(target, prop, receiver) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -17,15 +17,18 @@ import {
   type PrerenderStoreLegacy,
   type StaticPrerenderStoreModern,
   type StaticPrerenderStore,
+  throwInvariantForMissingStore,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   describeStringPropertyAccess,
   wellKnownProperties,
 } from '../../shared/lib/utils/reflect-utils'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { scheduleImmediate } from '../../lib/scheduler'
 import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
 
 export type ParamValue = string | Array<string> | undefined
@@ -62,7 +65,7 @@ export type UnsafeUnwrappedParams<P> =
 export function createParamsFromClient(
   underlyingParams: Params,
   workStore: WorkStore
-) {
+): Promise<Params> {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -82,12 +85,24 @@ export function createParamsFromClient(
           'createParamsFromClient should not be called in a runtime prerender.'
         )
       case 'request':
-        break
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          const devFallbackParams = workUnitStore.devFallbackParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            devFallbackParams,
+            workStore
+          )
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderParams(underlyingParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
@@ -98,7 +113,7 @@ export const createServerParamsForMetadata = createServerParamsForServerSegment
 export function createServerParamsForRoute(
   underlyingParams: Params,
   workStore: WorkStore
-) {
+): Promise<Params> {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -114,13 +129,33 @@ export function createServerParamsForRoute(
           'createServerParamsForRoute should not be called in cache contexts.'
         )
       case 'prerender-runtime':
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          return createRenderParamsInDev(underlyingParams, null, workStore)
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       case 'request':
-        break
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          const devFallbackParams = workUnitStore.devFallbackParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            devFallbackParams,
+            workStore
+          )
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderParams(underlyingParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 export function createServerParamsForServerSegment(
@@ -142,13 +177,33 @@ export function createServerParamsForServerSegment(
           'createServerParamsForServerSegment should not be called in cache contexts.'
         )
       case 'prerender-runtime':
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          return createRenderParamsInDev(underlyingParams, null, workStore)
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       case 'request':
-        break
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          const devFallbackParams = workUnitStore.devFallbackParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            devFallbackParams,
+            workStore
+          )
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderParams(underlyingParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 export function createPrerenderParamsForClientSegment(
@@ -259,29 +314,41 @@ function createPrerenderParams(
   }
 }
 
-function createRenderParams(
+function createRenderParamsInProd(underlyingParams: Params): Promise<Params> {
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    return makeUntrackedParams(underlyingParams)
+  }
+
+  return makeUntrackedExoticParams(underlyingParams)
+}
+
+function createRenderParamsInDev(
   underlyingParams: Params,
+  devFallbackParams: FallbackRouteParams | null | undefined,
   workStore: WorkStore
 ): Promise<Params> {
-  if (process.env.NODE_ENV === 'development' && !workStore.isPrefetchRequest) {
-    if (process.env.__NEXT_CACHE_COMPONENTS) {
-      return makeDynamicallyTrackedParamsWithDevWarnings(
-        underlyingParams,
-        workStore
-      )
+  let hasFallbackParams = false
+  if (devFallbackParams) {
+    for (let key in underlyingParams) {
+      if (devFallbackParams.has(key)) {
+        hasFallbackParams = true
+        break
+      }
     }
-
-    return makeDynamicallyTrackedExoticParamsWithDevWarnings(
+  }
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    return makeDynamicallyTrackedParamsWithDevWarnings(
       underlyingParams,
+      hasFallbackParams,
       workStore
     )
-  } else {
-    if (process.env.__NEXT_CACHE_COMPONENTS) {
-      return makeUntrackedParams(underlyingParams)
-    }
-
-    return makeUntrackedExoticParams(underlyingParams)
   }
+
+  return makeDynamicallyTrackedExoticParamsWithDevWarnings(
+    underlyingParams,
+    hasFallbackParams,
+    workStore
+  )
 }
 
 interface CacheLifetime {}
@@ -472,6 +539,7 @@ function makeUntrackedParams(underlyingParams: Params): Promise<Params> {
 
 function makeDynamicallyTrackedExoticParamsWithDevWarnings(
   underlyingParams: Params,
+  hasFallbackParams: boolean,
   store: WorkStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
@@ -482,9 +550,10 @@ function makeDynamicallyTrackedExoticParamsWithDevWarnings(
   // We don't use makeResolvedReactPromise here because params
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = new Promise<Params>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingParams))
-  )
+  const promise = hasFallbackParams
+    ? makeDevtoolsIOAwarePromise(underlyingParams)
+    : // We don't want to force an environment transition when this params is not part of the fallback params set
+      Promise.resolve(underlyingParams)
 
   const proxiedProperties = new Set<string>()
   const unproxiedProperties: Array<string> = []
@@ -534,6 +603,7 @@ function makeDynamicallyTrackedExoticParamsWithDevWarnings(
 // logging the sync access without actually defining the params on the promise.
 function makeDynamicallyTrackedParamsWithDevWarnings(
   underlyingParams: Params,
+  hasFallbackParams: boolean,
   store: WorkStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
@@ -544,9 +614,10 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
   // We don't use makeResolvedReactPromise here because params
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = new Promise<Params>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingParams))
-  )
+  const promise = hasFallbackParams
+    ? makeDevtoolsIOAwarePromise(underlyingParams)
+    : // We don't want to force an environment transition when this params is not part of the fallback params set
+      Promise.resolve(underlyingParams)
 
   const proxiedProperties = new Set<string>()
   const unproxiedProperties: Array<string> = []

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -6,6 +6,7 @@ import {
 } from '../app-render/dynamic-rendering'
 
 import {
+  throwInvariantForMissingStore,
   workUnitAsyncStorage,
   type StaticPrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
@@ -38,12 +39,12 @@ export function createServerPathnameForMetadata(
 
       case 'prerender-runtime':
       case 'request':
-        break
+        return createRenderPathname(underlyingPathname)
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderPathname(underlyingPathname)
+  throwInvariantForMissingStore()
 }
 
 function createPrerenderPathname(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -15,9 +15,13 @@ import {
   type PrerenderStorePPR,
   type PrerenderStoreModern,
   type StaticPrerenderStore,
+  throwInvariantForMissingStore,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import {
   describeStringPropertyAccess,
@@ -28,7 +32,6 @@ import {
   throwWithStaticGenerationBailoutErrorWithDynamicError,
   throwForSearchParamsAccessInUseCache,
 } from './utils'
-import { scheduleImmediate } from '../../lib/scheduler'
 
 export type SearchParams = { [key: string]: string | string[] | undefined }
 
@@ -63,7 +66,7 @@ export type UnsafeUnwrappedSearchParams<P> =
 export function createSearchParamsFromClient(
   underlyingSearchParams: SearchParams,
   workStore: WorkStore
-) {
+): Promise<SearchParams> {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -83,12 +86,12 @@ export function createSearchParamsFromClient(
           'createSearchParamsFromClient should not be called in cache contexts.'
         )
       case 'request':
-        break
+        return createRenderSearchParams(underlyingSearchParams, workStore)
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderSearchParams(underlyingSearchParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
@@ -115,12 +118,13 @@ export function createServerSearchParamsForServerPage(
         )
       case 'prerender-runtime':
       case 'request':
+        return createRenderSearchParams(underlyingSearchParams, workStore)
         break
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderSearchParams(underlyingSearchParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 export function createPrerenderSearchParamsForClientPage(
@@ -157,15 +161,12 @@ export function createPrerenderSearchParamsForClientPage(
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
-        break
+        return Promise.resolve({})
       default:
         workUnitStore satisfies never
     }
   }
-  // We're prerendering in a mode that does not abort. We resolve the promise
-  // without any tracking because we're just transporting a value from server to
-  // client where the tracking will be applied.
-  return Promise.resolve({})
+  throwInvariantForMissingStore()
 }
 
 function createPrerenderSearchParams(
@@ -202,10 +203,10 @@ function createRenderSearchParams(
     // dictionary object.
     return Promise.resolve({})
   } else {
-    if (
-      process.env.NODE_ENV === 'development' &&
-      !workStore.isPrefetchRequest
-    ) {
+    if (process.env.NODE_ENV === 'development') {
+      // Semantically we only need the dev tracking when running in `next dev`
+      // but since you would never use next dev with production NODE_ENV we use this
+      // as a proxy so we can statically exclude this code from production builds.
       if (process.env.__NEXT_CACHE_COMPONENTS) {
         return makeUntrackedSearchParamsWithDevWarnings(
           underlyingSearchParams,
@@ -628,9 +629,7 @@ function makeDynamicallyTrackedExoticSearchParamsWithDevWarnings(
   // We don't use makeResolvedReactPromise here because searchParams
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = new Promise<SearchParams>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingSearchParams))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingSearchParams)
   promise.then(() => {
     promiseInitialized = true
   })
@@ -731,7 +730,7 @@ function makeUntrackedSearchParamsWithDevWarnings(
 
   const proxiedProperties = new Set<string>()
   const unproxiedProperties: Array<string> = []
-  const promise = Promise.resolve(underlyingSearchParams)
+  const promise = makeDevtoolsIOAwarePromise(underlyingSearchParams)
 
   Object.keys(underlyingSearchParams).forEach((prop) => {
     if (wellKnownProperties.has(prop)) {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -624,7 +624,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 9 : 8,
+                          'next.clientComponentLoadCount': isNextDev ? 11 : 8,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },


### PR DESCRIPTION
Currently we error if you cannot produce a shell unless you have a Suspense boundary above the root. This is fine for normal IO but sync IO like Math.random() and new Date() have much more significant bad consequences for prerendering. Instead of treating these errors as another flavor of "must have a shell" validation we should instead treat them like they must be guarded behind something else dynamic like `await connection()`.

---
🔄 **This is a mirror of [upstream PR #82500](https://github.com/vercel/next.js/pull/82500)**