### PR TITLE
docs: fix typos in packages

### DIFF
--- a/packages/create-next-app/templates/app-api/ts/gitignore
+++ b/packages/create-next-app/templates/app-api/ts/gitignore
@@ -29,7 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# env files (can opt-in for commiting if needed)
+# env files (can opt-in for committing if needed)
 .env*
 
 # vercel

--- a/packages/next-swc/README.md
+++ b/packages/next-swc/README.md
@@ -64,7 +64,7 @@ flowchart TD
     D(next-core) --> E(next-build)
 ```
 
-- `next-custom-transforms`: provides next-swc specific SWC transform visitors. Turbopack, and the plain next-swc bidnings (`transform`) use these transforms. Since this is a bottom package can be imported in any place (turbopack / next-swc / wasm), it is important package do not contain specific dependencies. For example, using Turbopack's VC in this package will cause build failures to wasm bindings.
+- `next-custom-transforms`: provides next-swc specific SWC transform visitors. Turbopack, and the plain next-swc bindings (`transform`) use these transforms. Since this is a bottom package can be imported in any place (turbopack / next-swc / wasm), it is important package do not contain specific dependencies. For example, using Turbopack's VC in this package will cause build failures to wasm bindings.
 - `next-core`: Implements Turbopack features for the next.js core functionality. This is also the place where Turbopack-specific transform providers (implementing `CustomTransformer`) lives, which wraps swc's transformer in the `next-custom-transforms`.
 - `next-api`: Binding interface to the next.js provides a proper next.js functionality using `next-core`.
 - `napi` / `wasm`: The actual binding interfaces, napi for the node.js and wasm for the wasm. Note wasm bindings cannot import packages using turbopack's feature.


### PR DESCRIPTION
## Summary

Fix typos in package documentation and templates

Documentation:
- Correct spelling of “bindings” in [next-swc README](https://github.com/vercel/next.js/blob/canary/packages/next-swc/README.md)
- Update [gitignore](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/templates/app-api/ts/gitignore) template in create-next-app app-api/ts setup

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

---
🔄 **This is a mirror of [upstream PR #82508](https://github.com/vercel/next.js/pull/82508)**