### PR TITLE
feat: add validation for root-level files when src directory exists

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -98,7 +98,6 @@ import {
   validateInstrumentationInSrcDir,
 } from './utils'
 
-
 import {
   eventBuildOptimize,
   eventCliSession,
@@ -1165,10 +1164,12 @@ export default async function build(
       if (isSrcDir) {
         for (const rootPath of rootPaths) {
           if (rootPath.includes(MIDDLEWARE_FILENAME)) {
-            validateMiddlewareInSrcDir(rootPath, isSrcDir)
+            const pathWithoutExtension = rootPath.replace(/\.[^/.]+$/, '')
+            validateMiddlewareInSrcDir(pathWithoutExtension, isSrcDir)
           }
           if (rootPath.includes(INSTRUMENTATION_HOOK_FILENAME)) {
-            validateInstrumentationInSrcDir(rootPath, isSrcDir)
+            const pathWithoutExtension = rootPath.replace(/\.[^/.]+$/, '')
+            validateInstrumentationInSrcDir(pathWithoutExtension, isSrcDir)
           }
         }
       }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -93,6 +93,11 @@ import {
   TurborepoAccessTraceResult,
   writeTurborepoAccessTraceResult,
 } from './turborepo-access-trace'
+import {
+  validateMiddlewareInSrcDir,
+  validateInstrumentationInSrcDir,
+} from './utils'
+
 
 import {
   eventBuildOptimize,
@@ -1156,6 +1161,17 @@ export default async function build(
       )
 
       NextBuildContext.hasInstrumentationHook = hasInstrumentationHook
+
+      if (isSrcDir) {
+        for (const rootPath of rootPaths) {
+          if (rootPath.includes(MIDDLEWARE_FILENAME)) {
+            validateMiddlewareInSrcDir(rootPath, isSrcDir)
+          }
+          if (rootPath.includes(INSTRUMENTATION_HOOK_FILENAME)) {
+            validateInstrumentationInSrcDir(rootPath, isSrcDir)
+          }
+        }
+      }
 
       const previewProps: __ApiPreviewProps = await generatePreviewKeys({
         isBuild: true,

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1821,6 +1821,33 @@ export class NestedMiddlewareError extends Error {
   }
 }
 
+export class SrcDirectoryError extends Error {
+  constructor(
+    fileName: string,
+    fileType: 'middleware' | 'instrumentation'
+  ) {
+    super(
+      `${fileType === 'middleware' ? 'Middleware' : 'Instrumentation'} file found outside src directory.\n` +
+        `Found: ${fileName}\n` +
+        `When using the src directory, ${fileType} files must be placed inside the src directory.\n` +
+        `Please move your ${fileType} file to src/${fileType}.\n` +
+        `Read More - https://nextjs.org/docs/app/api-reference/file-conventions/src-folder`
+    )
+  }
+}
+
+export function validateMiddlewareInSrcDir(fileName: string, isSrcDir: boolean) {
+  if (isSrcDir && isMiddlewareFile(fileName) && !fileName.startsWith('/src/')) {
+    throw new SrcDirectoryError(fileName, 'middleware')
+  }
+}
+
+export function validateInstrumentationInSrcDir(fileName: string, isSrcDir: boolean) {
+  if (isSrcDir && isInstrumentationHookFile(fileName) && !fileName.startsWith('/src/')) {
+    throw new SrcDirectoryError(fileName, 'instrumentation')
+  }
+}
+
 export function getSupportedBrowsers(
   dir: string,
   isDevelopment: boolean

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -81,6 +81,8 @@ import { buildAppStaticPaths } from './static-paths/app'
 import { buildPagesStaticPaths } from './static-paths/pages'
 import type { PrerenderedRoute } from './static-paths/types'
 import type { CacheControl } from '../server/lib/cache-control'
+import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
+
 import { formatExpire, formatRevalidate } from './output/format'
 
 export type ROUTER_TYPE = 'pages' | 'app'
@@ -1822,10 +1824,7 @@ export class NestedMiddlewareError extends Error {
 }
 
 export class SrcDirectoryError extends Error {
-  constructor(
-    fileName: string,
-    fileType: 'middleware' | 'instrumentation'
-  ) {
+  constructor(fileName: string, fileType: 'middleware' | 'instrumentation') {
     super(
       `${fileType === 'middleware' ? 'Middleware' : 'Instrumentation'} file found outside src directory.\n` +
         `Found: ${fileName}\n` +
@@ -1836,14 +1835,30 @@ export class SrcDirectoryError extends Error {
   }
 }
 
-export function validateMiddlewareInSrcDir(fileName: string, isSrcDir: boolean) {
-  if (isSrcDir && isMiddlewareFile(fileName) && !fileName.startsWith('/src/')) {
+export function validateMiddlewareInSrcDir(
+  fileName: string,
+  isSrcDir: boolean
+) {
+  const normalizedPath = normalizePathSep(fileName)
+  if (
+    isSrcDir &&
+    isMiddlewareFile(fileName) &&
+    !normalizedPath.startsWith('/src/')
+  ) {
     throw new SrcDirectoryError(fileName, 'middleware')
   }
 }
 
-export function validateInstrumentationInSrcDir(fileName: string, isSrcDir: boolean) {
-  if (isSrcDir && isInstrumentationHookFile(fileName) && !fileName.startsWith('/src/')) {
+export function validateInstrumentationInSrcDir(
+  fileName: string,
+  isSrcDir: boolean
+) {
+  const normalizedPath = normalizePathSep(fileName)
+  if (
+    isSrcDir &&
+    isInstrumentationHookFile(fileName) &&
+    !normalizedPath.startsWith('/src/')
+  ) {
     throw new SrcDirectoryError(fileName, 'instrumentation')
   }
 }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -428,7 +428,7 @@ async function startWatcher(
         })
 
         if (isMiddlewareFile(rootFile)) {
-          validateMiddlewareInSrcDir(rootFile, isSrcDir)
+          validateMiddlewareInSrcDir(rootFile, opts.isSrcDir)
           
           const staticInfo = await getStaticInfoIncludingLayouts({
             pageFilePath: fileName,
@@ -457,7 +457,7 @@ async function startWatcher(
           continue
         }
         if (isInstrumentationHookFile(rootFile)) {
-          validateInstrumentationInSrcDir(rootFile, isSrcDir)
+          validateInstrumentationInSrcDir(rootFile, opts.isSrcDir)
           
           serverFields.actualInstrumentationHookFile = rootFile
           await propagateServerField(

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -64,6 +64,8 @@ import {
   isInstrumentationHookFile,
   getPossibleMiddlewareFilenames,
   getPossibleInstrumentationHookFilenames,
+  validateMiddlewareInSrcDir,
+  validateInstrumentationInSrcDir,
 } from '../../../build/utils'
 import { devPageFiles } from '../../../build/webpack/plugins/next-types-plugin/shared'
 import type { LazyRenderServerInstance } from '../router-server'
@@ -426,6 +428,8 @@ async function startWatcher(
         })
 
         if (isMiddlewareFile(rootFile)) {
+          validateMiddlewareInSrcDir(rootFile, isSrcDir)
+          
           const staticInfo = await getStaticInfoIncludingLayouts({
             pageFilePath: fileName,
             config: nextConfig,
@@ -453,6 +457,8 @@ async function startWatcher(
           continue
         }
         if (isInstrumentationHookFile(rootFile)) {
+          validateInstrumentationInSrcDir(rootFile, isSrcDir)
+          
           serverFields.actualInstrumentationHookFile = rootFile
           await propagateServerField(
             opts,

--- a/test/integration/src-dir-validation/next.config.js
+++ b/test/integration/src-dir-validation/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: false,
+  },
+}

--- a/test/integration/src-dir-validation/src/pages/index.js
+++ b/test/integration/src-dir-validation/src/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Hello World</div>
+}

--- a/test/integration/src-dir-validation/test/index.test.js
+++ b/test/integration/src-dir-validation/test/index.test.js
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild, nextStart, findPort, killApp } from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+
+describe('Src Directory Validation', () => {
+  beforeEach(async () => {
+    await fs.remove(join(appDir, 'middleware.js')).catch(() => {})
+    await fs.remove(join(appDir, 'instrumentation.js')).catch(() => {})
+  })
+
+  afterEach(async () => {
+    await fs.remove(join(appDir, 'middleware.js')).catch(() => {})
+    await fs.remove(join(appDir, 'instrumentation.js')).catch(() => {})
+  })
+
+  it('should throw error when middleware is outside src directory', async () => {
+    await fs.writeFile(
+      join(appDir, 'middleware.js'),
+      `export function middleware() { return new Response('middleware') }`
+    )
+
+    const result = await nextBuild(appDir, [], { stderr: true, stdout: true })
+    expect(result.stderr + result.stdout).toContain('Middleware file found outside src directory')
+  })
+
+  it('should throw error when instrumentation is outside src directory', async () => {
+    await fs.writeFile(
+      join(appDir, 'instrumentation.js'),
+      `export function register() { console.log('instrumentation') }`
+    )
+
+    const result = await nextBuild(appDir, [], { stderr: true, stdout: true })
+    expect(result.stderr + result.stdout).toContain('Instrumentation file found outside src directory')
+  })
+
+  it('should work correctly when middleware is inside src directory', async () => {
+    await fs.writeFile(
+      join(appDir, 'src/middleware.js'),
+      `export function middleware() { return new Response('middleware') }`
+    )
+
+    const result = await nextBuild(appDir, [], { stderr: true, stdout: true })
+    expect(result.code).toBe(0)
+  })
+
+  it('should work correctly when instrumentation is inside src directory', async () => {
+    await fs.writeFile(
+      join(appDir, 'src/instrumentation.js'),
+      `export function register() { console.log('instrumentation') }`
+    )
+
+    const result = await nextBuild(appDir, [], { stderr: true, stdout: true })
+    expect(result.code).toBe(0)
+  })
+})


### PR DESCRIPTION
## What?

This PR adds validation to throw an error when root-level files (`middleware` and `instrumentation`) are found outside the `src/` directory when a `src/` directory structure is being used.

## Why?

Currently, Next.js allows middleware and instrumentation files to exist at the project root even when using a `src/` directory structure. This can lead to confusion and inconsistent file organization. The [Next.js documentation](https://nextjs.org/docs/app/api-reference/file-conventions/src-folder) states that when using the src directory, middleware should be placed inside the src folder, but this wasn't enforced.

## How?

1. **Added new error class**: `SrcDirectoryError` in `packages/next/src/build/utils.ts` that provides clear error messaging and documentation links

2. **Added validation functions**: 
   - `validateMiddlewareInSrcDir(fileName: string, isSrcDir: boolean)`
   - `validateInstrumentationInSrcDir(fileName: string, isSrcDir: boolean)`

3. **Integrated validation in two key locations**:
   - **Development**: `packages/next/src/server/lib/router-utils/setup-dev-bundler.ts` - validates during dev server startup
   - **Build time**: `packages/next/src/build/index.ts` - validates during production build

4. **Added test cases**: Created `test/integration/src-dir-validation/` to verify the validation behavior

The validation logic checks:
- If `src/` directory structure is being used (`isSrcDir`)
- If the file is a middleware or instrumentation file 
- If the file is located outside the `src/` directory
- If all conditions are true, throws `SrcDirectoryError` with helpful guidance

## ⚠️ Human Review Checklist

**Critical items to verify:**

1. **File path logic**: Verify that `fileName.startsWith('/src/')` correctly identifies files inside src directory for Next.js internal file paths
2. **Test execution**: Run the new tests in `test/integration/src-dir-validation/` to ensure they work correctly  
3. **Existing tests**: Confirm existing middleware-related tests still pass (especially `test/integration/middleware-src`)
4. **Dev vs Build consistency**: Test that validation works identically in both `next dev` and `next build` scenarios
5. **Error message accuracy**: Verify the documentation link in the error message is correct and helpful
6. **Edge cases**: Test scenarios like:
   - Projects without src directory (should not validate)
   - Projects with src directory but no middleware/instrumentation (should not error)
   - Mixed scenarios with some files in src and some outside

**⚠️ Testing Gap**: This implementation could not be tested locally due to missing pnpm dependency. The validation logic and integration points need thorough testing to ensure correctness.

**Breaking Change Consideration**: This introduces new fatal errors for previously "working" (but incorrectly organized) projects. Consider if this should be a warning first before becoming an error in a future version.

---

**Link to Devin run**: https://app.devin.ai/sessions/94e9f081963a4ec3bc8bc9c8c1ca8975  
**Requested by**: @devjiwonchoi

---
🔄 **This is a mirror of [upstream PR #82514](https://github.com/vercel/next.js/pull/82514)**