### PR TITLE
fix: prioritize src/ directory for instrumentation.ts in development

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1783,11 +1783,22 @@ export function getPossibleInstrumentationHookFilenames(
   extensions: string[]
 ) {
   const files = []
+  const srcDir = path.join(folder, 'src')
+  
+  // Check if src directory exists
+  const fs = require('fs')
+  const hasSrcDir = fs.existsSync(srcDir)
+  
   for (const extension of extensions) {
-    files.push(
-      path.join(folder, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`),
-      path.join(folder, `src`, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`)
-    )
+    if (hasSrcDir) {
+      files.push(
+        path.join(folder, `src`, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`)
+      )
+    } else {
+      files.push(
+        path.join(folder, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`)
+      )
+    }
   }
 
   return files

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -35,7 +35,7 @@ import {
 import getGzipSize from 'next/dist/compiled/gzip-size'
 import textTable from 'next/dist/compiled/text-table'
 import path from 'path'
-import { promises as fs } from 'fs'
+import { promises as fs, existsSync } from 'fs'
 import { isValidElementType } from 'next/dist/compiled/react-is'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import browserslist from 'next/dist/compiled/browserslist'
@@ -1785,9 +1785,7 @@ export function getPossibleInstrumentationHookFilenames(
   const files = []
   const srcDir = path.join(folder, 'src')
   
-  // Check if src directory exists
-  const fs = require('fs')
-  const hasSrcDir = fs.existsSync(srcDir)
+  const hasSrcDir = existsSync(srcDir)
   
   for (const extension of extensions) {
     if (hasSrcDir) {


### PR DESCRIPTION
## What?

Fixes inconsistent instrumentation.ts loading behavior between development and production environments when a `src/` directory exists.

## Why?

**Problem**: 
- **Development**: Loads `instrumentation.ts` from root directory even when `src/` directory exists
- **Production**: Correctly loads `instrumentation.ts` from `src/` directory when it exists
- **Expected**: Should exclusively load from `src/` when `src/` directory exists, ignoring any root-level file

This inconsistency causes confusion and potential issues when projects have both `instrumentation.ts` in root and `src/instrumentation.ts`, as different files are loaded in different environments.

## How?

Modified `getPossibleInstrumentationHookFilenames()` in `packages/next/src/build/utils.ts`:

1. **Check for `src/` directory existence** using `fs.existsSync()`
2. **If `src/` exists**: Only return paths within `src/` directory
3. **If no `src/`**: Only return root directory paths
4. **Result**: Development behavior now matches production behavior

### Before:
```typescript
// Always returned both root AND src paths
files.push(
  path.join(folder, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`),
  path.join(folder, `src`, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`)
)
```

### After:
```typescript
// Only returns src paths if src/ exists, otherwise only root paths
if (hasSrcDir) {
  files.push(path.join(folder, `src`, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`))
} else {
  files.push(path.join(folder, `${INSTRUMENTATION_HOOK_FILENAME}.${extension}`))
}
```

## Testing

Created test script that validates:
- ✅ When no `src/` directory exists → only returns root paths  
- ✅ When `src/` directory exists → only returns src paths

## Human Review Checklist

**Critical items to verify:**
- [ ] Logic correctly prioritizes `src/` when directory exists
- [ ] No regressions in development server instrumentation loading
- [ ] File system check approach (`fs.existsSync()`) is appropriate for this context
- [ ] Consider if existing tests need updates for this behavior change
- [ ] Verify alignment with documented instrumentation.ts behavior

**Potential risks:**
- Synchronous `fs.existsSync()` call in hot path (though just directory check)
- Projects incorrectly depending on old buggy behavior might be affected
- Runtime `require('fs')` usage (follows existing codebase pattern)

---

**Link to Devin run**: https://app.devin.ai/sessions/dd6bf37499764766864e431921c83280  
**Requested by**: @devjiwonchoi

This change ensures consistent instrumentation.ts loading behavior across all Next.js environments.

---
🔄 **This is a mirror of [upstream PR #82513](https://github.com/vercel/next.js/pull/82513)**