### PR TITLE
test: fix various typos across codebase

### DIFF
--- a/test/development/acceptance-app/fixtures/app-hmr-changes/tailwind.config.js
+++ b/test/development/acceptance-app/fixtures/app-hmr-changes/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   plugins: [
     plugin(function ({ addVariant }) {
-      // this class is applied to `html` by `app/theme-efect.ts`, similar
+      // this class is applied to `html` by `app/theme-effect.ts`, similar
       // to how `dark:` gets enabled
       addVariant('theme-system', '.theme-system &')
     }),

--- a/test/development/app-dir/cache-components-dev-fallback-validation/app/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/app/layout.tsx
@@ -22,7 +22,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
           <p>
             In Dev, our validation needs to match and the way we do this is we
             look at the current route and determine the most specific set of
-            params that would be availalbe during the build and then use the
+            params that would be available during the build and then use the
             remaining fallback params for the validation render. This way if you
             see an error during the build you should be able to debug that error
             during development too.

--- a/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
@@ -7,7 +7,7 @@ describe('Cache Components Fallback Validation', () => {
   })
 
   it('should not warn about missing Suspense when accessing params if static params are completely known at build time', async () => {
-    // when the params are complete we don't expect to see any errors await params regarless of where there
+    // when the params are complete we don't expect to see any errors await params regardless of where there
     // are Suspense boundaries.
     const browser = await next.browser(
       '/complete/prerendered/wrapped/prerendered'

--- a/test/development/app-dir/edge-errors-hmr/index.test.ts
+++ b/test/development/app-dir/edge-errors-hmr/index.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { assertHasRedbox, assertNoRedbox } from 'next-test-utils'
 
-describe('develop - app-dir - edge errros hmr', () => {
+describe('develop - app-dir - edge errors hmr', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -29,7 +29,7 @@ describe('react-dom/server in React Server environment', () => {
 
   let isStarted = false
   beforeEach(async () => {
-    // FIXME: next-custom-transforms RSC errors are not cleared during dev server livetime so we have to restart
+    // FIXME: next-custom-transforms RSC errors are not cleared during dev server lifetime so we have to restart
     if (isStarted) {
       await next.stop()
     }

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -11,7 +11,7 @@ describe(`app-dir-hmr`, () => {
   })
 
   describe('filesystem changes', () => {
-    it('should not continously poll when hitting a not found page', async () => {
+    it('should not continuously poll when hitting a not found page', async () => {
       let requestCount = 0
 
       const browser = await next.browser('/does-not-exist', {

--- a/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
@@ -95,7 +95,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
   })
   ;(process.env.IS_TURBOPACK_TEST ? it.skip : it)(
     // this test fails frequently with turbopack
-    'should not continously poll a custom error page',
+    'should not continuously poll a custom error page',
     async () => {
       const errorPage = join('pages', '_error.js')
 

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -331,12 +331,12 @@ describe('next.rs api', () => {
   for (const { name, path, type, runtime, config } of routes) {
     // eslint-disable-next-line no-loop-func
     it(`should allow to write ${name} to disk`, async () => {
-      const entrypointsSubscribtion = project.entrypointsSubscribe()
+      const entrypointsSubscription = project.entrypointsSubscribe()
       const entrypoints: TurbopackResult<RawEntrypoints> = (
-        await entrypointsSubscribtion.next()
+        await entrypointsSubscription.next()
       ).value
       const route = entrypoints.routes.get(path)
-      entrypointsSubscribtion.return()
+      entrypointsSubscription.return()
 
       expect(route.type).toBe(type)
 
@@ -467,12 +467,12 @@ describe('next.rs api', () => {
       it(`should have working HMR on ${name} ${i}`, async () => {
         console.log('start')
         await new Promise((r) => setTimeout(r, 1000))
-        const entrypointsSubscribtion = project.entrypointsSubscribe()
+        const entrypointsSubscription = project.entrypointsSubscribe()
         const entrypoints: TurbopackResult<RawEntrypoints> = (
-          await entrypointsSubscribtion.next()
+          await entrypointsSubscription.next()
         ).value
         const route = entrypoints.routes.get(path)
-        entrypointsSubscribtion.return()
+        entrypointsSubscription.return()
 
         expect(route.type).toBe(type)
 
@@ -610,12 +610,12 @@ describe('next.rs api', () => {
   it.skip('should allow to make many HMR updates', async () => {
     console.log('start')
     await new Promise((r) => setTimeout(r, 1000))
-    const entrypointsSubscribtion = project.entrypointsSubscribe()
+    const entrypointsSubscription = project.entrypointsSubscribe()
     const entrypoints: TurbopackResult<RawEntrypoints> = (
-      await entrypointsSubscribtion.next()
+      await entrypointsSubscription.next()
     ).value
     const route = entrypoints.routes.get('/')
-    entrypointsSubscribtion.return()
+    entrypointsSubscription.return()
 
     if (route.type !== 'page') throw new Error('unknown route type')
     await route.htmlEndpoint.writeToDisk()

--- a/test/development/middleware-warnings/index.test.ts
+++ b/test/development/middleware-warnings/index.test.ts
@@ -77,7 +77,7 @@ describe('middlewares', () => {
 
   it.each([
     {
-      title: 'returning null reponse body',
+      title: 'returning null response body',
       code: outdent`
         export default function middleware() {
           return new Response(null);

--- a/test/e2e/app-dir/actions/app/error-handling/page.js
+++ b/test/e2e/app-dir/actions/app/error-handling/page.js
@@ -11,7 +11,7 @@ export default function Page() {
       <p>
         This button will call a server action and pass something unserializable
         like a class instance. We expect this action to error with a reasonable
-        message explaning what happened
+        message explaining what happened
       </p>
       <button
         id="submit"

--- a/test/e2e/app-dir/actions/app/redirects/page.js
+++ b/test/e2e/app-dir/actions/app/redirects/page.js
@@ -17,11 +17,11 @@ export default function Home() {
           id="submit-api-redirect-permanent"
         />
       </form>
-      <h1>POST /api-reponse-redirect-307</h1>
+      <h1>POST /api-response-redirect-307</h1>
       <form action="/redirects/api-redirect-307" method="POST">
         <input type="submit" value="Submit" id="submit-api-redirect-307" />
       </form>
-      <h1>POST /api-reponse-redirect-308</h1>
+      <h1>POST /api-response-redirect-308</h1>
       <form action="/redirects/api-redirect-308" method="POST">
         <input type="submit" value="Submit" id="submit-api-redirect-308" />
       </form>

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -20,7 +20,7 @@ describe('app a11y features', () => {
       )
     }
 
-    it('should not announce the initital title', async () => {
+    it('should not announce the initial title', async () => {
       const browser = await next.browser('/page-with-h1')
       await check(() => getAnnouncerContent(browser), '')
     })

--- a/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
+++ b/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
@@ -40,7 +40,7 @@ describe('custom-app-server-action-redirect', () => {
     expect(await getCount()).toBe('Count: 2')
   })
 
-  it('redirects with proper cookies set from both redirect response and post respose', async () => {
+  it('redirects with proper cookies set from both redirect response and post response', async () => {
     const browser = await next.browser('/base')
 
     await browser.elementById('submit-server-action-redirect').click()

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -251,7 +251,7 @@ describe('app-dir static/dynamic handling', () => {
       })
     })
 
-    it('force-dynamic should supercede a "default" cache value', async () => {
+    it('force-dynamic should supersede a "default" cache value', async () => {
       const $ = await next.render$('/force-dynamic-fetch-cache/default-cache')
       const initData = $('#data').text()
       await retry(async () => {
@@ -276,7 +276,7 @@ describe('app-dir static/dynamic handling', () => {
       })
     })
 
-    it('fetchCache config should supercede dynamic config when force-dynamic is used', async () => {
+    it('fetchCache config should supersede dynamic config when force-dynamic is used', async () => {
       const $ = await next.render$(
         '/force-dynamic-fetch-cache/with-fetch-cache'
       )
@@ -303,7 +303,7 @@ describe('app-dir static/dynamic handling', () => {
       })
     })
 
-    it('fetch `cache` should supercede dynamic config when force-dynamic is used', async () => {
+    it('fetch `cache` should supersede dynamic config when force-dynamic is used', async () => {
       const $ = await next.render$('/force-dynamic-fetch-cache/force-cache')
       const initData = $('#data').text()
       await retry(async () => {

--- a/test/e2e/app-dir/cache-components/app/cases/fetch_cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/fetch_cached/page.tsx
@@ -8,7 +8,7 @@ export default async function Page() {
         This page renders two components each performing one or more cached
         fetches. There is no uncached IO in this example
       </p>
-      <p>Niether component is wrapped in a Suspense boundary.</p>
+      <p>Neither component is wrapped in a Suspense boundary.</p>
       <p>With PPR this page should be entirely static.</p>
       <p>Without PPR this page should be static.</p>
       <ComponentOne />

--- a/test/e2e/app-dir/cache-components/app/cases/full_cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/full_cached/page.tsx
@@ -13,7 +13,7 @@ export default async function Page({
         This page renders two components. Both call a simulated IO function. The
         whole page is wrapped in "use cache".
       </p>
-      <p>Niether component is wrapped in a Suspense boundary</p>
+      <p>Neither component is wrapped in a Suspense boundary</p>
       <p>
         With PPR this page should be entirely static because all IO is cached.
       </p>

--- a/test/e2e/app-dir/cache-components/app/cases/io_cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/io_cached/page.tsx
@@ -10,7 +10,7 @@ export default async function Page() {
         This page renders two components. Both call a simulated IO function
         wrapped in `unstable_cache`.
       </p>
-      <p>Niether component is wrapped in a Suspense boundary</p>
+      <p>Neither component is wrapped in a Suspense boundary</p>
       <p>
         With PPR this page should be entirely static because all IO is cached.
       </p>

--- a/test/e2e/app-dir/cache-components/app/cases/use_cache_cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/use_cache_cached/page.tsx
@@ -8,7 +8,7 @@ export default async function Page() {
         This page renders two components. Both call a simulated IO function
         wrapped in `"use cache"`.
       </p>
-      <p>Niether component is wrapped in a Suspense boundary</p>
+      <p>Neither component is wrapped in a Suspense boundary</p>
       <p>
         With PPR this page should be entirely static because all IO is cached.
       </p>

--- a/test/e2e/app-dir/draft-mode/draft-mode.test.ts
+++ b/test/e2e/app-dir/draft-mode/draft-mode.test.ts
@@ -7,8 +7,8 @@ describe('app dir - draft mode', () => {
   })
 
   async function runTests({ basePath = '/' }: { basePath: string }) {
-    let origRandHome = 'unintialized'
-    let origRandWithCookies = 'unintialized'
+    let origRandHome = 'uninitialized'
+    let origRandWithCookies = 'uninitialized'
     let Cookie = ''
 
     it(`should use initial rand when draft mode is disabled on ${basePath}index`, async () => {

--- a/test/e2e/app-dir/hooks/hooks.test.ts
+++ b/test/e2e/app-dir/hooks/hooks.test.ts
@@ -76,7 +76,7 @@ describe('app dir - hooks', () => {
   })
 
   describe('useDraftMode', () => {
-    let initialRand = 'unintialized'
+    let initialRand = 'uninitialized'
     it('should use initial rand when draft mode be disabled', async () => {
       const $ = await next.render$('/hooks/use-draft-mode')
       expect($('#draft-mode-val').text()).toBe('DISABLED')

--- a/test/e2e/app-dir/monaco-editor/components/editor/editor.tsx
+++ b/test/e2e/app-dir/monaco-editor/components/editor/editor.tsx
@@ -35,7 +35,7 @@ export function Editor() {
   const editorRef = useRef<HTMLDivElement>(null)
   return (
     <>
-      <Suspense fallback="initalizing monaco">
+      <Suspense fallback="initializing monaco">
         <LazyMonaco editorRef={editorRef} />
         <div id="editor" ref={editorRef} className="h-full" />
       </Suspense>

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -688,7 +688,7 @@ describe('app dir - navigation', () => {
       // this test is pretty hard to test in playwright, so most of the heavy lifting is in the page component itself
       // it triggers a hover on a link to initiate a prefetch request every second, and so we check that
       // it doesn't repeatedly initiate the mpa navigation request
-      it('should not continously initiate a mpa navigation to the same URL when router state changes', async () => {
+      it('should not continuously initiate a mpa navigation to the same URL when router state changes', async () => {
         let requestCount = 0
         await next.browser('/mpa-nav-test', {
           beforePageLoad(page) {

--- a/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
+++ b/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
@@ -12,7 +12,7 @@ describe('Node Extensions', () => {
         return
       }
 
-      it('should not error when accessing middlware that use Math.random()', async () => {
+      it('should not error when accessing middleware that use Math.random()', async () => {
         let res: Awaited<ReturnType<typeof next.fetch>>,
           $: Awaited<ReturnType<typeof next.render$>>
 
@@ -160,7 +160,7 @@ describe('Node Extensions', () => {
         return
       }
 
-      it('should not error when accessing middlware that use Math.random()', async () => {
+      it('should not error when accessing middleware that use Math.random()', async () => {
         let res, $
 
         res = await next.fetch('/rewrite')

--- a/test/e2e/app-dir/resource-url-encoding/app/page.tsx
+++ b/test/e2e/app-dir/resource-url-encoding/app/page.tsx
@@ -1,6 +1,6 @@
-import Compoment from './client#component'
+import Component from './client#component'
 import '../my@style.css'
 
 export default function Page() {
-  return <Compoment />
+  return <Component />
 }

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -408,7 +408,7 @@ describe('segment cache (incremental opt in)', () => {
 
       // Then initiate a prefetch for the PPR-enabled route.
       await act(async () => {
-        // Create an inner act scope so we initate a prefetch but block it
+        // Create an inner act scope so we initiate a prefetch but block it
         // from responding.
         await act(
           async () => {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
@@ -682,7 +682,7 @@ describe('<Link prefetch={true}> (runtime prefetch)', () => {
       {
         // If a cache has an expiration time under 5min (DYNAMIC_EXPIRE), we omit it from static prerenders.
         // However, it should still be included in a runtime prefetch if its stale time is >=30s. (RUNTIME_PREFETCH_DYNAMIC_STALE)
-        // `cacheLife("seconds")` is deliberately set to have a stale time of 30s to stay above this treshold.
+        // `cacheLife("seconds")` is deliberately set to have a stale time of 30s to stay above this threshold.
         description: 'includes public caches with cacheLife("seconds")',
         staticContent: 'This page uses a short-lived public cache',
         path: '/caches/public-seconds',
@@ -690,7 +690,7 @@ describe('<Link prefetch={true}> (runtime prefetch)', () => {
       {
         // A Private cache will always be omitted from static prerenders.
         // However, it should still be included in a runtime prefetch if its stale time is >=30s. (RUNTIME_PREFETCH_DYNAMIC_STALE)
-        // `cacheLife("seconds")` is deliberately set to have a stale time of 30s to stay above this treshold.
+        // `cacheLife("seconds")` is deliberately set to have a stale time of 30s to stay above this threshold.
         description: 'includes private caches with cacheLife("seconds")',
         staticContent: 'This page uses a short-lived private cache',
         path: '/caches/private-seconds',

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -89,7 +89,7 @@ describe('segment cache (revalidation)', () => {
     await act(async () => {
       const link = await browser.elementByCss('a[href="/greeting"]')
       await link.click()
-      // Navigation should finish immedately because the page is
+      // Navigation should finish immediately because the page is
       // fully prefetched.
       const greeting = await browser.elementById('greeting')
       expect(await greeting.innerHTML()).toBe('random-greeting [1]')
@@ -142,7 +142,7 @@ describe('segment cache (revalidation)', () => {
         'form[action="/greeting"] button'
       )
       await button.click()
-      // Navigation should finish immedately because the page is
+      // Navigation should finish immediately because the page is
       // fully prefetched.
       const greeting = await browser.elementById('greeting')
       expect(await greeting.innerHTML()).toBe('random-greeting [1]')
@@ -193,7 +193,7 @@ describe('segment cache (revalidation)', () => {
     await act(async () => {
       const link = await browser.elementByCss('a[href="/greeting"]')
       await link.click()
-      // Navigation should finish immedately because the page is
+      // Navigation should finish immediately because the page is
       // fully prefetched.
       const greeting = await browser.elementById('greeting')
       expect(await greeting.innerHTML()).toBe('random-greeting [1]')
@@ -240,7 +240,7 @@ describe('segment cache (revalidation)', () => {
     await act(async () => {
       const link = await browser.elementByCss('a[href="/greeting"]')
       await link.click()
-      // Navigation should finish immedately because the page is
+      // Navigation should finish immediately because the page is
       // fully prefetched.
       const greeting = await browser.elementById('greeting')
       expect(await greeting.innerHTML()).toBe('random-greeting [1]')

--- a/test/e2e/app-document/client.test.ts
+++ b/test/e2e/app-document/client.test.ts
@@ -84,14 +84,14 @@ describe('Document and App - Client side', () => {
 
       const randomNumber = await browser.elementByCss('#random-number').text()
 
-      const switchedRandomNumer = await browser
+      const switchedRandomNumber = await browser
         .elementByCss('#about-link')
         .click()
         .waitForElementByCss('.page-about')
         .elementByCss('#random-number')
         .text()
 
-      expect(switchedRandomNumer).toBe(randomNumber)
+      expect(switchedRandomNumber).toBe(randomNumber)
       await browser.close()
     })
   }

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -384,7 +384,7 @@ describe.each([
     expect(res2.headers.get('X-From-Middleware')).toBe('true')
   })
 
-  it('adds the header for a mathed root path with /index', async () => {
+  it('adds the header for a matched root path with /index', async () => {
     const res1 = await fetchViaHTTP(next.url, `/index`)
     expect(await res1.text()).toContain(`(en) Hello from /`)
     expect(res1.headers.get('X-From-Middleware')).toBe('true')
@@ -489,7 +489,7 @@ describe.each([
       expect(res2.headers.get('X-From-Middleware')).toBe('true')
     })
 
-    it('adds the header for a mathed root path with /index', async () => {
+    it('adds the header for a matched root path with /index', async () => {
       const res1 = await fetchViaHTTP(next.url, `/root/index`)
       expect(await res1.text()).toContain(`(en) Hello from /`)
       expect(res1.headers.get('X-From-Middleware')).toBe('true')

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -843,7 +843,7 @@ describe('Middleware Rewrite', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/rewrite-me-to-vercel`)
       const html = await res.text()
       // const browser = await webdriver(next.url, '/rewrite-me-to-vercel')
-      // TODO: running this to chech the window.location.pathname hangs for some reason;
+      // TODO: running this to check the window.location.pathname hangs for some reason;
       expect(html).toContain('Example Domain')
     })
 

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -354,7 +354,7 @@ describe('empty strategy in document body', () => {
     describe('experimental.nextScriptWorkers: true with required Partytown dependency for inline script', () => {
       let next: NextInstance
 
-      // Note: previously we were using `finally` cluase inside of test assertion. However, if the test times out
+      // Note: previously we were using `finally` clause inside of test assertion. However, if the test times out
       // exceeding jest.setTimeout() value, the finally clause is not executed and subsequent tests will fail due to
       // hanging next instance.
       afterEach(async () => {

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/rsc-fetch/edge/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/rsc-fetch/edge/page.tsx
@@ -9,5 +9,5 @@ export async function generateMetadata() {
 
 export default async function Page() {
   const data = await fetch('https://example.vercel.sh')
-  return <pre>RESONSE: {data.status}</pre>
+  return <pre>RESPONSE: {data.status}</pre>
 }

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -122,7 +122,7 @@ describe('testmode', () => {
   })
 
   describe('middleware', () => {
-    it('should intercept fetchs in middleware', async () => {
+    it('should intercept fetches in middleware', async () => {
       const resp = await fetchForTest('/app/rsc-fetch')
       expect(resp.headers.get('x-middleware-fetch')).toEqual('middleware-test1')
     })

--- a/test/e2e/trailing-slashes/basepath.test.ts
+++ b/test/e2e/trailing-slashes/basepath.test.ts
@@ -7,7 +7,7 @@ import {
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
 // we don't need to exhaustively test this, just do some basic sanity checks
-// for use in combiantion with basePath
+// for use in combination with basePath
 ;(isNextDev ? describe : describe.skip)(
   'Trailing slashes in development mode, with basepath, trailingSlash: true',
   () => {

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -82,7 +82,7 @@ describe('transpile packages', () => {
       )
     })
 
-    it('should hide dynammic module dependency errors from node_modules', async () => {
+    it('should hide dynamic module dependency errors from node_modules', async () => {
       expect(next.cliOutput).not.toContain(
         'Critical dependency: the request of a dependency is an expression'
       )

--- a/test/examples/examples.test.ts
+++ b/test/examples/examples.test.ts
@@ -40,7 +40,7 @@ const testedExamples = [
 
 describe.each(testedExamples)(`example '%s'`, (example) => {
   // If there is an issue during a build, jest won't tell us which example caused it
-  // we need to log it ourselfs
+  // we need to log it ourselves
   beforeAll(() => {
     require('console').log(`Running example '${example}'`)
   })

--- a/test/integration/absolute-assetprefix/test/index.test.js
+++ b/test/integration/absolute-assetprefix/test/index.test.js
@@ -44,7 +44,7 @@ describe('absolute assetPrefix with path prefix', () => {
               // [NOTE] if socket doesn't have a handler to error event and if error
               // event leaks, node.js ends its process with errored exit code.
               // However, there can be failing socket event while running test
-              // as long as assertion is correct, do not care indiviual socket errors.
+              // as long as assertion is correct, do not care individual socket errors.
               proxyRes.on('error', (e) => {
                 require('console').error(e)
               })

--- a/test/integration/custom-routes/pages/overridden/[slug].js
+++ b/test/integration/custom-routes/pages/overridden/[slug].js
@@ -1,5 +1,5 @@
 export default function Page() {
-  return <p>/overriden/[slug]</p>
+  return <p>/overridden/[slug]</p>
 }
 
 export function getStaticProps({ params }) {

--- a/test/integration/edge-runtime-dynamic-code/lib/utils.js
+++ b/test/integration/edge-runtime-dynamic-code/lib/utils.js
@@ -2,8 +2,8 @@ export const useCases = {
   eval: 'using-eval',
   noEval: 'not-using-eval',
   wasmCompile: 'using-webassembly-compile',
-  wasmInstanciate: 'using-webassembly-instantiate',
-  wasmBufferInstanciate: 'using-webassembly-instantiate-with-buffer',
+  wasmInstantiate: 'using-webassembly-instantiate',
+  wasmBufferInstantiate: 'using-webassembly-instantiate-with-buffer',
 }
 
 export async function usingEval() {

--- a/test/integration/edge-runtime-dynamic-code/middleware.js
+++ b/test/integration/edge-runtime-dynamic-code/middleware.js
@@ -25,13 +25,13 @@ export async function middleware(request) {
     })
   }
 
-  if (request.nextUrl.pathname === `/${useCases.wasmInstanciate}`) {
+  if (request.nextUrl.pathname === `/${useCases.wasmInstantiate}`) {
     return new Response(null, {
       headers: { data: JSON.stringify(await usingWebAssemblyInstantiate(9)) },
     })
   }
 
-  if (request.nextUrl.pathname === `/${useCases.wasmBufferInstanciate}`) {
+  if (request.nextUrl.pathname === `/${useCases.wasmBufferInstantiate}`) {
     return new Response(null, {
       headers: {
         data: JSON.stringify(await usingWebAssemblyInstantiateWithBuffer(9)),

--- a/test/integration/edge-runtime-dynamic-code/pages/api/route.js
+++ b/test/integration/edge-runtime-dynamic-code/pages/api/route.js
@@ -15,9 +15,9 @@ export default async function handler(request) {
         ? await notUsingEval()
         : useCase === useCases.wasmCompile
           ? await usingWebAssemblyCompile(9)
-          : useCase === useCases.wasmInstanciate
+          : useCase === useCases.wasmInstantiate
             ? await usingWebAssemblyInstantiate(9)
-            : useCase === useCases.wasmBufferInstanciate
+            : useCase === useCases.wasmBufferInstantiate
               ? await usingWebAssemblyInstantiateWithBuffer(9)
               : { ok: true }
   )

--- a/test/integration/gip-identifier/test/index.test.js
+++ b/test/integration/gip-identifier/test/index.test.js
@@ -27,7 +27,7 @@ const runTests = (isDev) => {
       app = await launchApp(appDir, appPort)
     } else {
       const { code } = await nextBuild(appDir)
-      if (code !== 0) throw new Error(`build faild, exit code: ${code}`)
+      if (code !== 0) throw new Error(`build failed, exit code: ${code}`)
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
     }

--- a/test/integration/i18n-support-catchall/pages/[[...slug]].js
+++ b/test/integration/i18n-support-catchall/pages/[[...slug]].js
@@ -6,7 +6,7 @@ export default function Page(props) {
 
   return (
     <>
-      <p id="catch-alll">catch-all page</p>
+      <p id="catch-all">catch-all page</p>
       <p id="props">{JSON.stringify(props)}</p>
       <p id="router-locale">{router.locale}</p>
       <p id="router-default-locale">{router.defaultLocale}</p>

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -2686,7 +2686,7 @@ export function runTests(ctx) {
     // expect(result2.query).toEqual({})
   })
 
-  // ('should set locale cookie when removing default locale and accept-lang doesnt match', async () => {
+  // ("should set locale cookie when removing default locale and accept-lang doesn't match", async () => {
   //   const res = await fetchViaHTTP(ctx.appPort, '/en-US', undefined, {
   //     headers: {
   //       'accept-language': 'nl',

--- a/test/integration/invalid-multi-match/test/index.test.js
+++ b/test/integration/invalid-multi-match/test/index.test.js
@@ -16,7 +16,7 @@ let appPort
 let app
 
 const runTests = () => {
-  it('should show error for invalid mulit-match', async () => {
+  it('should show error for invalid multi-match', async () => {
     await renderViaHTTP(appPort, '/random')
     expect(stderr).toContain(
       'To use a multi-match in the destination you must add'

--- a/test/integration/next-dynamic-css-asset-prefix/test/index.test.js
+++ b/test/integration/next-dynamic-css-asset-prefix/test/index.test.js
@@ -75,7 +75,7 @@ describe('next/dynamic with assetPrefix', () => {
               // [NOTE] if socket doesn't have a handler to error event and if error
               // event leaks, node.js ends its process with errored exit code.
               // However, there can be failing socket event while running test
-              // as long as assertion is correct, do not care indiviual socket errors.
+              // as long as assertion is correct, do not care individual socket errors.
               proxyRes.on('error', (e) => {
                 require('console').error(e)
               })
@@ -132,7 +132,7 @@ describe('next/dynamic with assetPrefix', () => {
               // [NOTE] if socket doesn't have a handler to error event and if error
               // event leaks, node.js ends its process with errored exit code.
               // However, there can be failing socket event while running test
-              // as long as assertion is correct, do not care indiviual socket errors.
+              // as long as assertion is correct, do not care individual socket errors.
               proxyRes.on('error', (e) => {
                 require('console').error(e)
               })

--- a/test/integration/next-image-legacy/default/pages/invalid-loader.js
+++ b/test/integration/next-image-legacy/default/pages/invalid-loader.js
@@ -4,7 +4,7 @@ import Image from 'next/legacy/image'
 const Page = () => {
   return (
     <div>
-      <h1>Warn for this loader that doesnt use width</h1>
+      <h1>Warn for this loader that doesn't use width</h1>
       <Image
         id="no-width"
         src="/test.png"

--- a/test/integration/next-image-legacy/react-virtualized/test/index.test.ts
+++ b/test/integration/next-image-legacy/react-virtualized/test/index.test.ts
@@ -63,7 +63,7 @@ describe('react-virtualized wrapping next/legacy/image', () => {
       })
 
       it('should not cancel requests for images', async () => {
-        // TODO: this test doesnt work unless we can set `disableCache: true`
+        // TODO: this test doesn't work unless we can set `disableCache: true`
         let browser = await webdriver(appPort, '/', {
           disableCache: true,
         })

--- a/test/integration/next-image-new/app-dir/app/invalid-loader/page.js
+++ b/test/integration/next-image-new/app-dir/app/invalid-loader/page.js
@@ -5,7 +5,7 @@ import Image from 'next/image'
 const Page = () => {
   return (
     <div>
-      <h1>Warn for this loader that doesnt use width</h1>
+      <h1>Warn for this loader that doesn't use width</h1>
       <Image
         id="no-width"
         src="/test.png"

--- a/test/integration/next-image-new/app-dir/app/static-img/page.js
+++ b/test/integration/next-image-new/app-dir/app/static-img/page.js
@@ -22,7 +22,7 @@ const blurDataURL =
 const shimmer = `data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjIwMCIgaGVpZ2h0PSIyMDAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImciPgogICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMzMzIiBvZmZzZXQ9IjIwJSIgLz4KICAgICAgPHN0b3Agc3RvcC1jb2xvcj0iIzIyMiIgb2Zmc2V0PSI1MCUiIC8+CiAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMzMzMiIG9mZnNldD0iNzAlIiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIyMDAiIGZpbGw9IiMzMzMiIC8+CiAgPHJlY3QgaWQ9InIiIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJ1cmwoI2cpIiAvPgogIDxhbmltYXRlIHhsaW5rOmhyZWY9IiNyIiBhdHRyaWJ1dGVOYW1lPSJ4IiBmcm9tPSItMjAwIiB0bz0iMjAwIiBkdXI9IjFzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgIC8+Cjwvc3ZnPg==`
 
 const Page = async () => {
-  // We wait a task to allow React to flush headers before we render images becuase
+  // We wait a task to allow React to flush headers before we render images because
   // these tests are asserting tag behavior. We really should be resilient to link
   // headers in these tests but there is a larger concern about whether React should
   // even be hoisting image preloads to link headers if the image uses srcset or sizes.

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -393,7 +393,7 @@ function runTests(mode: 'dev' | 'server') {
     }
   })
 
-  it('should callback native onLoad with sythetic event', async () => {
+  it('should callback native onLoad with synthetic event', async () => {
     let browser = await webdriver(appPort, '/on-load')
 
     await browser.eval(

--- a/test/integration/next-image-new/default/pages/invalid-loader.js
+++ b/test/integration/next-image-new/default/pages/invalid-loader.js
@@ -4,7 +4,7 @@ import Image from 'next/image'
 const Page = () => {
   return (
     <div>
-      <h1>Warn for this loader that doesnt use width</h1>
+      <h1>Warn for this loader that doesn't use width</h1>
       <Image
         id="no-width"
         src="/test.png"

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -395,7 +395,7 @@ function runTests(mode) {
     }
   })
 
-  it('should callback native onLoad with sythetic event', async () => {
+  it('should callback native onLoad with synthetic event', async () => {
     let browser = await webdriver(appPort, '/on-load')
 
     await browser.eval(

--- a/test/integration/next-image-new/react-virtualized/test/index.test.ts
+++ b/test/integration/next-image-new/react-virtualized/test/index.test.ts
@@ -63,7 +63,7 @@ describe('react-virtualized wrapping next/image', () => {
       })
 
       it('should not cancel requests for images', async () => {
-        // TODO: this test doesnt work unless we can set `disableCache: true`
+        // TODO: this test doesn't work unless we can set `disableCache: true`
         let browser = await webdriver(appPort, '/', {
           disableCache: true,
         })

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -270,7 +270,7 @@ describe('config telemetry', () => {
 
       // Turbopack intentionally does not support these events
       ;(process.env.IS_TURBOPACK_TEST ? it.skip : it)(
-        'emits telemery for usage of image, script & dynamic',
+        'emits telemetry for usage of image, script & dynamic',
         async () => {
           const { stderr } = await nextBuild(appDir, [], {
             stderr: true,

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -27,7 +27,7 @@ declare global {
        * If the project root appears in the snapshot, pass in the `NextInstance`
        * as well to normalize the snapshot e.g. `await expect({ browser, next }).toDisplayRedbox()`.
        *
-       * Unintented content in the snapshot should be reported to the Next.js DX team.
+       * Unintended content in the snapshot should be reported to the Next.js DX team.
        * `<FIXME-internal-frame>` in the snapshot would be unintended.
        * `<FIXME-project-root>` in the snapshot would be unintended.
        * `<FIXME-file-protocol>` in the snapshot would be unintended.
@@ -50,7 +50,7 @@ declare global {
        * If the project root appears in the snapshot, pass in the `NextInstance`
        * as well to normalize the snapshot e.g. `await expect({ browser, next }).toDisplayCollapsedRedbox()`.
        *
-       * Unintented content in the snapshot should be reported to the Next.js DX team.
+       * Unintended content in the snapshot should be reported to the Next.js DX team.
        * `<FIXME-internal-frame>` in the snapshot would be unintended.
        * `<FIXME-project-root>` in the snapshot would be unintended.
        * `<FIXME-file-protocol>` in the snapshot would be unintended.

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -145,7 +145,7 @@ const setupTracing = () => {
 
   setGlobal('distDir', './test/.trace')
   // This is a hacky way to use tracing utils even for tracing test utils.
-  // We want the same treatment as DEVELOPMENT_SERVER - adds a reasonable treshold for logs size.
+  // We want the same treatment as DEVELOPMENT_SERVER - adds a reasonable threshold for logs size.
   setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
 }
 

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1425,7 +1425,7 @@ export function findAllTelemetryEvents(output: string, eventName: string) {
 type TestVariants = 'default' | 'turbo'
 
 // WEB-168: There are some differences / incompletes in turbopack implementation enforces jest requires to update
-// test snapshot when run against turbo. This fn returns describe, or describe.skip dependes on the running context
+// test snapshot when run against turbo. This fn returns describe, or describe.skip depends on the running context
 // to avoid force-snapshot update per each runs until turbopack update includes all the changes.
 export function getSnapshotTestDescribe(variant: TestVariants) {
   const runningEnv = variant ?? 'default'

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -808,7 +808,7 @@ describe('required server files i18n', () => {
     expect($('#index').text()).toBe('index page')
   })
 
-  it('should match the root dyanmic page correctly', async () => {
+  it('should match the root dynamic page correctly', async () => {
     const res = await fetchViaHTTP(appPort, '/slug-1', undefined, {
       headers: {
         'x-matched-path': '/[slug]',

--- a/test/production/typescript-basic/typechecking.test.ts
+++ b/test/production/typescript-basic/typechecking.test.ts
@@ -21,7 +21,7 @@ describe('typechecking', () => {
     if (status !== 0) {
       // Piped output is incomplete and the format barely useable.
       // Printing it as a last resort in case it's not reproducible locally.
-      // Best to NEXT_TEST_SKIP_CLEANUP=1 this test and run the command in the app localy.
+      // Best to NEXT_TEST_SKIP_CLEANUP=1 this test and run the command in the app locally.
       throw new Error('Typecheck failed: \n' + stdout)
     }
   })

--- a/test/production/typescript-basic/typechecking/index.ts
+++ b/test/production/typescript-basic/typechecking/index.ts
@@ -13,7 +13,7 @@ import 'next/head'
 import 'next/headers'
 import 'next/image'
 import 'next'
-// TODO @jest/types is an undeclared peer dependecy
+// TODO @jest/types is an undeclared peer dependency
 // import 'next/jest';
 import 'next/link'
 import 'next/navigation'

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -369,7 +369,7 @@
       "app a11y features route announcer should announce document.title changes",
       "app a11y features route announcer should announce h1 changes",
       "app a11y features route announcer should announce route changes when h1 changes inside an inner layout",
-      "app a11y features route announcer should not announce the initital title"
+      "app a11y features route announcer should not announce the initial title"
     ],
     "failed": [],
     "pending": [],
@@ -391,7 +391,7 @@
   "test/e2e/app-dir/app-basepath-custom-server/index.test.ts": {
     "passed": [
       "custom-app-server-action-redirect redirects with basepath properly when server action handler uses `redirect`",
-      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post respose"
+      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post response"
     ],
     "failed": [],
     "pending": [],
@@ -1098,9 +1098,9 @@
   "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts": {
     "passed": [
       "app-dir static/dynamic handling Incremental cache limits should cache large data when using custom cache handler and force-cache mode",
-      "app-dir static/dynamic handling fetch `cache` should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling fetchCache config should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling force-dynamic should supercede a \"default\" cache value",
+      "app-dir static/dynamic handling fetch `cache` should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling fetchCache config should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling force-dynamic should supersede a \"default\" cache value",
       "app-dir static/dynamic handling should allow dynamic routes to access cookies",
       "app-dir static/dynamic handling should build dynamic param with edge runtime correctly",
       "app-dir static/dynamic handling should cache correctly for cache: \"force-cache\" and \"revalidate\"",
@@ -1199,9 +1199,9 @@
   "test/e2e/app-dir/app-static/app-static.test.ts": {
     "passed": [
       "app-dir static/dynamic handling Incremental cache limits should load data only at build time even if response data size is greater than 2MB and FetchCache is possible",
-      "app-dir static/dynamic handling fetch `cache` should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling fetchCache config should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling force-dynamic should supercede a \"default\" cache value",
+      "app-dir static/dynamic handling fetch `cache` should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling fetchCache config should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling force-dynamic should supersede a \"default\" cache value",
       "app-dir static/dynamic handling it should revalidate correctly with edge route handler",
       "app-dir static/dynamic handling it should revalidate correctly with node route handler",
       "app-dir static/dynamic handling it should revalidate tag correctly with edge route handler",
@@ -3707,7 +3707,7 @@
       "app dir - navigation navigating to dynamic params & changing the casing should load the page correctly",
       "app dir - navigation navigation between pages and app should not contain _rsc query while navigating from app to pages",
       "app dir - navigation navigation between pages and app should not contain _rsc query while navigating from pages to app",
-      "app dir - navigation navigation between pages and app should not continously initiate a mpa navigation to the same URL when router state changes",
+      "app dir - navigation navigation between pages and app should not continuously initiate a mpa navigation to the same URL when router state changes",
       "app dir - navigation navigation between pages and app should not omit the hash while navigating from app to pages",
       "app dir - navigation navigations when attaching a Proxy to `window.Promise` should navigate without issue",
       "app dir - navigation nested navigation should load chunks correctly without double encoding of url",
@@ -4091,12 +4091,12 @@
   },
   "test/e2e/app-dir/node-extensions/node-extensions.random.test.ts": {
     "passed": [
-      "Node Extensions Random Cache Components should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Cache Components should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in Pages Router",
-      "Node Extensions Random Legacy should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Legacy should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Legacy should not error when accessing routes that use Math.random() in App Router",
@@ -8045,18 +8045,18 @@
       "using a single matcher does not add the header for root data request",
       "using a single matcher does not add the header for root request",
       "using a single matcher with i18n adds the header for a matched path",
-      "using a single matcher with i18n adds the header for a mathed root path with /index",
+      "using a single matcher with i18n adds the header for a matched root path with /index",
       "using a single matcher with i18n adds the headers for a matched data path",
       "using a single matcher with i18n and basePath adds the header for a matched path",
-      "using a single matcher with i18n and basePath adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and basePath and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n and basePath does not add the header for an unmatched path",
       "using a single matcher with i18n and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n does not add the header for an unmatched path",
@@ -9200,7 +9200,7 @@
       "testmode app router should handle RSC with fetch in edge function",
       "testmode app router should handle RSC with fetch in serverless function",
       "testmode app router should handle RSC with http.get in serverless function",
-      "testmode middleware should intercept fetchs in middleware",
+      "testmode middleware should intercept fetches in middleware",
       "testmode page router should handle API with fetch",
       "testmode page router should handle API with http.get",
       "testmode page router should handle getServerSideProps with fetch",
@@ -9343,7 +9343,7 @@
       "transpile packages css should handle global css imports inside transpiled modules",
       "transpile packages css should handle global scss imports inside transpiled modules",
       "transpile packages css should handle scss modules imports inside transpiled modules",
-      "transpile packages optional deps should hide dynammic module dependency errors from node_modules",
+      "transpile packages optional deps should hide dynamic module dependency errors from node_modules",
       "transpile packages optional deps should not throw an error when optional deps are not installed"
     ],
     "failed": [],
@@ -16004,11 +16004,11 @@
   },
   "test/integration/invalid-multi-match/test/index.test.js": {
     "passed": [
-      "Custom routes invalid multi-match production mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match production mode should show error for invalid multi-match"
     ],
     "failed": [],
     "pending": [
-      "Custom routes invalid multi-match development mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match development mode should show error for invalid multi-match"
     ],
     "flakey": [],
     "runtimeError": false
@@ -16780,7 +16780,7 @@
       "Image Component Default Tests production mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -16824,7 +16824,7 @@
       "Image Component Default Tests development mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -17004,7 +17004,7 @@
       "Image Component Default Tests production mode should be valid HTML",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -17048,7 +17048,7 @@
       "Image Component Default Tests development mode should be valid HTML",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -18439,7 +18439,7 @@
       "config telemetry production mode detects i18n and image configs for session start",
       "config telemetry production mode detects output config for session start",
       "config telemetry production mode detects rewrites, headers, and redirects for next build",
-      "config telemetry production mode emits telemery for usage of image, script & dynamic",
+      "config telemetry production mode emits telemetry for usage of image, script & dynamic",
       "config telemetry production mode emits telemetry for `next lint`",
       "config telemetry production mode emits telemetry for configured React Compiler options",
       "config telemetry production mode emits telemetry for default React Compiler options",
@@ -20223,7 +20223,7 @@
       "required server files i18n should have the correct asPath for fallback page",
       "required server files i18n should have the correct asPath for fallback page locale",
       "required server files i18n should match the index page correctly",
-      "required server files i18n should match the root dyanmic page correctly",
+      "required server files i18n should match the root dynamic page correctly",
       "required server files i18n should normalize catch-all rewrite query values correctly",
       "required server files i18n should normalize optional values correctly for API page",
       "required server files i18n should normalize optional values correctly for SSG page",

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -2701,8 +2701,8 @@
   },
   "test/development/app-dir/edge-errors-hmr/index.test.ts": {
     "passed": [
-      "develop - app-dir - edge errros hmr should recover from build errors when client component error",
-      "develop - app-dir - edge errros hmr should recover from build errors when server component error"
+      "develop - app-dir - edge errors hmr should recover from build errors when client component error",
+      "develop - app-dir - edge errors hmr should recover from build errors when server component error"
     ],
     "failed": [],
     "pending": [],
@@ -3106,7 +3106,7 @@
       "app-dir-hmr filesystem changes can navigate cleanly to a page that requires a change in the Webpack runtime",
       "app-dir-hmr filesystem changes should have no unexpected action error for hmr",
       "app-dir-hmr filesystem changes should not break when renaming a folder",
-      "app-dir-hmr filesystem changes should not continously poll when hitting a not found page",
+      "app-dir-hmr filesystem changes should not continuously poll when hitting a not found page",
       "app-dir-hmr filesystem changes should update server components after navigating to a page with a different runtime"
     ],
     "failed": [],
@@ -3277,7 +3277,7 @@
     ],
     "failed": [
       "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"\"} should detect runtime errors on the module scope",
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"\"} should not continuously poll a custom error page"
     ],
     "pending": [],
     "flakey": [],
@@ -3301,7 +3301,7 @@
     ],
     "failed": [
       "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"/asset-prefix\"} should detect runtime errors on the module scope",
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"/asset-prefix\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"/asset-prefix\"} should not continuously poll a custom error page"
     ],
     "pending": [],
     "flakey": [],
@@ -3325,7 +3325,7 @@
     ],
     "failed": [
       "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"\"} should detect runtime errors on the module scope",
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"\"} should not continuously poll a custom error page"
     ],
     "pending": [],
     "flakey": [],
@@ -3349,7 +3349,7 @@
     ],
     "failed": [
       "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"/asset-prefix\"} should detect runtime errors on the module scope",
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"/asset-prefix\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"/asset-prefix\"} should not continuously poll a custom error page"
     ],
     "pending": [],
     "flakey": [],
@@ -3907,7 +3907,7 @@
       "middlewares does not warn when populating response with a function call",
       "middlewares does not warn when populating response with a value",
       "middlewares does not warn when populating response with an async function call",
-      "middlewares does not warn when returning null reponse body",
+      "middlewares does not warn when returning null response body",
       "middlewares does not warn when returning response with JSON.stringify",
       "middlewares does not warn when returning response with literal number",
       "middlewares does not warn when returning response with literal string",
@@ -4711,7 +4711,7 @@
       "app a11y features route announcer should announce document.title changes",
       "app a11y features route announcer should announce h1 changes",
       "app a11y features route announcer should announce route changes when h1 changes inside an inner layout",
-      "app a11y features route announcer should not announce the initital title"
+      "app a11y features route announcer should not announce the initial title"
     ],
     "failed": [],
     "pending": [],
@@ -4731,7 +4731,7 @@
   "test/e2e/app-dir/app-basepath-custom-server/index.test.ts": {
     "passed": [
       "custom-app-server-action-redirect redirects with basepath properly when server action handler uses `redirect`",
-      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post respose"
+      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post response"
     ],
     "failed": [],
     "pending": [],
@@ -8206,12 +8206,12 @@
   },
   "test/e2e/app-dir/node-extensions/node-extensions.random.test.ts": {
     "passed": [
-      "Node Extensions Random Cache Components should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Cache Components should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in Pages Router",
-      "Node Extensions Random Legacy should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Legacy should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Legacy should not error when accessing routes that use Math.random() in App Router",
@@ -11859,18 +11859,18 @@
       "using a single matcher does not add the header for root data request",
       "using a single matcher does not add the header for root request",
       "using a single matcher with i18n adds the header for a matched path",
-      "using a single matcher with i18n adds the header for a mathed root path with /index",
+      "using a single matcher with i18n adds the header for a matched root path with /index",
       "using a single matcher with i18n adds the headers for a matched data path",
       "using a single matcher with i18n and basePath adds the header for a matched path",
-      "using a single matcher with i18n and basePath adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and basePath and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n and basePath does not add the header for an unmatched path",
       "using a single matcher with i18n and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n does not add the header for an unmatched path",
@@ -12976,7 +12976,7 @@
       "testmode app router should handle RSC with fetch in edge function",
       "testmode app router should handle RSC with fetch in serverless function",
       "testmode app router should handle RSC with http.get in serverless function",
-      "testmode middleware should intercept fetchs in middleware",
+      "testmode middleware should intercept fetches in middleware",
       "testmode page router should handle API with fetch",
       "testmode page router should handle API with http.get",
       "testmode page router should handle getServerSideProps with fetch",
@@ -13121,7 +13121,7 @@
       "transpile packages css should handle global css imports inside transpiled modules",
       "transpile packages css should handle global scss imports inside transpiled modules",
       "transpile packages css should handle scss modules imports inside transpiled modules",
-      "transpile packages optional deps should hide dynammic module dependency errors from node_modules",
+      "transpile packages optional deps should hide dynamic module dependency errors from node_modules",
       "transpile packages optional deps should not throw an error when optional deps are not installed"
     ],
     "failed": [],
@@ -19780,11 +19780,11 @@
   },
   "test/integration/invalid-multi-match/test/index.test.js": {
     "passed": [
-      "Custom routes invalid multi-match development mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match development mode should show error for invalid multi-match"
     ],
     "failed": [],
     "pending": [
-      "Custom routes invalid multi-match production mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match production mode should show error for invalid multi-match"
     ],
     "flakey": [],
     "runtimeError": false
@@ -20560,7 +20560,7 @@
       "Image Component Default Tests development mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -20623,7 +20623,7 @@
       "Image Component Default Tests production mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -20783,7 +20783,7 @@
       "Image Component Default Tests development mode should be valid HTML",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -20844,7 +20844,7 @@
       "Image Component Default Tests production mode should be valid HTML",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -22225,7 +22225,7 @@
       "config telemetry production mode detects i18n and image configs for session start",
       "config telemetry production mode detects output config for session start",
       "config telemetry production mode detects rewrites, headers, and redirects for next build",
-      "config telemetry production mode emits telemery for usage of image, script & dynamic",
+      "config telemetry production mode emits telemetry for usage of image, script & dynamic",
       "config telemetry production mode emits telemetry for `next lint`",
       "config telemetry production mode emits telemetry for configured React Compiler options",
       "config telemetry production mode emits telemetry for default React Compiler options",

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -368,7 +368,7 @@
       "app a11y features route announcer should announce document.title changes",
       "app a11y features route announcer should announce h1 changes",
       "app a11y features route announcer should announce route changes when h1 changes inside an inner layout",
-      "app a11y features route announcer should not announce the initital title"
+      "app a11y features route announcer should not announce the initial title"
     ],
     "failed": [],
     "pending": [],
@@ -390,7 +390,7 @@
   "test/e2e/app-dir/app-basepath-custom-server/index.test.ts": {
     "passed": [
       "custom-app-server-action-redirect redirects with basepath properly when server action handler uses `redirect`",
-      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post respose"
+      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post response"
     ],
     "failed": [],
     "pending": [],
@@ -1042,9 +1042,9 @@
   "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts": {
     "passed": [
       "app-dir static/dynamic handling Incremental cache limits should cache large data when using custom cache handler and force-cache mode",
-      "app-dir static/dynamic handling fetch `cache` should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling fetchCache config should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling force-dynamic should supercede a \"default\" cache value",
+      "app-dir static/dynamic handling fetch `cache` should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling fetchCache config should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling force-dynamic should supersede a \"default\" cache value",
       "app-dir static/dynamic handling should allow dynamic routes to access cookies",
       "app-dir static/dynamic handling should build dynamic param with edge runtime correctly",
       "app-dir static/dynamic handling should cache correctly for cache: \"force-cache\" and \"revalidate\"",
@@ -1141,9 +1141,9 @@
   "test/e2e/app-dir/app-static/app-static.test.ts": {
     "passed": [
       "app-dir static/dynamic handling Incremental cache limits should load data only at build time even if response data size is greater than 2MB and FetchCache is possible",
-      "app-dir static/dynamic handling fetch `cache` should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling fetchCache config should supercede dynamic config when force-dynamic is used",
-      "app-dir static/dynamic handling force-dynamic should supercede a \"default\" cache value",
+      "app-dir static/dynamic handling fetch `cache` should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling fetchCache config should supersede dynamic config when force-dynamic is used",
+      "app-dir static/dynamic handling force-dynamic should supersede a \"default\" cache value",
       "app-dir static/dynamic handling it should revalidate correctly with edge route handler",
       "app-dir static/dynamic handling it should revalidate correctly with node route handler",
       "app-dir static/dynamic handling it should revalidate tag correctly with edge route handler",
@@ -3444,7 +3444,7 @@
       "app dir - navigation navigating to dynamic params & changing the casing should load the page correctly",
       "app dir - navigation navigation between pages and app should not contain _rsc query while navigating from app to pages",
       "app dir - navigation navigation between pages and app should not contain _rsc query while navigating from pages to app",
-      "app dir - navigation navigation between pages and app should not continously initiate a mpa navigation to the same URL when router state changes",
+      "app dir - navigation navigation between pages and app should not continuously initiate a mpa navigation to the same URL when router state changes",
       "app dir - navigation navigation between pages and app should not omit the hash while navigating from app to pages",
       "app dir - navigation navigations when attaching a Proxy to `window.Promise` should navigate without issue",
       "app dir - navigation nested navigation should load chunks correctly without double encoding of url",
@@ -3828,12 +3828,12 @@
   },
   "test/e2e/app-dir/node-extensions/node-extensions.random.test.ts": {
     "passed": [
-      "Node Extensions Random Cache Components should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Cache Components should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in Pages Router",
-      "Node Extensions Random Legacy should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Legacy should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Legacy should not error when accessing routes that use Math.random() in App Router",
@@ -7606,18 +7606,18 @@
       "using a single matcher does not add the header for root data request",
       "using a single matcher does not add the header for root request",
       "using a single matcher with i18n adds the header for a matched path",
-      "using a single matcher with i18n adds the header for a mathed root path with /index",
+      "using a single matcher with i18n adds the header for a matched root path with /index",
       "using a single matcher with i18n adds the headers for a matched data path",
       "using a single matcher with i18n and basePath adds the header for a matched path",
-      "using a single matcher with i18n and basePath adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and basePath and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n and basePath does not add the header for an unmatched path",
       "using a single matcher with i18n and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n does not add the header for an unmatched path",
@@ -8755,7 +8755,7 @@
       "testmode app router should handle RSC with fetch in edge function",
       "testmode app router should handle RSC with fetch in serverless function",
       "testmode app router should handle RSC with http.get in serverless function",
-      "testmode middleware should intercept fetchs in middleware",
+      "testmode middleware should intercept fetches in middleware",
       "testmode page router should handle API with fetch",
       "testmode page router should handle API with http.get",
       "testmode page router should handle getServerSideProps with fetch",
@@ -8898,7 +8898,7 @@
       "transpile packages css should handle global css imports inside transpiled modules",
       "transpile packages css should handle global scss imports inside transpiled modules",
       "transpile packages css should handle scss modules imports inside transpiled modules",
-      "transpile packages optional deps should hide dynammic module dependency errors from node_modules",
+      "transpile packages optional deps should hide dynamic module dependency errors from node_modules",
       "transpile packages optional deps should not throw an error when optional deps are not installed"
     ],
     "failed": [],
@@ -15479,11 +15479,11 @@
   },
   "test/integration/invalid-multi-match/test/index.test.js": {
     "passed": [
-      "Custom routes invalid multi-match production mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match production mode should show error for invalid multi-match"
     ],
     "failed": [],
     "pending": [
-      "Custom routes invalid multi-match development mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match development mode should show error for invalid multi-match"
     ],
     "flakey": [],
     "runtimeError": false
@@ -16254,7 +16254,7 @@
       "Image Component Default Tests production mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -16298,7 +16298,7 @@
       "Image Component Default Tests development mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -16475,7 +16475,7 @@
       "Image Component Default Tests production mode should be valid HTML",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -16519,7 +16519,7 @@
       "Image Component Default Tests development mode should be valid HTML",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -17926,7 +17926,7 @@
     ],
     "failed": [],
     "pending": [
-      "config telemetry production mode emits telemery for usage of image, script & dynamic",
+      "config telemetry production mode emits telemetry for usage of image, script & dynamic",
       "config telemetry production mode emits telemetry for middleware related options",
       "config telemetry production mode emits telemetry for transpilePackages",
       "config telemetry production mode emits telemetry for usage of @vercel/og",
@@ -19678,7 +19678,7 @@
       "required server files i18n should have the correct asPath for fallback page",
       "required server files i18n should have the correct asPath for fallback page locale",
       "required server files i18n should match the index page correctly",
-      "required server files i18n should match the root dyanmic page correctly",
+      "required server files i18n should match the root dynamic page correctly",
       "required server files i18n should normalize catch-all rewrite query values correctly",
       "required server files i18n should normalize optional values correctly for API page",
       "required server files i18n should normalize optional values correctly for SSG page",

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -2465,8 +2465,8 @@
   },
   "test/development/app-dir/edge-errors-hmr/index.test.ts": {
     "passed": [
-      "develop - app-dir - edge errros hmr should recover from build errors when client component error",
-      "develop - app-dir - edge errros hmr should recover from build errors when server component error"
+      "develop - app-dir - edge errors hmr should recover from build errors when client component error",
+      "develop - app-dir - edge errors hmr should recover from build errors when server component error"
     ],
     "failed": [],
     "pending": [],
@@ -2847,7 +2847,7 @@
       "app-dir-hmr filesystem changes can navigate cleanly to a page that requires a change in the Webpack runtime",
       "app-dir-hmr filesystem changes should have no unexpected action error for hmr",
       "app-dir-hmr filesystem changes should not break when renaming a folder",
-      "app-dir-hmr filesystem changes should not continously poll when hitting a not found page",
+      "app-dir-hmr filesystem changes should not continuously poll when hitting a not found page",
       "app-dir-hmr filesystem changes should update server components after navigating to a page with a different runtime"
     ],
     "failed": [],
@@ -3017,7 +3017,7 @@
     ],
     "failed": [],
     "pending": [
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"\"} should not continuously poll a custom error page"
     ],
     "flakey": [],
     "runtimeError": false
@@ -3039,7 +3039,7 @@
     ],
     "failed": [],
     "pending": [
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"/asset-prefix\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"\",\"assetPrefix\":\"/asset-prefix\"} should not continuously poll a custom error page"
     ],
     "flakey": [],
     "runtimeError": false
@@ -3061,7 +3061,7 @@
     ],
     "failed": [],
     "pending": [
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"\"} should not continuously poll a custom error page"
     ],
     "flakey": [],
     "runtimeError": false
@@ -3083,7 +3083,7 @@
     ],
     "failed": [],
     "pending": [
-      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"/asset-prefix\"} should not continously poll a custom error page"
+      "HMR - Error Recovery, nextConfig: {\"basePath\":\"/docs\",\"assetPrefix\":\"/asset-prefix\"} should not continuously poll a custom error page"
     ],
     "flakey": [],
     "runtimeError": false
@@ -3613,7 +3613,7 @@
       "middlewares does not warn when populating response with a function call",
       "middlewares does not warn when populating response with a value",
       "middlewares does not warn when populating response with an async function call",
-      "middlewares does not warn when returning null reponse body",
+      "middlewares does not warn when returning null response body",
       "middlewares does not warn when returning response with JSON.stringify",
       "middlewares does not warn when returning response with literal number",
       "middlewares does not warn when returning response with literal string",
@@ -4433,7 +4433,7 @@
       "app a11y features route announcer should announce document.title changes",
       "app a11y features route announcer should announce h1 changes",
       "app a11y features route announcer should announce route changes when h1 changes inside an inner layout",
-      "app a11y features route announcer should not announce the initital title"
+      "app a11y features route announcer should not announce the initial title"
     ],
     "failed": [],
     "pending": [],
@@ -4453,7 +4453,7 @@
   "test/e2e/app-dir/app-basepath-custom-server/index.test.ts": {
     "passed": [
       "custom-app-server-action-redirect redirects with basepath properly when server action handler uses `redirect`",
-      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post respose"
+      "custom-app-server-action-redirect redirects with proper cookies set from both redirect response and post response"
     ],
     "failed": [],
     "pending": [],
@@ -7668,12 +7668,12 @@
   },
   "test/e2e/app-dir/node-extensions/node-extensions.random.test.ts": {
     "passed": [
-      "Node Extensions Random Cache Components should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Cache Components should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in App Router",
       "Node Extensions Random Cache Components should not error when accessing routes that use Math.random() in Pages Router",
-      "Node Extensions Random Legacy should not error when accessing middlware that use Math.random()",
+      "Node Extensions Random Legacy should not error when accessing middleware that use Math.random()",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in App Router",
       "Node Extensions Random Legacy should not error when accessing pages that use Math.random() in Pages Router",
       "Node Extensions Random Legacy should not error when accessing routes that use Math.random() in App Router",
@@ -11188,18 +11188,18 @@
       "using a single matcher does not add the header for root data request",
       "using a single matcher does not add the header for root request",
       "using a single matcher with i18n adds the header for a matched path",
-      "using a single matcher with i18n adds the header for a mathed root path with /index",
+      "using a single matcher with i18n adds the header for a matched root path with /index",
       "using a single matcher with i18n adds the headers for a matched data path",
       "using a single matcher with i18n and basePath adds the header for a matched path",
-      "using a single matcher with i18n and basePath adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and basePath and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and basePath and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and basePath and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and basePath and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n and basePath does not add the header for an unmatched path",
       "using a single matcher with i18n and trailingSlash adds the header for a matched path",
-      "using a single matcher with i18n and trailingSlash adds the header for a mathed root path with /index",
+      "using a single matcher with i18n and trailingSlash adds the header for a matched root path with /index",
       "using a single matcher with i18n and trailingSlash adds the headers for a matched data path",
       "using a single matcher with i18n and trailingSlash does not add the header for an unmatched path",
       "using a single matcher with i18n does not add the header for an unmatched path",
@@ -12298,7 +12298,7 @@
       "testmode app router should handle RSC with fetch in edge function",
       "testmode app router should handle RSC with fetch in serverless function",
       "testmode app router should handle RSC with http.get in serverless function",
-      "testmode middleware should intercept fetchs in middleware",
+      "testmode middleware should intercept fetches in middleware",
       "testmode page router should handle API with fetch",
       "testmode page router should handle API with http.get",
       "testmode page router should handle getServerSideProps with fetch",
@@ -12443,7 +12443,7 @@
       "transpile packages css should handle global css imports inside transpiled modules",
       "transpile packages css should handle global scss imports inside transpiled modules",
       "transpile packages css should handle scss modules imports inside transpiled modules",
-      "transpile packages optional deps should hide dynammic module dependency errors from node_modules",
+      "transpile packages optional deps should hide dynamic module dependency errors from node_modules",
       "transpile packages optional deps should not throw an error when optional deps are not installed"
     ],
     "failed": [],
@@ -19017,11 +19017,11 @@
   },
   "test/integration/invalid-multi-match/test/index.test.js": {
     "passed": [
-      "Custom routes invalid multi-match development mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match development mode should show error for invalid multi-match"
     ],
     "failed": [],
     "pending": [
-      "Custom routes invalid multi-match production mode should show error for invalid mulit-match"
+      "Custom routes invalid multi-match production mode should show error for invalid multi-match"
     ],
     "flakey": [],
     "runtimeError": false
@@ -19796,7 +19796,7 @@
       "Image Component Default Tests development mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -19858,7 +19858,7 @@
       "Image Component Default Tests production mode should call callback ref cleanups when unmounting",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -20018,7 +20018,7 @@
       "Image Component Default Tests development mode should be valid HTML",
       "Image Component Default Tests development mode should callback native onError even when error before hydration",
       "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests development mode should callback native onLoad with synthetic event",
       "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests development mode should correctly ignore prose styles",
       "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
@@ -20078,7 +20078,7 @@
       "Image Component Default Tests production mode should be valid HTML",
       "Image Component Default Tests production mode should callback native onError even when error before hydration",
       "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
-      "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+      "Image Component Default Tests production mode should callback native onLoad with synthetic event",
       "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
       "Image Component Default Tests production mode should correctly ignore prose styles",
       "Image Component Default Tests production mode should correctly rotate image",
@@ -21459,7 +21459,7 @@
       "config telemetry production mode detects i18n and image configs for session start",
       "config telemetry production mode detects output config for session start",
       "config telemetry production mode detects rewrites, headers, and redirects for next build",
-      "config telemetry production mode emits telemery for usage of image, script & dynamic",
+      "config telemetry production mode emits telemetry for usage of image, script & dynamic",
       "config telemetry production mode emits telemetry for `next lint`",
       "config telemetry production mode emits telemetry for configured React Compiler options",
       "config telemetry production mode emits telemetry for default React Compiler options",

--- a/test/unit/accept-headers.test.ts
+++ b/test/unit/accept-headers.test.ts
@@ -41,13 +41,13 @@ describe('acceptLanguage', () => {
     expect(language).toEqual('en-US')
   })
 
-  it('returns preference with highest order when equal weigths', () => {
+  it('returns preference with highest order when equal weights', () => {
     expect(acceptLanguage('da, en, en-GB', ['en', 'en-GB'])).toEqual('en')
     expect(acceptLanguage('da, en, en-GB', ['en-GB', 'en'])).toEqual('en-GB')
     expect(acceptLanguage('en, en-GB, en-US')).toEqual('en')
   })
 
-  it('return language with heighest weight', () => {
+  it('return language with highest weight', () => {
     const language = acceptLanguage('da;q=0.5, en;q=1', ['da', 'en'])
     expect(language).toEqual('en')
   })

--- a/test/unit/cssnano-simple/cssnano-simple/basic.test.ts
+++ b/test/unit/cssnano-simple/cssnano-simple/basic.test.ts
@@ -20,7 +20,7 @@ describe('basic test', () => {
   })
 
   test('should be able to declare layer names', async () => {
-    // @layer b is equivlaent to @layer b {}
+    // @layer b is equivalents to @layer b {}
     const input = css`
       @layer b {
         ._5-enzrfpb:lang(ar) {

--- a/test/unit/is-serializable-props.test.ts
+++ b/test/unit/is-serializable-props.test.ts
@@ -138,7 +138,7 @@ describe('isSerializableProps', () => {
     `)
   })
 
-  it('diallows nested non-serializable types', () => {
+  it('disallows nested non-serializable types', () => {
     expect(() =>
       isSerializableProps('/', 'test', { k: { a: [1, { n: new Date() }] } })
     ).toThrowErrorMatchingInlineSnapshot(`
@@ -209,23 +209,23 @@ describe('isSerializableProps', () => {
   })
 
   it('can handle deep obj circular refs', () => {
-    const obj: any = { foo: 'bar', test: true, leve1: { level2: {} } }
-    obj.leve1.level2.child = obj
+    const obj: any = { foo: 'bar', test: true, level1: { level2: {} } }
+    obj.level1.level2.child = obj
 
     expect(() => isSerializableProps('/', 'test', obj))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Error serializing \`.leve1.level2.child\` returned from \`test\` in "/".
+      "Error serializing \`.level1.level2.child\` returned from \`test\` in "/".
       Reason: Circular references cannot be expressed in JSON (references: \`(self)\`)."
     `)
   })
 
   it('can handle deep obj circular refs (with arrays)', () => {
-    const obj: any = { foo: 'bar', test: true, leve1: { level2: {} } }
-    obj.leve1.level2.child = [{ another: [obj] }]
+    const obj: any = { foo: 'bar', test: true, level1: { level2: {} } }
+    obj.level1.level2.child = [{ another: [obj] }]
 
     expect(() => isSerializableProps('/', 'test', obj))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Error serializing \`.leve1.level2.child[0].another[0]\` returned from \`test\` in "/".
+      "Error serializing \`.level1.level2.child[0].another[0]\` returned from \`test\` in "/".
       Reason: Circular references cannot be expressed in JSON (references: \`(self)\`)."
     `)
   })

--- a/test/unit/web-runtime/next-url.test.ts
+++ b/test/unit/web-runtime/next-url.test.ts
@@ -107,7 +107,7 @@ it('allows to get empty locale when there is no locale', () => {
   expect(url.locale).toEqual('')
 })
 
-it('doesnt allow to set an unexisting locale', () => {
+it("doesn't allow to set an unexisting locale", () => {
   const url = new NextURL('https://localhost:3000/foo')
   let error: Error | null = null
   try {


### PR DESCRIPTION
## Summary

Fix typos and spelling mistakes across the test suite to improve readability and correctness

Tests:
- Correct spelling in test descriptions, comments, error messages, and snapshots across unit, integration, and e2e tests

Chores:
- Rename mispelled variables and identifiers (e.g. entrypointsSubscription, Component) and update import and identifier names for consistency

---
🔄 **This is a mirror of [upstream PR #82523](https://github.com/vercel/next.js/pull/82523)**