### PR TITLE
Fix: Keep metadata outlet consistent in prerender and resume

### DIFF
--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.node.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.node.production.js
@@ -10,7 +10,7 @@
 
 "use strict";
 
-console.log('file override react-dom-server.node.production.js')
+console.log('file override react-dom-server.node.production.js 111')
 
 var util = require("util"),
   crypto = require("crypto"),

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.node.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.node.production.js
@@ -9,6 +9,9 @@
  */
 
 "use strict";
+
+console.log('file override react-dom-server.node.production.js')
+
 var util = require("util"),
   crypto = require("crypto"),
   async_hooks = require("async_hooks"),
@@ -5792,7 +5795,15 @@ function retryNode(request, task) {
                         0 < task.replay.nodes.length
                       )
                         throw Error(
-                          "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering."
+                          "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering. Debug info: " + JSON.stringify({
+                            component: getComponentNameFromType(type) || "Unknown",
+                            props: Object.keys(props || {}),
+                            keyPath: task.keyPath,
+                            childIndex: task.childIndex,
+                            replayNodes: task.replay.nodes,
+                            replaySlots: task.replay.slots,
+                            pendingTasks: task.replay.pendingTasks
+                          })
                         );
                       task.replay.pendingTasks--;
                     } catch (x) {
@@ -5883,7 +5894,15 @@ function retryNode(request, task) {
                           0 < task.replay.nodes.length
                         )
                           throw Error(
-                            "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering."
+                            "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering. Debug info: " + JSON.stringify({
+                              boundaryID: props.rootSegmentID || "Unknown",
+                              content: typeof content === "string" ? content.substring(0, 100) : typeof content,
+                              keyPath: task.keyPath,
+                              childIndex: task.childIndex,
+                              replayNodes: task.replay.nodes,
+                              replaySlots: task.replay.slots,
+                              pendingTasks: task.replay.pendingTasks
+                            })
                           );
                         task.replay.pendingTasks--;
                         if (0 === props.pendingTasks && 0 === props.status) {
@@ -6064,7 +6083,15 @@ function renderChildrenArray(request, task, children, childIndex) {
           renderChildrenArray(request, task, children, -1);
           if (1 === task.replay.pendingTasks && 0 < task.replay.nodes.length)
             throw Error(
-              "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering."
+              "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering. Debug info: " + JSON.stringify({
+                arrayIndex: childIndex,
+                childrenCount: Array.isArray(children) ? children.length : "not array",
+                keyPath: task.keyPath,
+                childIndex: task.childIndex,
+                replayNodes: task.replay.nodes,
+                replaySlots: task.replay.slots,
+                pendingTasks: task.replay.pendingTasks
+              })
             );
           task.replay.pendingTasks--;
         } catch (x) {
@@ -6829,7 +6856,14 @@ function performWork(request$jscomp$1) {
                 0 < task.replay.nodes.length
               )
                 throw Error(
-                  "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering."
+                  "Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering. Debug info: " + JSON.stringify({
+                    taskNode: task.node || "Unknown",
+                    keyPath: task.keyPath,
+                    childIndex: task.childIndex,
+                    replayNodes: task.replay.nodes,
+                    replaySlots: task.replay.slots,
+                    pendingTasks: task.replay.pendingTasks
+                  })
                 );
               task.replay.pendingTasks--;
               task.abortSet.delete(task);

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -38,7 +38,7 @@ import {
   METADATA_BOUNDARY_NAME,
   VIEWPORT_BOUNDARY_NAME,
 } from '../framework/boundary-constants'
-import { AsyncMetadataOutlet } from '../../client/components/metadata/async-metadata'
+// import { AsyncMetadataOutlet } from '../../client/components/metadata/async-metadata'
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
 import { createServerPathnameForMetadata } from '../../server/request/pathname'
@@ -243,13 +243,17 @@ export function createMetadataComponents({
     return undefined
   }
 
-  function StreamingMetadataOutletImpl() {
-    return <AsyncMetadataOutlet promise={resolveFinalMetadata()} />
-  }
+  // function StreamingMetadataOutletImpl() {
+  //   return <AsyncMetadataOutlet promise={resolveFinalMetadata()} />
+  // }
 
-  const StreamingMetadataOutlet = serveStreamingMetadata
-    ? StreamingMetadataOutletImpl
-    : null
+  // HACK: For PPR routes, always use null to ensure consistency between prerender and resume
+  // This prevents "Couldn't find all resumable slots" errors when the tree structure differs
+  const StreamingMetadataOutlet = null
+  // Original logic (commented out for debugging):
+  // const StreamingMetadataOutlet = serveStreamingMetadata
+  //   ? StreamingMetadataOutletImpl
+  //   : null
 
   return {
     ViewportTree,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -823,7 +823,7 @@ async function createComponentTreeInternal(
         {wrappedPageElement}
         {layerAssets}
         <OutletBoundary>
-          <MetadataOutlet ready={getViewportReady} />
+          <MetadataOutlet ready={getViewportReady} StreamingComponent={null} />
           {metadataOutlet}
         </OutletBoundary>
       </React.Fragment>,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -420,10 +420,13 @@ async function createComponentTreeInternal(
       ? process.env.__NEXT_EDGE_PROJECT_DIR
       : ctx.renderOpts.dir) || ''
 
-  console.log('StreamingMetadataOutlet', !!StreamingMetadataOutlet)
-
+  // StreamingMetadataOutlet is now always null from createMetadataComponents
+  // to ensure consistency between prerender and resume for PPR routes
   const metadataOutlet = (
-    <MetadataOutlet ready={getMetadataReady} StreamingComponent={null} />
+    <MetadataOutlet
+      ready={getMetadataReady}
+      StreamingComponent={StreamingMetadataOutlet}
+    />
   )
 
   const [notFoundElement, notFoundFilePath] =
@@ -823,7 +826,7 @@ async function createComponentTreeInternal(
         {wrappedPageElement}
         {layerAssets}
         <OutletBoundary>
-          <MetadataOutlet ready={getViewportReady} StreamingComponent={null} />
+          <MetadataOutlet ready={getViewportReady} />
           {metadataOutlet}
         </OutletBoundary>
       </React.Fragment>,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -420,11 +420,10 @@ async function createComponentTreeInternal(
       ? process.env.__NEXT_EDGE_PROJECT_DIR
       : ctx.renderOpts.dir) || ''
 
+  console.log('StreamingMetadataOutlet', !!StreamingMetadataOutlet)
+
   const metadataOutlet = (
-    <MetadataOutlet
-      ready={getMetadataReady}
-      StreamingComponent={StreamingMetadataOutlet}
-    />
+    <MetadataOutlet ready={getMetadataReady} StreamingComponent={null} />
   )
 
   const [notFoundElement, notFoundFilePath] =

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -420,11 +420,11 @@ async function createComponentTreeInternal(
       ? process.env.__NEXT_EDGE_PROJECT_DIR
       : ctx.renderOpts.dir) || ''
 
-  // Use the same condition to render metadataOutlet as metadata
-  const metadataOutlet = StreamingMetadataOutlet ? (
-    <StreamingMetadataOutlet />
-  ) : (
-    <MetadataOutlet ready={getMetadataReady} />
+  const metadataOutlet = (
+    <MetadataOutlet
+      ready={getMetadataReady}
+      StreamingComponent={StreamingMetadataOutlet}
+    />
   )
 
   const [notFoundElement, notFoundFilePath] =
@@ -1014,9 +1014,15 @@ async function createComponentTreeInternal(
 
 async function MetadataOutlet({
   ready,
+  StreamingComponent,
 }: {
   ready: () => Promise<void> & { status?: string; value?: unknown }
+  StreamingComponent?: React.ComponentType | null
 }) {
+  if (StreamingComponent) {
+    return <StreamingComponent />
+  }
+
   const r = ready()
   // We can avoid a extra microtask by unwrapping the instrumented promise directly if available.
   if (r.status === 'rejected') {

--- a/test/e2e/app-dir/resume-streaming-metadata/app/@content/default.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/@content/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>Content</div>
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/@content/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/@content/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+
+async function AsyncComponent() {
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return <div>Async content {Math.random()}</div>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AsyncComponent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/@sidebar/default.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/@content/(chat)/id/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/@content/(chat)/id/page.tsx
@@ -1,0 +1,41 @@
+import { headers } from 'next/headers'
+import { Metadata } from 'next'
+import { unstable_noStore } from 'next/cache'
+
+async function getChatIdFromHeaders() {
+  const headersList = await headers()
+  return headersList.get('x-chat-id') || 'default-id'
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const chatId = await getChatIdFromHeaders()
+
+  // Simulate async DB call like v0
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  return {
+    title: `Chat ${chatId}`,
+    description: `Chat session ${chatId}`,
+  }
+}
+
+export default async function ChatPage() {
+  unstable_noStore()
+
+  const chatId = await getChatIdFromHeaders()
+
+  if (!chatId) {
+    return <div>No chat ID</div>
+  }
+
+  // Simulate some async work
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const random = Math.random()
+
+  return (
+    <div>
+      <h1>Chat {chatId}</h1>
+      <p>Random: {random}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/@content/default.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/@content/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/default.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/layout.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/chat/[variants]/(dynamic-root)/(app)/layout.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+
+export default async function Layout({
+  children,
+  content,
+}: {
+  children: React.ReactNode
+  content: React.ReactNode
+  params: Promise<{ variants: string }>
+}) {
+  return (
+    <>
+      {children}
+      <Suspense>{content}</Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/layout.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/layout.tsx
@@ -1,0 +1,22 @@
+import { ReactNode, Suspense } from 'react'
+export default function Root({
+  children,
+  sidebar,
+  content,
+}: {
+  children: ReactNode
+  sidebar: ReactNode
+  content: ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <Suspense>
+          {sidebar}
+          {children}
+          {content}
+        </Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/page.tsx
@@ -1,0 +1,19 @@
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ id: string | undefined }>
+}) {
+  const { id } = await searchParams
+  const random = Math.random()
+  return (
+    <p>
+      hello world {random} {id}
+    </p>
+  )
+}
+
+export const generateMetadata = async () => {
+  return {
+    title: 'Hello World',
+  }
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/shift/@slot1/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/shift/@slot1/page.tsx
@@ -1,0 +1,4 @@
+export default async function Slot1() {
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  return <div>Slot 1</div>
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/shift/@slot2/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/shift/@slot2/page.tsx
@@ -1,0 +1,4 @@
+export default async function Slot2() {
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  return <div>Slot 2</div>
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/shift/@slot3/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/shift/@slot3/page.tsx
@@ -1,0 +1,4 @@
+export default async function Slot3() {
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  return <div>Slot 3</div>
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/shift/layout.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/shift/layout.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react'
+
+export default function Layout({
+  children,
+  slot1,
+  slot2,
+  slot3,
+}: {
+  children: React.ReactNode
+  slot1: React.ReactNode
+  slot2: React.ReactNode
+  slot3: React.ReactNode
+}) {
+  // The order of these slots might differ between prerender and resume
+  return (
+    <div>
+      <Suspense fallback={<div>Loading slot1...</div>}>{slot1}</Suspense>
+      <Suspense fallback={<div>Loading slot2...</div>}>{slot2}</Suspense>
+      {/* Children at index 2 - this is where metadata might interfere */}
+      <Suspense>{children}</Suspense>
+      <Suspense fallback={<div>Loading slot3...</div>}>{slot3}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/shift/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/shift/page.tsx
@@ -1,0 +1,29 @@
+import { headers } from 'next/headers'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  // This async metadata generation might cause timing differences
+  const headersList = await headers()
+  const id = headersList.get('x-id') || 'default'
+
+  // Simulate DB call
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  return {
+    title: `Page ${id}`,
+    description: `Description for ${id}`,
+  }
+}
+
+export default async function Page() {
+  await connection()
+  // Dynamic content that changes between renders
+  const random = Math.random()
+
+  return (
+    <div>
+      <h1>Main Page Content</h1>
+      <p>Random: {random}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/app/test/page.tsx
+++ b/test/e2e/app-dir/resume-streaming-metadata/app/test/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+
+// Force multiple components before metadata
+function Component1() {
+  return <div>Component 1</div>
+}
+
+function Component2() {
+  return <div>Component 2</div>
+}
+
+async function AsyncComponent() {
+  // This component loads async data that might affect position
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  return <div>Async Component</div>
+}
+
+export async function generateMetadata() {
+  // Async metadata that takes time
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  // Try to access headers which might affect timing
+  const headersList = await headers()
+  const testHeader = headersList.get('x-test') || 'default'
+
+  return {
+    title: `Test Page - ${testHeader}`,
+    description: 'Testing metadata boundary position',
+  }
+}
+
+export default function TestPage() {
+  return (
+    <>
+      <Component1 />
+      <Component2 />
+      <Suspense fallback={<div>Loading...</div>}>
+        <AsyncComponent />
+      </Suspense>
+      <div>Main content at index 3</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/resume-streaming-metadata/next.config.js
+++ b/test/e2e/app-dir/resume-streaming-metadata/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    cacheComponents: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/resume-streaming-metadata/resume-streaming-metadata.test.ts
+++ b/test/e2e/app-dir/resume-streaming-metadata/resume-streaming-metadata.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('resume-streaming-metadata', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+
+  // Recommended for tests that need a full browser
+  it('should work using browser', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
+
+  // In case you need the full HTML. Can also use $.html() with cheerio.
+  it('should work with html', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})


### PR DESCRIPTION


---
🔄 **This is a mirror of [upstream PR #82540](https://github.com/vercel/next.js/pull/82540)**