### PR TITLE
Revert "Turbopack: fix CSS module references, take 2"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -314,6 +314,8 @@ jobs:
         export TURBOPACK_BUILD=1
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+        # TODO(PACK-4578): Remove
+        export TURBOPACK_TEMP_DISABLE_DUPLICATE_MODULES_CHECK=1
 
         node run-tests.js --timings -g ${{ matrix.group }} --type production
       stepName: 'test-turbopack-production-react-${{ matrix.react }}-${{ matrix.group }}'

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -64,10 +64,7 @@ use crate::{
         get_decorators_transform_options, get_jsx_transform_options,
         get_typescript_transform_options,
     },
-    util::{
-        OptionEnvMap, defines, foreign_code_context_condition, internal_assets_conditions,
-        module_styles_rule_condition,
-    },
+    util::{OptionEnvMap, defines, foreign_code_context_condition, internal_assets_conditions},
 };
 
 #[turbo_tasks::function]
@@ -319,7 +316,6 @@ pub async fn get_client_module_options_context(
         },
         css: CssOptionsContext {
             source_maps,
-            module_css_condition: Some(module_styles_rule_condition()),
             ..Default::default()
         },
         environment: Some(env),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -75,7 +75,6 @@ use crate::{
     util::{
         NextRuntime, OptionEnvMap, defines, foreign_code_context_condition,
         get_transpiled_packages, internal_assets_conditions, load_next_js_templateon,
-        module_styles_rule_condition,
     },
 };
 
@@ -584,7 +583,6 @@ pub async fn get_server_module_options_context(
         environment: Some(environment),
         css: CssOptionsContext {
             source_maps,
-            module_css_condition: Some(module_styles_rule_condition()),
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -16,7 +16,6 @@ use turbo_tasks_fs::{
     self, File, FileContent, FileSystem, FileSystemPath, json::parse_json_rope_with_source_context,
     rope::Rope,
 };
-use turbopack::module_options::RuleCondition;
 use turbopack_core::{
     asset::AssetContent,
     compile_time_info::{CompileTimeDefineValue, CompileTimeDefines, DefinableNameSegment},
@@ -793,49 +792,4 @@ pub async fn load_next_js_templateon<T: DeserializeOwned>(
     let result: T = parse_json_rope_with_source_context(file.content())?;
 
     Ok(result)
-}
-
-pub fn styles_rule_condition() -> RuleCondition {
-    RuleCondition::any(vec![
-        RuleCondition::all(vec![
-            RuleCondition::ResourcePathEndsWith(".css".into()),
-            RuleCondition::not(RuleCondition::ResourcePathEndsWith(".module.css".into())),
-        ]),
-        RuleCondition::all(vec![
-            RuleCondition::ResourcePathEndsWith(".sass".into()),
-            RuleCondition::not(RuleCondition::ResourcePathEndsWith(".module.sass".into())),
-        ]),
-        RuleCondition::all(vec![
-            RuleCondition::ResourcePathEndsWith(".scss".into()),
-            RuleCondition::not(RuleCondition::ResourcePathEndsWith(".module.scss".into())),
-        ]),
-        RuleCondition::all(vec![
-            RuleCondition::ContentTypeStartsWith("text/css".into()),
-            RuleCondition::not(RuleCondition::ContentTypeStartsWith(
-                "text/css+module".into(),
-            )),
-        ]),
-        RuleCondition::all(vec![
-            RuleCondition::ContentTypeStartsWith("text/sass".into()),
-            RuleCondition::not(RuleCondition::ContentTypeStartsWith(
-                "text/sass+module".into(),
-            )),
-        ]),
-        RuleCondition::all(vec![
-            RuleCondition::ContentTypeStartsWith("text/scss".into()),
-            RuleCondition::not(RuleCondition::ContentTypeStartsWith(
-                "text/scss+module".into(),
-            )),
-        ]),
-    ])
-}
-pub fn module_styles_rule_condition() -> RuleCondition {
-    RuleCondition::any(vec![
-        RuleCondition::ResourcePathEndsWith(".module.css".into()),
-        RuleCondition::ResourcePathEndsWith(".module.scss".into()),
-        RuleCondition::ResourcePathEndsWith(".module.sass".into()),
-        RuleCondition::ContentTypeStartsWith("text/css+module".into()),
-        RuleCondition::ContentTypeStartsWith("text/sass+module".into()),
-        RuleCondition::ContentTypeStartsWith("text/scss+module".into()),
-    ])
 }

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -1,9 +1,4 @@
-use std::{
-    fmt::{Debug, Display},
-    future::Future,
-    pin::Pin,
-    task::Poll,
-};
+use std::{fmt::Display, future::Future, pin::Pin, task::Poll};
 
 use anyhow::Result;
 use auto_hash_map::AutoSet;
@@ -59,7 +54,7 @@ impl Display for CellId {
 /// otherwise be treated as an internal implementation detail of `turbo-tasks`.
 ///
 /// [monomorphization]: https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RawVc {
     /// The synchronous return value of a task (after argument resolution). This is the
     /// representation used by [`OperationVc`][crate::OperationVc].
@@ -77,28 +72,6 @@ pub enum RawVc {
     /// Task's APIs are designed to prevent escapes of local [`Vc`]s, but [`ExecutionId`] is used
     /// for a fallback runtime assertion.
     LocalOutput(ExecutionId, LocalTaskId, TaskPersistence),
-}
-
-impl Debug for RawVc {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RawVc::TaskOutput(task_id) => f
-                .debug_tuple("RawVc::TaskOutput")
-                .field(&**task_id)
-                .finish(),
-            RawVc::TaskCell(task_id, cell_id) => f
-                .debug_tuple("RawVc::TaskCell")
-                .field(&**task_id)
-                .field(&cell_id.to_string())
-                .finish(),
-            RawVc::LocalOutput(execution_id, local_task_id, task_persistence) => f
-                .debug_tuple("RawVc::LocalOutput")
-                .field(&**execution_id)
-                .field(&**local_task_id)
-                .field(task_persistence)
-                .finish(),
-        }
-    }
 }
 
 impl RawVc {

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -357,7 +357,7 @@ where
     T: ?Sized,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Vc").field(&self.node).finish()
+        f.debug_struct("Vc").field("node", &self.node).finish()
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -295,7 +295,9 @@ where
     T: ?Sized,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("ResolvedVc").field(&self.node.node).finish()
+        f.debug_struct("ResolvedVc")
+            .field("node", &self.node.node)
+            .finish()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -348,6 +348,8 @@ impl SingleModuleGraph {
         #[cfg(debug_assertions)]
         {
             use once_cell::sync::Lazy;
+
+            // TODO(PACK-4578): This is temporary while the last issues are being addressed.
             static CHECK_FOR_DUPLICATE_MODULES: Lazy<bool> = Lazy::new(|| {
                 match std::env::var_os("TURBOPACK_TEMP_DISABLE_DUPLICATE_MODULES_CHECK") {
                     Some(v) => v != "1" && v != "true",

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -221,7 +221,7 @@ pub enum CssReferenceSubType {
     /// class name
     Compose,
     /// Reference from ModuleCssAsset to the CssModuleAsset
-    Inner,
+    Internal,
     /// Used for generating the list of classes in a ModuleCssAsset
     Analyze,
     Custom(u8),
@@ -417,6 +417,11 @@ impl ReferenceType {
     /// combination with [`ModuleRuleCondition::Internal`] to determine if a
     /// rule should be applied to an internal asset/reference.
     pub fn is_internal(&self) -> bool {
-        matches!(self, ReferenceType::Internal(_) | ReferenceType::Runtime)
+        matches!(
+            self,
+            ReferenceType::Internal(_)
+                | ReferenceType::Css(CssReferenceSubType::Internal)
+                | ReferenceType::Runtime
+        )
     }
 }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -88,7 +88,7 @@ impl Module for ModuleCssAsset {
             .copied()
             .chain(
                 match *self
-                    .inner(ReferenceType::Css(CssReferenceSubType::Inner))
+                    .inner(ReferenceType::Css(CssReferenceSubType::Internal))
                     .try_into_module()
                     .await?
                 {

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -17,7 +17,6 @@ use turbopack_node::{
 };
 
 use super::ModuleRule;
-use crate::module_options::RuleCondition;
 
 #[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
 pub struct LoaderRuleItem {
@@ -214,11 +213,6 @@ pub struct CssOptionsContext {
 
     /// Specifies how Source Maps are handled.
     pub source_maps: SourceMapsType,
-
-    /// Override the conditions for module CSS (doesn't have any effect if `enable_raw_css` is
-    /// true). By default (for `None`), it uses
-    /// `Any(ResourcePathEndsWith(".module.css"), ContentTypeStartsWith("text/css+module"))`
-    pub module_css_condition: Option<RuleCondition>,
 
     pub placeholder_for_future_extensions: (),
 }


### PR DESCRIPTION
Reverts vercel/next.js#82448

---
🔄 **This is a mirror of [upstream PR #82545](https://github.com/vercel/next.js/pull/82545)**