### PR TITLE
[turbopack] drop an opt out PACK-4578

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -347,25 +347,16 @@ impl SingleModuleGraph {
 
         #[cfg(debug_assertions)]
         {
-            use once_cell::sync::Lazy;
-            static CHECK_FOR_DUPLICATE_MODULES: Lazy<bool> = Lazy::new(|| {
-                match std::env::var_os("TURBOPACK_TEMP_DISABLE_DUPLICATE_MODULES_CHECK") {
-                    Some(v) => v != "1" && v != "true",
-                    None => true,
+            let mut duplicates = Vec::new();
+            let mut set = FxHashSet::default();
+            for &module in modules.keys() {
+                let ident = module.ident().to_string().await?;
+                if !set.insert(ident.clone()) {
+                    duplicates.push(ident)
                 }
-            });
-            if *CHECK_FOR_DUPLICATE_MODULES {
-                let mut duplicates = Vec::new();
-                let mut set = FxHashSet::default();
-                for &module in modules.keys() {
-                    let ident = module.ident().to_string().await?;
-                    if !set.insert(ident.clone()) {
-                        duplicates.push(ident)
-                    }
-                }
-                if !duplicates.is_empty() {
-                    panic!("Duplicate module idents in graph: {duplicates:#?}");
-                }
+            }
+            if !duplicates.is_empty() {
+                panic!("Duplicate module idents in graph: {duplicates:#?}");
             }
         }
 


### PR DESCRIPTION
Drop our opt out for duplicate modules checking, #82448 fixed the last known case

Closes PACK-4578

---
🔄 **This is a mirror of [upstream PR #82544](https://github.com/vercel/next.js/pull/82544)**