### PR TITLE
Turbopack: use lightningcss for CSS Module pure lint

### DIFF
--- a/test/e2e/app-dir/css-modules-pure/app/home.module.css
+++ b/test/e2e/app-dir/css-modules-pure/app/home.module.css
@@ -1,0 +1,16 @@
+div {
+  width: 20px;
+}
+
+:global(.foo) {
+  width: 20px;
+}
+
+[foo='bar'] {
+  width: 20px;
+}
+
+div,
+.foo {
+  width: 20px;
+}

--- a/test/e2e/app-dir/css-modules-pure/app/layout.tsx
+++ b/test/e2e/app-dir/css-modules-pure/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-modules-pure/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-pure/app/page.tsx
@@ -1,0 +1,10 @@
+import styles from './home.module.css'
+import pure from './pure.module.css'
+
+export default function Home() {
+  return (
+    <div id="my-div" className={`${styles.home} ${pure.root} global`}>
+      <div>This text should be bold</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/css-modules-pure/app/pure.module.css
+++ b/test/e2e/app-dir/css-modules-pure/app/pure.module.css
@@ -1,0 +1,9 @@
+.root {
+  color: red;
+}
+
+:not(:global(.dark-theme)) {
+  .root {
+    color: blue;
+  }
+}

--- a/test/e2e/app-dir/css-modules-pure/css-modules-pure-no-check.test.ts
+++ b/test/e2e/app-dir/css-modules-pure/css-modules-pure-no-check.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+import cheerio from 'cheerio'
+
+describe('css-modules-pure-no-check', () => {
+  const { isNextStart, next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should apply styles correctly', async () => {
+    const browser = await next.browser('/')
+
+    const elementWithGlobalStyles = await browser
+      .elementByCss('#my-div')
+      .getComputedCss('font-weight')
+
+    expect(elementWithGlobalStyles).toBe('700')
+  })
+
+  if (isNextStart) {
+    it('should have emitted a CSS file', async () => {
+      const html = await next.render('/')
+      const $html = cheerio.load(html)
+
+      const cssLink = $html('link[rel="stylesheet"]')
+      expect(cssLink.length).toBe(1)
+      const cssHref = cssLink[0].attribs['href']
+
+      const res = await next.fetch(cssHref)
+      const cssCode = await res.text()
+
+      expect(cssCode).toInclude(`.global{font-weight:700}`)
+      expect(cssCode).toInclude(
+        `::view-transition-old(root){animation-duration:.3s}`
+      )
+    })
+  }
+})

--- a/test/e2e/app-dir/css-modules-pure/next.config.ts
+++ b/test/e2e/app-dir/css-modules-pure/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  /* config options here */
+}
+
+export default nextConfig


### PR DESCRIPTION
This allows showing line/column information.

Downside being that only a single one of these errors can be shown at the same time.

---
🔄 **This is a mirror of [upstream PR #82548](https://github.com/vercel/next.js/pull/82548)**