### PR TITLE
[Deprecation Warnings]: add amp deprecation warning

### DIFF
--- a/docs/02-pages/02-guides/amp.mdx
+++ b/docs/02-pages/02-guides/amp.mdx
@@ -11,6 +11,8 @@ description: With minimal config, and without leaving React, you can start addin
 
 </details>
 
+> **Warning**: Built-in amp support will be deprecated in Next.js 16.
+
 With Next.js you can turn any React page into an AMP page, with minimal config, and without leaving React.
 
 You can read more about AMP in the official [amp.dev](https://amp.dev/) site.

--- a/docs/02-pages/02-guides/amp.mdx
+++ b/docs/02-pages/02-guides/amp.mdx
@@ -11,7 +11,7 @@ description: With minimal config, and without leaving React, you can start addin
 
 </details>
 
-> **Warning**: Built-in amp support will be deprecated in Next.js 16.
+> **Warning**: Built-in amp support will be removed in Next.js 16.
 
 With Next.js you can turn any React page into an AMP page, with minimal config, and without leaving React.
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -500,6 +500,7 @@ export interface ExperimentalConfig {
   nextScriptWorkers?: boolean
   scrollRestoration?: boolean
   externalDir?: boolean
+  /** @deprecated built-in amp support will be removed in Next 16 */
   amp?: {
     optimizer?: any
     validator?: string
@@ -1146,7 +1147,10 @@ export interface NextConfig extends Record<string, any> {
     pagesBufferLength?: number
   }
 
-  /** @see [`next/amp`](https://nextjs.org/docs/api-reference/next/amp) */
+  /**
+   * @deprecated built-in amp support will be removed in Next 16
+   * @see [`next/amp`](https://nextjs.org/docs/api-reference/next/amp)
+   */
   amp?: {
     canonicalBase?: string
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -511,14 +511,14 @@ function assignDefaults(
     warnOptionHasBeenDeprecated(
       result,
       'amp',
-      `Built-in amp support is being deprecated and the \`amp\` configuration option will be removed in Next 16.`,
+      `Built-in amp support is deprecated and the \`amp\` configuration option will be removed in Next.js 16.`,
       silent
     )
 
     warnOptionHasBeenDeprecated(
       result,
       'experimental.amp',
-      `Built-in amp support is being deprecated and the \`experimental.amp\` configuration option will be removed in Next 16.`,
+      `Built-in amp support is deprecated and the \`experimental.amp\` configuration option will be removed in Next.js 16.`,
       silent
     )
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -503,6 +503,26 @@ function assignDefaults(
     }
   }
 
+  // There are a good amount of test fixtures that have amp enabled
+  // that also assert on stderr output being empty, so we're gating the
+  // warning to be skipped when running in Next.js tests until we fully
+  // remove the feature.
+  if (!process.env.__NEXT_TEST_MODE) {
+    warnOptionHasBeenDeprecated(
+      result,
+      'amp',
+      `Built-in amp support is being deprecated and the \`amp\` configuration option will be removed in Next 16.`,
+      silent
+    )
+
+    warnOptionHasBeenDeprecated(
+      result,
+      'experimental.amp',
+      `Built-in amp support is being deprecated and the \`experimental.amp\` configuration option will be removed in Next 16.`,
+      silent
+    )
+  }
+
   warnCustomizedOption(
     result,
     'experimental.esmExternals',


### PR DESCRIPTION
We are dropping amp support in an upcoming major. This adds a warning for using these configuration options and updates the docs with the warning. 

---
🔄 **This is a mirror of [upstream PR #82551](https://github.com/vercel/next.js/pull/82551)**