### PR TITLE
Update Rspack production test manifest

### DIFF
--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -2407,6 +2407,13 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts": {
+    "passed": ["css-server-chunks should not write CSS chunks for the server"],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/cssnano-colormin/index.test.ts": {
     "passed": ["cssnano-colormin should not minify rgb colors to hsla"],
     "failed": [],
@@ -5220,6 +5227,17 @@
       "app-dir root layout Should do a mpa navigation when switching root layout should work with static routes",
       "app-dir root layout should correctly handle navigation between multiple root layouts",
       "app-dir root layout should correctly handle navigation between multiple root layouts when redirecting in a server action"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts": {
+    "passed": [
+      "Root Suspense Dynamic Rendering placeholder to satisfy at least one test when isNextDev is false",
+      "Root Suspense Dynamic Rendering should correctly mark route as dynamic",
+      "Root Suspense Dynamic Rendering should handle dynamic content wrapped in Suspense above HTML structure"
     ],
     "failed": [],
     "pending": [],
@@ -17706,16 +17724,6 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/integration/production-browser-sourcemaps/test/index.test.js": {
-    "passed": [
-      "Production browser sourcemaps production mode Server support correctly generated the source map",
-      "Production browser sourcemaps production mode Server support includes sourcemaps for all browser files"
-    ],
-    "failed": [],
-    "pending": [],
-    "flakey": [],
-    "runtimeError": false
-  },
   "test/integration/production-build-dir/test/index.test.js": {
     "passed": [
       "Production Custom Build Directory production mode With basic usage should render the page"
@@ -20113,10 +20121,11 @@
   },
   "test/production/pnpm-support/index.test.ts": {
     "passed": [
-      "pnpm support should build with dependencies installed via pnpm",
+      "pnpm support should build with dependencies installed via pnpm"
+    ],
+    "failed": [
       "pnpm support should execute client-side JS on each page in output: \"standalone\""
     ],
-    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false
@@ -20144,6 +20153,17 @@
       "Prerender prefetch with optimisticClientCache enabled should update cache using router.push with unstable_skipClientCache"
     ],
     "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/production/production-browser-sourcemaps/index.test.ts": {
+    "passed": [
+      "Production browser sourcemaps productionBrowserSourceMaps = false check sourcemaps for all browser files"
+    ],
+    "failed": [
+      "Production browser sourcemaps productionBrowserSourceMaps = true check sourcemaps for all browser files"
+    ],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
This auto-generated PR updates the production integration test manifest used when testing Rspack.

---
🔄 **This is a mirror of [upstream PR #82557](https://github.com/vercel/next.js/pull/82557)**