### PR TITLE
[turbopack] Update next docs with information about turbopack known adoption issues

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
@@ -1,0 +1,32 @@
+---
+title: turbopackPersistentCaching
+description: Learn how to enable Persistent Caching for Turbopack builds
+version: canary
+---
+
+## Usage
+
+Turbopack Persistent Caching enables turbopack to share state across multiple `next dev` or `next build` commands. When enabled, Turbopack will save and restore data to the `.next` folder between builds, which can greatly speed up builds.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    turbopackPersistentCaching: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    turbopackPersistentCaching: true,
+  },
+}
+
+module.exports = nextConfig
+```

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -91,6 +91,40 @@ Turbopack in Next.js has **zero-configuration** for the common use cases. Below 
 | **Fast Refresh**         | **Supported** | Updates JavaScript, TypeScript, and CSS without a full refresh.                          |
 | **Incremental Bundling** | **Supported** | Turbopack lazily builds only what’s requested by the dev server, speeding up large apps. |
 
+## Known Behavior differences with Webpack
+
+### Css Module Ordering
+
+Turbopack will follow JS import order to order [CSS modules](/docs/app/getting-started/css#css-modules) which are not otherwise ordered. For example,
+
+```jsx filename="pages/blog/index.js" switcher
+import s1 from './utils.module.css'
+import s2 from './button.module.css'
+```
+
+Given such a module, `utils.module.css` will appear before `button.module.css` in the produced CSS chunk.
+
+Webpack generally does this as well, but there are cases where it will ignore JS inferred ordering, for example if it infers the JS file is side-effect-free.
+
+This can lead to subtle rendering changes when adopting Turbopack, if applications have come to rely on an arbitrary ordering. Generally, the solution is easy, e.g. have `button.module.css` `@import utils.module.css` to force the ordering, or identify the conflicting rules and change them to not target the same properties.
+
+### Bundle Sizes
+
+Turbopack does not yet have an equivalent to the `[Inner Graph Optimization](docs/app/getting-started/css#css-modules)` in Webpack. This optimization is useful to tree shake large modules. For example:
+
+```js filename=large.module.js
+import heavy from 'some-heavy-dependency.js'
+
+export function usesHeavy() {...}
+
+export const CONSTANT_VALUE = 3;
+
+```
+
+If an application only uses `CONSTANT_VALUE` Turbopack will detect this and delete the `usesHeavy` export but not the `import`, however, with the `optimization.innerGraph = true` option enabled, Webpack can delete the `import` too.
+
+We are planning to offer an equivalent to the `innerGraph` optimization in Turbopack but it is still under development. As a workaround, it is sometimes easy to just manually split these modules.
+
 ## Unsupported and unplanned features
 
 Some features are not yet implemented or not planned:


### PR DESCRIPTION

* Document the experimental persistent caching flag
* Document the gap with the `innerGraph` optimization
* Document the css module ordering issue

Will wait to submit this until the when we publish the release.

---
🔄 **This is a mirror of [upstream PR #82560](https://github.com/vercel/next.js/pull/82560)**